### PR TITLE
feat(text_metrics): Japanese-aware width estimation

### DIFF
--- a/src/pptx_mcp_server/engine/text_metrics.py
+++ b/src/pptx_mcp_server/engine/text_metrics.py
@@ -1,0 +1,229 @@
+"""テキスト描画メトリクスの簡易推定モジュール.
+
+自動レイアウト用のテキスト幅・高さ推定を提供する。
+実フォントメトリクスファイルに依存せず、Arial/Helvetica を想定した平均字幅
+モデルで近似する。CJK は 1em 全角、ASCII は 0.5em 相当として扱う。
+
+# 既知の制限
+- カーニングやヒンティングは考慮しない。
+- フォントファミリ差は現時点で無視する (引数は将来拡張のため保持)。
+- プロポーショナルフォントであっても全 ASCII 文字を同一の平均幅として扱う。
+- イタリック・装飾体の幅差分は無視する。Bold のみ 1.05 倍の補正を行う。
+- 合字・結合文字・絵文字の幅は保証しない。
+"""
+
+from __future__ import annotations
+
+# ASCII 平均文字幅 (size_pt あたりの inches 係数)
+_ASCII_WIDTH_PER_PT: float = 0.0083
+
+# CJK 全角 1em 幅 (size_pt あたりの inches 係数)
+_CJK_WIDTH_PER_PT: float = 0.0139
+
+# Bold 補正倍率
+_BOLD_MULTIPLIER: float = 1.05
+
+
+def is_cjk(char: str) -> bool:
+    """CJK Unified / Hiragana / Katakana / 全角句読点・記号を判定する.
+
+    判定対象の Unicode 範囲:
+    - CJK Unified Ideographs: U+4E00 – U+9FFF
+    - Hiragana: U+3040 – U+309F
+    - Katakana: U+30A0 – U+30FF
+    - CJK Symbols and Punctuation: U+3000 – U+303F
+    - Halfwidth and Fullwidth Forms: U+FF00 – U+FFEF
+
+    改行文字 (``\\n`` など) は False を返す。
+    """
+    if not char:
+        return False
+    # 明示的に ASCII 改行類は False
+    if char in ("\n", "\r", "\t"):
+        return False
+    code = ord(char[0])
+    if 0x4E00 <= code <= 0x9FFF:
+        return True
+    if 0x3040 <= code <= 0x309F:
+        return True
+    if 0x30A0 <= code <= 0x30FF:
+        return True
+    if 0x3000 <= code <= 0x303F:
+        return True
+    if 0xFF00 <= code <= 0xFFEF:
+        return True
+    return False
+
+
+def estimate_char_width(char: str, size_pt: float, font: str = "Arial") -> float:
+    """単一文字の推定描画幅 (inches) を返す.
+
+    CJK 全角は ``size_pt * 0.0139`` (1em)、ASCII 相当は ``size_pt * 0.0083``
+    (平均幅) として近似する。``font`` は将来拡張のため引数に残すが、現状は
+    Arial/Helvetica を前提として無視される。
+    """
+    if not char:
+        return 0.0
+    if is_cjk(char):
+        return size_pt * _CJK_WIDTH_PER_PT
+    return size_pt * _ASCII_WIDTH_PER_PT
+
+
+def estimate_text_width(
+    text: str,
+    size_pt: float,
+    font: str = "Arial",
+    bold: bool = False,
+) -> float:
+    """テキスト全体の推定描画幅 (inches) を返す.
+
+    各文字について :func:`estimate_char_width` の合計を取る。``bold=True``
+    のとき全体に 1.05 倍の補正を掛ける。改行文字 (``\\n``) の幅は 0 として
+    扱う (改行後の新しい行の開始とみなす想定)。
+    """
+    if not text:
+        return 0.0
+    total = 0.0
+    for ch in text:
+        if ch == "\n":
+            continue
+        total += estimate_char_width(ch, size_pt, font)
+    if bold:
+        total *= _BOLD_MULTIPLIER
+    return total
+
+
+def wrap_text(
+    text: str,
+    max_width_inches: float,
+    size_pt: float,
+    font: str = "Arial",
+) -> list[str]:
+    """``max_width_inches`` に収まるようにテキストを改行分割する.
+
+    ルール:
+    - 日本語/CJK は文字単位で折り返す。
+    - ASCII は word 単位で折り返す (スペース区切り)。
+    - 混在時は文字単位で現在行幅を追跡し、ASCII 部では直近の空白位置で折り
+      返せる場合はそこで折り返す。
+    - 単一の ASCII ワードが ``max_width_inches`` を超える場合は、そのワード
+      を単独行として配置する (無限ループ回避)。
+    - 入力内の ``\\n`` は強制改行として扱う。
+    """
+    if not text:
+        return []
+
+    # 明示改行で分割し、各セグメントを独立に折り返す。
+    segments = text.split("\n")
+    lines: list[str] = []
+    for seg in segments:
+        if seg == "":
+            lines.append("")
+            continue
+        lines.extend(_wrap_segment(seg, max_width_inches, size_pt, font))
+    return lines
+
+
+def _wrap_segment(
+    text: str,
+    max_width_inches: float,
+    size_pt: float,
+    font: str,
+) -> list[str]:
+    """改行を含まない 1 セグメントを折り返す内部関数.
+
+    処理方針:
+    - テキストを「トークン」に分割する。CJK 文字とスペースはそれぞれ単独トークン。
+      連続する ASCII (非 CJK・非空白) 文字は 1 ワードとして 1 トークン化する。
+    - トークン単位で現在行に詰め、max_width を超える直前で改行する。
+    - ASCII ワードが単独で max_width を超える場合でも、そのワードをそのまま
+      1 行として配置し、途中で切らない (仕様)。
+    """
+    tokens: list[str] = _tokenize(text)
+
+    lines: list[str] = []
+    current: str = ""
+    current_width: float = 0.0
+
+    for tok in tokens:
+        tok_width = _measure(tok, size_pt, font)
+        if current == "":
+            # 行頭: 空白トークンは無視する (行頭空白は詰める)
+            if tok == " ":
+                continue
+            current = tok
+            current_width = tok_width
+            continue
+
+        if current_width + tok_width <= max_width_inches:
+            current += tok
+            current_width += tok_width
+        else:
+            # 行を確定して新しい行を始める
+            # 末尾の空白は trim
+            lines.append(current.rstrip(" "))
+            if tok == " ":
+                current = ""
+                current_width = 0.0
+            else:
+                current = tok
+                current_width = tok_width
+
+    if current != "":
+        lines.append(current.rstrip(" "))
+    return lines
+
+
+def _tokenize(text: str) -> list[str]:
+    """wrap 用のトークン分割.
+
+    - CJK 文字: 1 文字 1 トークン
+    - スペース: 1 トークン
+    - その他 (ASCII ワード等): 連続する非 CJK・非空白をまとめて 1 トークン
+    """
+    tokens: list[str] = []
+    buf: str = ""
+    for ch in text:
+        if ch == " ":
+            if buf:
+                tokens.append(buf)
+                buf = ""
+            tokens.append(" ")
+        elif is_cjk(ch):
+            if buf:
+                tokens.append(buf)
+                buf = ""
+            tokens.append(ch)
+        else:
+            buf += ch
+    if buf:
+        tokens.append(buf)
+    return tokens
+
+
+def _measure(text: str, size_pt: float, font: str) -> float:
+    """内部用: bold 無し・改行無しの幅を返す."""
+    total = 0.0
+    for ch in text:
+        total += estimate_char_width(ch, size_pt, font)
+    return total
+
+
+def estimate_text_height(
+    text: str,
+    max_width_inches: float,
+    size_pt: float,
+    font: str = "Arial",
+    line_height_factor: float = 1.2,
+) -> float:
+    """wrap した結果の総高さ (inches) を返す.
+
+    ``len(wrap_text(...)) * size_pt * 0.0139 * line_height_factor`` で算出する。
+    空文字列は 0 を返す。``size_pt * 0.0139`` は 1em の inches 換算値である。
+    """
+    if not text:
+        return 0.0
+    lines = wrap_text(text, max_width_inches, size_pt, font)
+    if not lines:
+        return 0.0
+    return len(lines) * size_pt * _CJK_WIDTH_PER_PT * line_height_factor

--- a/tests/test_text_metrics.py
+++ b/tests/test_text_metrics.py
@@ -1,0 +1,172 @@
+"""text_metrics モジュールのテスト.
+
+Japanese-aware 幅推定・折り返し・高さ推定が仕様どおりに動作することを確認する。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pptx_mcp_server.engine.text_metrics import (
+    estimate_char_width,
+    estimate_text_height,
+    estimate_text_width,
+    is_cjk,
+    wrap_text,
+)
+
+
+class TestIsCjk:
+    """is_cjk の判定ロジックを検証する."""
+
+    def test_hiragana(self) -> None:
+        assert is_cjk("あ") is True
+
+    def test_katakana(self) -> None:
+        assert is_cjk("ア") is True
+
+    def test_kanji(self) -> None:
+        assert is_cjk("漢") is True
+
+    def test_fullwidth_punctuation(self) -> None:
+        assert is_cjk("、") is True
+        assert is_cjk("。") is True
+
+    def test_ascii_letter(self) -> None:
+        assert is_cjk("a") is False
+        assert is_cjk("A") is False
+
+    def test_ascii_digit(self) -> None:
+        assert is_cjk("1") is False
+        assert is_cjk("9") is False
+
+    def test_newline_is_not_cjk(self) -> None:
+        assert is_cjk("\n") is False
+
+    def test_empty_is_not_cjk(self) -> None:
+        assert is_cjk("") is False
+
+
+class TestEstimateTextWidth:
+    """estimate_text_width の数値検証."""
+
+    def test_japanese_bold(self) -> None:
+        # "プレミアムモルツ" = 8 文字 × 9pt × 0.0139 × 1.05 ≈ 1.050 inches
+        width = estimate_text_width("プレミアムモルツ", 9, bold=True)
+        expected = 8 * 9 * 0.0139 * 1.05
+        assert width == pytest.approx(expected, abs=0.01)
+        assert width == pytest.approx(1.050, abs=0.01)
+
+    def test_ascii_hello_world(self) -> None:
+        # "Hello World" = 11 文字 × 12pt × 0.0083 ≈ 1.096 inches
+        width = estimate_text_width("Hello World", 12)
+        expected = 12 * 11 * 0.0083
+        assert width == pytest.approx(expected, abs=0.01)
+        assert width == pytest.approx(1.096, abs=0.01)
+
+    def test_mixed_ai_seikatsusha(self) -> None:
+        # "AI生活者" = 2 ASCII + 3 CJK @ 10pt
+        width = estimate_text_width("AI生活者", 10)
+        expected = 2 * 10 * 0.0083 + 3 * 10 * 0.0139
+        assert width == pytest.approx(expected, abs=0.001)
+
+    def test_empty_string_has_zero_width(self) -> None:
+        assert estimate_text_width("", 12) == 0.0
+        assert estimate_text_width("", 12, bold=True) == 0.0
+
+    def test_bold_multiplier(self) -> None:
+        normal = estimate_text_width("Hello", 12, bold=False)
+        bold = estimate_text_width("Hello", 12, bold=True)
+        assert bold == pytest.approx(normal * 1.05, abs=0.0001)
+
+    def test_newline_does_not_add_width(self) -> None:
+        # 改行文字は幅に寄与しない
+        w_with_nl = estimate_text_width("ab\ncd", 12)
+        w_without_nl = estimate_text_width("abcd", 12)
+        assert w_with_nl == pytest.approx(w_without_nl, abs=0.0001)
+
+
+class TestEstimateCharWidth:
+    """estimate_char_width のスポットチェック."""
+
+    def test_ascii_char(self) -> None:
+        assert estimate_char_width("a", 10) == pytest.approx(10 * 0.0083, abs=0.0001)
+
+    def test_cjk_char(self) -> None:
+        assert estimate_char_width("あ", 10) == pytest.approx(10 * 0.0139, abs=0.0001)
+
+    def test_digit_same_as_ascii(self) -> None:
+        assert estimate_char_width("0", 10) == pytest.approx(estimate_char_width("a", 10))
+
+    def test_empty_char_zero(self) -> None:
+        assert estimate_char_width("", 10) == 0.0
+
+
+class TestWrapText:
+    """wrap_text の分割ロジック."""
+
+    def test_japanese_wraps_to_2_or_3_lines(self) -> None:
+        # 仕様: "父の日ギフトシーンで安定露出も定番2位に留まる" を width=2.0, 10pt
+        result = wrap_text("父の日ギフトシーンで安定露出も定番2位に留まる", 2.0, 10)
+        assert 2 <= len(result) <= 3
+
+    def test_empty_returns_empty_list(self) -> None:
+        assert wrap_text("", 2.0, 10) == []
+
+    def test_explicit_newline_forces_line(self) -> None:
+        # 明示的 \n を含む場合は強制改行
+        result = wrap_text("abc\ndef", 10.0, 12)
+        assert result == ["abc", "def"]
+
+    def test_multiple_newlines_preserve_blank_line(self) -> None:
+        result = wrap_text("a\n\nb", 10.0, 12)
+        assert len(result) == 3
+        assert result[0] == "a"
+        assert result[1] == ""
+        assert result[2] == "b"
+
+    def test_long_word_placed_on_own_line(self) -> None:
+        # max_width より長い ASCII ワードも単独行として配置される (無限ループしない)
+        long_word = "supercalifragilisticexpialidocious"
+        result = wrap_text(long_word, 0.5, 12)
+        # 少なくとも 1 行にそのまま置かれる
+        assert any(long_word in line for line in result)
+        assert len(result) >= 1
+
+    def test_ascii_word_wrap_at_space(self) -> None:
+        # "Hello World Foo Bar Baz" を狭めの幅で折り返す → 空白で分割される
+        result = wrap_text("Hello World Foo Bar Baz", 0.6, 12)
+        assert len(result) >= 2
+        # 各行に空白以外の単語が含まれる
+        for line in result:
+            assert line != ""
+
+    def test_single_line_fits(self) -> None:
+        # 十分に広ければ 1 行で収まる
+        result = wrap_text("Hello", 10.0, 12)
+        assert result == ["Hello"]
+
+
+class TestEstimateTextHeight:
+    """estimate_text_height の算出."""
+
+    def test_empty_string_zero_height(self) -> None:
+        assert estimate_text_height("", 5.0, 12) == 0.0
+
+    def test_single_line_height(self) -> None:
+        # "Hello" は十分広い max_width では 1 行 → 12 * 0.0139 * 1.2
+        height = estimate_text_height("Hello", 10.0, 12)
+        expected = 1 * 12 * 0.0139 * 1.2
+        assert height == pytest.approx(expected, abs=0.001)
+
+    def test_multiline_height_scales(self) -> None:
+        # 明示改行で 3 行 → 高さは 1 行の 3 倍
+        single = estimate_text_height("a", 10.0, 12)
+        triple = estimate_text_height("a\nb\nc", 10.0, 12)
+        assert triple == pytest.approx(single * 3, abs=0.001)
+
+    def test_line_height_factor_applied(self) -> None:
+        h_default = estimate_text_height("Hello", 10.0, 12)
+        h_double = estimate_text_height("Hello", 10.0, 12, line_height_factor=2.4)
+        # line_height_factor 2.4 は 1.2 の 2 倍
+        assert h_double == pytest.approx(h_default * 2, abs=0.001)


### PR DESCRIPTION
## Summary
- Adds `src/pptx_mcp_server/engine/text_metrics.py` — a dependency-free text metric estimator for auto-layout primitives.
- Public API: `is_cjk`, `estimate_char_width`, `estimate_text_width`, `wrap_text`, `estimate_text_height`.
- Width model: Arial/Helvetica approximation. ASCII = `size_pt * 0.0083` in, CJK full-width = `size_pt * 0.0139` in (1em). Bold multiplies by 1.05.
- Wrap: CJK breaks at any character, ASCII word-wraps on spaces, long ASCII words are placed on their own line without looping, explicit `\n` forces a line.
- Height = `len(wrap_text(...)) * size_pt * 0.0139 * line_height_factor` (empty string → 0).

## Test plan
- [x] `python -m pytest tests/test_text_metrics.py -v` — 29 passed
- [x] `python -m pytest` — 291 passed (no regressions)
- [x] `estimate_text_width("プレミアムモルツ", 9, bold=True)` ≈ 1.050 in
- [x] `estimate_text_width("Hello World", 12)` ≈ 1.096 in
- [x] Mixed `"AI生活者"` at 10pt matches analytic formula
- [x] `wrap_text("父の日ギフトシーンで安定露出も定番2位に留まる", 2.0, 10)` → 2–3 lines
- [x] `is_cjk` covers hiragana, katakana, kanji, fullwidth punctuation; ASCII / digits / `\n` return False
- [x] bold 1.05x multiplier verified
- [x] explicit `\n` and blank-line preservation verified
- [x] empty string → width 0 and height 0
- [x] ASCII word longer than max_width placed on its own line (no infinite loop)
- [x] `estimate_text_height` single-line ≈ `size_pt * 0.0139 * 1.2`

Closes #1.