### PR TITLE
feat(shapes): auto-fit textbox helper (closes #2)

### DIFF
--- a/src/pptx_mcp_server/engine/__init__.py
+++ b/src/pptx_mcp_server/engine/__init__.py
@@ -23,6 +23,8 @@ from .shapes import (
     add_paragraph,
     delete_shape,
     list_shapes,
+    add_auto_fit_textbox,
+    add_auto_fit_textbox_file,
     _add_textbox,
     _add_shape,
     _add_image,
@@ -94,6 +96,7 @@ __all__ = [
     # Shapes
     "add_textbox", "add_shape", "add_image", "edit_text", "add_paragraph",
     "delete_shape", "list_shapes",
+    "add_auto_fit_textbox", "add_auto_fit_textbox_file",
     # Tables
     "add_table", "edit_table_cell", "edit_table_cells", "format_table",
     # Formatting

--- a/src/pptx_mcp_server/engine/shapes.py
+++ b/src/pptx_mcp_server/engine/shapes.py
@@ -14,6 +14,7 @@ from .pptx_io import (
     EngineError, ErrorCode,
     open_pptx, save_pptx, _get_slide, _get_shape, _parse_color,
 )
+from .text_metrics import estimate_text_height, estimate_text_width, wrap_text
 
 from ..theme import Theme, resolve_color
 
@@ -469,3 +470,230 @@ def list_shapes(file_path, slide_index):
     prs = open_pptx(file_path)
     slide = _get_slide(prs, slide_index)
     return _list_shapes(slide, slide_index)
+
+
+# ── Auto-fit textbox ────────────────────────────────────────────
+
+# 内側 padding (inches)。左右に同量の padding を見込むため、usable width は
+# width - 2 * _AUTO_FIT_PADDING となる。
+_AUTO_FIT_PADDING: float = 0.05
+
+# font size 縮小ステップ (pt)
+_AUTO_FIT_STEP_PT: float = 0.5
+
+# 高さ推定に使う行高倍率
+_AUTO_FIT_LINE_HEIGHT: float = 1.2
+
+# 省略記号
+_ELLIPSIS: str = "\u2026"
+
+
+def _fit_font_size(
+    text: str,
+    usable_width: float,
+    height: float,
+    font_name: str,
+    font_size_pt: float,
+    min_size_pt: float,
+) -> tuple[float, bool]:
+    """指定 box に収まる font size を二分探索ではなく 0.5pt ステップで決定する.
+
+    Returns:
+        (size, fits): ``size`` は採用する font size。``fits`` は最終的にその
+        size で text が box 内に収まるかどうか (min に達してもなおオーバー
+        フローする場合は False)。
+    """
+    size = float(font_size_pt)
+    min_size = float(min_size_pt)
+    while size > min_size:
+        height_est = estimate_text_height(
+            text, usable_width, size, font_name,
+            line_height_factor=_AUTO_FIT_LINE_HEIGHT,
+        )
+        if height_est <= height:
+            return size, True
+        size = round(size - _AUTO_FIT_STEP_PT, 2)
+    # min_size でチェック
+    height_est = estimate_text_height(
+        text, usable_width, min_size, font_name,
+        line_height_factor=_AUTO_FIT_LINE_HEIGHT,
+    )
+    return min_size, height_est <= height
+
+
+def _truncate_to_fit(
+    text: str,
+    usable_width: float,
+    height: float,
+    font_name: str,
+    size_pt: float,
+) -> str:
+    """``size_pt`` の size で ``(usable_width, height)`` に収まるよう末尾を
+    省略記号で切り詰める.
+
+    方針:
+    - まず wrap_text で折り返し結果を得る。
+    - 高さが許す行数 ``max_lines`` を算出する。
+    - 最終行は末尾から 1 文字ずつ削りながら ``line + 省略記号`` の幅が
+      ``usable_width`` 以下になるまで縮める。
+    - ``max_lines == 0`` の場合は空文字列を返す。
+    """
+    line_h = size_pt * 0.0139 * _AUTO_FIT_LINE_HEIGHT
+    if line_h <= 0:
+        return text
+    max_lines = int(height // line_h)
+    if max_lines <= 0:
+        return ""
+
+    lines = wrap_text(text, usable_width, size_pt, font_name)
+    if not lines:
+        return ""
+
+    if len(lines) <= max_lines:
+        # 高さには収まるが、幅の再確認は wrap で保証済み。そのまま返す。
+        return "\n".join(lines)
+
+    retained = lines[:max_lines]
+    last = retained[-1]
+    # last + ellipsis が usable_width を超える間、末尾から 1 文字ずつ削る。
+    while last and estimate_text_width(last + _ELLIPSIS, size_pt, font_name) > usable_width:
+        last = last[:-1]
+    retained[-1] = (last + _ELLIPSIS) if last else _ELLIPSIS
+    return "\n".join(retained)
+
+
+def add_auto_fit_textbox(
+    slide,
+    text: str,
+    left: float,
+    top: float,
+    width: float,
+    height: float,
+    *,
+    font_name: str = "Arial",
+    font_size_pt: float = 11,
+    min_size_pt: float = 7,
+    bold: bool = False,
+    color_hex: str = "333333",
+    align: str = "left",
+    vertical_anchor: str = "top",
+    truncate_with_ellipsis: bool = True,
+) -> tuple[object, float]:
+    """指定 box に収まる最大 font size でテキストを描画する.
+
+    動作:
+        (a) 内側 padding 0.05" を左右に見込んで usable width を計算する。
+        (b) ``font_size_pt`` から開始し、``estimate_text_height(wrapped)`` が
+            ``height`` 以下になるまで 0.5pt 刻みで縮小する。
+        (c) ``min_size_pt`` に達しても収まらない場合、
+            ``truncate_with_ellipsis=True`` なら末尾を省略記号で切り詰めて
+            描画する。False なら full text をそのまま描画しオーバーフロー
+            を許容する。
+        (d) 決定した font size で ``_add_textbox`` 経由で textframe を生成し、
+            ``vertical_anchor`` に応じて ``MSO_ANCHOR`` を設定する。
+
+    Args:
+        slide: 対象スライドオブジェクト。
+        text: 描画するテキスト。
+        left, top, width, height: 位置と寸法 (inches)。
+        font_name: フォント名。デフォルトは ``"Arial"``。
+        font_size_pt: 開始 font size (pt)。
+        min_size_pt: 縮小の下限 (pt)。
+        bold: 太字にするかどうか。
+        color_hex: 文字色 (hex、``#`` なし)。
+        align: 水平方向の揃え ``"left" | "center" | "right"``。
+        vertical_anchor: 垂直方向の揃え ``"top" | "middle" | "bottom"``。
+        truncate_with_ellipsis: min size でも収まらない場合に末尾を
+            省略記号で切り詰めるかどうか。
+
+    Returns:
+        ``(shape, actual_font_size)`` のタプル。テスト・デバッグ用途。
+    """
+    usable_width = max(width - 2 * _AUTO_FIT_PADDING, 0.01)
+
+    actual_size, fits = _fit_font_size(
+        text, usable_width, height, font_name, font_size_pt, min_size_pt,
+    )
+
+    rendered_text = text
+    if not fits and truncate_with_ellipsis:
+        rendered_text = _truncate_to_fit(
+            text, usable_width, height, font_name, actual_size,
+        )
+
+    idx = _add_textbox(
+        slide,
+        left, top, width, height,
+        text=rendered_text,
+        font_name=font_name,
+        font_size=actual_size,
+        font_color=color_hex,
+        bold=bold if bold else None,
+        italic=None,
+        alignment=align,
+        vertical_anchor=vertical_anchor,
+        word_wrap=True,
+        line_spacing=None,
+        underline=None,
+    )
+
+    shape = slide.shapes[idx]
+    tf = shape.text_frame
+    tf.word_wrap = True
+    # auto_size は手動でサイズ決定済みなので明示的に None にする。
+    tf.auto_size = None
+    if vertical_anchor in _ANCHOR_MAP:
+        tf.vertical_anchor = _ANCHOR_MAP[vertical_anchor]
+
+    return shape, actual_size
+
+
+def add_auto_fit_textbox_file(
+    file_path: str,
+    slide_index: int,
+    text: str,
+    left: float,
+    top: float,
+    width: float,
+    height: float,
+    font_name: str = "Arial",
+    font_size_pt: float = 11,
+    min_size_pt: float = 7,
+    bold: bool = False,
+    color_hex: str = "333333",
+    align: str = "left",
+    vertical_anchor: str = "top",
+    truncate_with_ellipsis: bool = True,
+) -> dict:
+    """File-based wrapper: 指定 box に収まるよう自動縮小する textbox を追加する.
+
+    Returns:
+        ``{"shape_index": int, "slide_index": int, "actual_font_size": float}``
+        を含む dict。MCP ツール経由で呼び出される想定。
+    """
+    prs = open_pptx(file_path)
+    slide = _get_slide(prs, slide_index)
+    shape, actual_size = add_auto_fit_textbox(
+        slide, text, left, top, width, height,
+        font_name=font_name,
+        font_size_pt=font_size_pt,
+        min_size_pt=min_size_pt,
+        bold=bold,
+        color_hex=color_hex,
+        align=align,
+        vertical_anchor=vertical_anchor,
+        truncate_with_ellipsis=truncate_with_ellipsis,
+    )
+    # shape_index を決定 (slide 内で shape を線形検索)
+    shape_index = -1
+    for i, s in enumerate(slide.shapes):
+        if s is shape:
+            shape_index = i
+            break
+    save_pptx(prs, file_path)
+    return {
+        "slide_index": slide_index,
+        "shape_index": shape_index,
+        "shape_name": shape.name,
+        "actual_font_size": actual_size,
+    }

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -18,6 +18,7 @@ from .engine import (
     duplicate_slide,
     set_slide_background,
     add_textbox,
+    add_auto_fit_textbox_file,
     add_shape,
     add_image,
     edit_text,
@@ -349,6 +350,42 @@ def pptx_add_textbox(
             font_name, font_size, font_color, bold, italic,
             alignment, vertical_anchor, word_wrap, line_spacing, underline,
         )
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def pptx_add_auto_fit_textbox(
+    file_path: str,
+    slide_index: int,
+    text: str,
+    left: float,
+    top: float,
+    width: float,
+    height: float,
+    font_name: str = "Arial",
+    font_size_pt: float = 11,
+    min_size_pt: float = 7,
+    bold: bool = False,
+    color_hex: str = "333333",
+    align: str = "left",
+    vertical_anchor: str = "top",
+    truncate_with_ellipsis: bool = True,
+) -> str:
+    """Add a textbox that auto-shrinks font size to fit a fixed box. Starts from font_size_pt and steps down 0.5pt until text fits height, or reaches min_size_pt. If still overflowing at min and truncate_with_ellipsis=True, trailing chars are replaced with an ellipsis. Returns a JSON object with shape_index, shape_name, and actual_font_size."""
+    try:
+        result = add_auto_fit_textbox_file(
+            file_path, slide_index, text, left, top, width, height,
+            font_name=font_name,
+            font_size_pt=font_size_pt,
+            min_size_pt=min_size_pt,
+            bold=bold,
+            color_hex=color_hex,
+            align=align,
+            vertical_anchor=vertical_anchor,
+            truncate_with_ellipsis=truncate_with_ellipsis,
+        )
+        return json.dumps(result)
     except Exception as e:
         return _err(e)
 

--- a/tests/test_shapes_auto_fit.py
+++ b/tests/test_shapes_auto_fit.py
@@ -1,0 +1,101 @@
+"""auto-fit textbox ヘルパーのテスト.
+
+``add_auto_fit_textbox`` が指定ボックスに収まる font size を正しく
+選択し、min size でも収まらない場合は省略記号で切り詰める挙動を検証する。
+"""
+
+from __future__ import annotations
+
+import pytest
+from pptx.enum.text import MSO_ANCHOR
+
+from pptx_mcp_server.engine.shapes import add_auto_fit_textbox
+
+
+def test_short_text_big_box_keeps_font_size(slide):
+    """短いテキスト + 余裕のある box では font size は縮まない."""
+    shape, actual = add_auto_fit_textbox(
+        slide,
+        "Hello",
+        left=1.0, top=1.0, width=5.0, height=2.0,
+        font_size_pt=11, min_size_pt=7,
+    )
+    assert actual == 11.0
+    assert shape.text_frame.text == "Hello"
+
+
+def test_long_japanese_in_narrow_box_shrinks(slide):
+    """長い日本語 + 狭い box では font size が縮小されるが min 以上に留まる."""
+    long_jp = "これは日本語のテキストサンプルです。" * 6
+    shape, actual = add_auto_fit_textbox(
+        slide,
+        long_jp,
+        left=1.0, top=1.0, width=3.0, height=0.8,
+        font_size_pt=14, min_size_pt=7,
+    )
+    assert actual < 14.0
+    assert actual >= 7.0
+
+
+def test_overflow_truncates_with_ellipsis(slide):
+    """min_size でも入らない量を truncate=True で流し込むと省略記号で終わる."""
+    huge = "これは非常に長いテキストです。" * 40
+    shape, actual = add_auto_fit_textbox(
+        slide,
+        huge,
+        left=1.0, top=1.0, width=1.0, height=0.3,
+        font_size_pt=11, min_size_pt=7,
+        truncate_with_ellipsis=True,
+    )
+    assert actual == 7.0
+    assert shape.text_frame.text.endswith("\u2026")
+
+
+def test_overflow_without_truncate_keeps_full_text(slide):
+    """truncate=False の場合は full text をそのまま描画しオーバーフローを許容する."""
+    huge = "これは非常に長いテキストです。" * 40
+    shape, actual = add_auto_fit_textbox(
+        slide,
+        huge,
+        left=1.0, top=1.0, width=1.0, height=0.3,
+        font_size_pt=11, min_size_pt=7,
+        truncate_with_ellipsis=False,
+    )
+    assert actual == 7.0
+    assert shape.text_frame.text == huge
+    assert "\u2026" not in shape.text_frame.text
+
+
+def test_vertical_anchor_middle(slide):
+    """vertical_anchor='middle' が MSO_ANCHOR.MIDDLE として反映される."""
+    shape, _ = add_auto_fit_textbox(
+        slide,
+        "centered",
+        left=1.0, top=1.0, width=3.0, height=1.5,
+        vertical_anchor="middle",
+    )
+    assert shape.text_frame.vertical_anchor == MSO_ANCHOR.MIDDLE
+
+
+def test_production_subtitle_11_5x0_5(slide):
+    """production-like: 約 120 文字の日本語を 11.5" x 0.5" の箱に流し込む.
+
+    McKinsey スタイルの 1-line アクションサブタイトルを想定したシナリオ。
+    結果の font size は [min_size_pt, 11] の範囲に収まる想定。
+    """
+    subtitle = (
+        "本施策は複数部門の合意形成を前提としつつ、短期では収益性の早期改善、"
+        "中期では顧客基盤を軸とした市場シェアの段階的拡大、"
+        "長期では持続的な競争優位と価値創出の確立を目指す統合的アプローチとして位置づけるものである"
+    )
+    assert 100 <= len(subtitle) <= 140  # 仕様 ~120 chars
+    shape, actual = add_auto_fit_textbox(
+        slide,
+        subtitle,
+        left=0.9, top=0.5, width=11.5, height=0.5,
+        font_size_pt=11, min_size_pt=7,
+    )
+    assert 7.0 <= actual <= 11.0
+    # 切り詰めが起きない場合、本文は保持されているはず (またはオーバーフロー
+    # で truncate 発動)。いずれにせよ空ではない。
+    assert shape.text_frame.text != ""


### PR DESCRIPTION
## Summary
- Add `add_auto_fit_textbox` in `engine/shapes.py` that shrinks the font 0.5pt at a time until wrapped text fits a fixed box, with optional ellipsis truncation at `min_size_pt`.
- Expose a new MCP tool `pptx_add_auto_fit_textbox` that returns `{shape_index, shape_name, actual_font_size}` as JSON.
- Covered by 6 new tests in `tests/test_shapes_auto_fit.py` including a production-like ~120-char Japanese subtitle in an 11.5" x 0.5" box.

Builds on #1's `text_metrics` (`estimate_text_height`, `estimate_text_width`, `wrap_text`). Does not change `_add_textbox` signature — only adds new public helpers.

Closes #2.

## Test plan
- [x] `python -m pytest tests/test_shapes_auto_fit.py -v` — 6/6 green
- [x] `python -m pytest` — 306/306 passing (was 300)
- [x] Manual: short text in big box -> no shrink; long JP in narrow box -> shrinks >= min; overflow + truncate=True -> ends with ellipsis; overflow + truncate=False -> preserves full text; vertical_anchor='middle' -> MSO_ANCHOR.MIDDLE

Generated with Claude Code