### PR TITLE
feat(validation): add text overflow, unreadable, divider, gap checks (closes #5)

### DIFF
--- a/src/pptx_mcp_server/engine/__init__.py
+++ b/src/pptx_mcp_server/engine/__init__.py
@@ -63,6 +63,12 @@ from .icons import (
 from .validation import (
     check_deck_overlaps,
     check_slide_overlaps,
+    check_deck_extended,
+    check_text_overflow,
+    check_unreadable_text,
+    check_divider_collision,
+    check_inconsistent_gaps,
+    ValidationFinding,
 )
 from .connectors import (
     add_connector,
@@ -105,7 +111,10 @@ __all__ = [
     # Connectors
     "add_connector", "add_callout",
     # Validation
-    "check_deck_overlaps",
+    "check_deck_overlaps", "check_slide_overlaps", "check_deck_extended",
+    "check_text_overflow", "check_unreadable_text",
+    "check_divider_collision", "check_inconsistent_gaps",
+    "ValidationFinding",
     # Composites
     "add_content_slide", "add_section_divider", "add_kpi_row", "add_bullet_block",
     "build_slide", "build_deck",

--- a/src/pptx_mcp_server/engine/validation.py
+++ b/src/pptx_mcp_server/engine/validation.py
@@ -1,19 +1,29 @@
 """
-Layout validation — detect overlapping shapes, out-of-bounds elements, etc.
+Layout validation — detect overlapping shapes, out-of-bounds elements,
+text overflow, unreadable font, title/divider collision, inconsistent gaps.
 
 Run after build_slide / build_deck to catch layout issues before delivery.
 """
 
 from __future__ import annotations
 
-from typing import List, Tuple
+import re
+import statistics
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, List, Optional, Tuple
 
 from pptx import Presentation
 from pptx.util import Emu
 
+from .text_metrics import estimate_text_height, estimate_text_width
+
+# ---------------------------------------------------------------------------
+# 既存互換ヘルパ
+# ---------------------------------------------------------------------------
+
 
 def _get_shape_bounds(shape) -> Tuple[float, float, float, float]:
-    """Return (left, top, right, bottom) in inches for a shape."""
+    """shape の (left, top, right, bottom) を inches で返す."""
     emu_to_in = 1 / 914400
     left = shape.left * emu_to_in
     top = shape.top * emu_to_in
@@ -23,15 +33,14 @@ def _get_shape_bounds(shape) -> Tuple[float, float, float, float]:
 
 
 def _boxes_overlap(a: Tuple, b: Tuple, margin: float = 0.0) -> bool:
-    """Check if two (left, top, right, bottom) boxes overlap.
+    """2 つの (left, top, right, bottom) box が重なるかを返す.
 
-    margin: minimum gap required between shapes (inches).
-    Negative margin means shapes must overlap by that amount to trigger.
+    margin: shape 間に要求する最小間隔 (inches)。
+    負値を与えると指定量以上重なった場合のみ True となる。
     """
     a_left, a_top, a_right, a_bottom = a
     b_left, b_top, b_right, b_bottom = b
 
-    # No overlap if separated on any axis
     if a_right + margin <= b_left:
         return False
     if b_right + margin <= a_left:
@@ -44,34 +53,32 @@ def _boxes_overlap(a: Tuple, b: Tuple, margin: float = 0.0) -> bool:
 
 
 def _is_small_decorative(shape) -> bool:
-    """Check if a shape is small/decorative (divider lines, accent bars)."""
+    """小さな装飾 shape (divider、accent bar 等) かを判定する."""
     emu_to_in = 1 / 914400
     w = shape.width * emu_to_in
     h = shape.height * emu_to_in
-    # Thin lines (dividers, accent bars)
     if h < 0.08 or w < 0.08:
         return True
-    # Very small shapes (icon accent bars in KPI cards)
     if w * h < 0.05:
         return True
     return False
 
 
 def _is_container(bounds_a: Tuple, bounds_b: Tuple) -> bool:
-    """Check if one shape fully contains the other (parent-child relationship).
-
-    Text placed inside a background rectangle is intentional, not an overlap.
-    """
+    """一方が他方を完全包含するか (背景矩形内のテキスト配置など)."""
     a_left, a_top, a_right, a_bottom = bounds_a
     b_left, b_top, b_right, b_bottom = bounds_b
 
-    # A contains B
     if a_left <= b_left and a_top <= b_top and a_right >= b_right and a_bottom >= b_bottom:
         return True
-    # B contains A
     if b_left <= a_left and b_top <= a_top and b_right >= a_right and b_bottom >= a_bottom:
         return True
     return False
+
+
+# ---------------------------------------------------------------------------
+# 既存チェッカ (後方互換のためシグネチャ・挙動を維持)
+# ---------------------------------------------------------------------------
 
 
 def check_slide_overlaps(
@@ -80,20 +87,17 @@ def check_slide_overlaps(
     slide_width: float = 13.333,
     slide_height: float = 7.5,
 ) -> List[str]:
-    """Check a slide for overlapping shapes and insufficient gaps.
+    """1 slide 内の重なり・はみ出しを検出する.
 
-    margin: minimum gap required between shapes (inches).
-            0.03 = shapes touching or within 0.03" trigger a warning.
+    margin: shape 間に要求する最小間隔 (inches)。
 
-    Returns list of warning strings. Empty = no issues.
+    戻り値は警告文字列のリスト。空リストなら問題なし。
     """
-    warnings = []
+    warnings: List[str] = []
     shapes = list(slide.shapes)
 
-    # Filter out small decorative shapes (divider lines, accent bars)
     content_shapes = [s for s in shapes if not _is_small_decorative(s)]
 
-    # Check pairwise overlaps
     for i in range(len(content_shapes)):
         for j in range(i + 1, len(content_shapes)):
             si = content_shapes[i]
@@ -103,16 +107,13 @@ def check_slide_overlaps(
             bj = _get_shape_bounds(sj)
 
             if _boxes_overlap(bi, bj, margin):
-                # Skip if one contains the other (text inside background shape)
                 if _is_container(bi, bj):
                     continue
 
-                # Compute actual overlap area
                 overlap_x = max(0, min(bi[2], bj[2]) - max(bi[0], bj[0]))
                 overlap_y = max(0, min(bi[3], bj[3]) - max(bi[1], bj[1]))
                 overlap_area = overlap_x * overlap_y
 
-                # Skip small labels/badges placed on charts (< 1.0 sq in shape)
                 area_i = (bi[2] - bi[0]) * (bi[3] - bi[1])
                 area_j = (bj[2] - bj[0]) * (bj[3] - bj[1])
                 if min(area_i, area_j) < 1.0:
@@ -128,11 +129,9 @@ def check_slide_overlaps(
                         f"× '{name_j}' at ({bj[0]:.1f},{bj[1]:.1f},{bj[2]:.1f},{bj[3]:.1f})"
                     )
                 else:
-                    # Compute minimum gap between edges
                     h_gap = max(0, max(bi[0], bj[0]) - min(bi[2], bj[2]))
                     v_gap = max(0, max(bi[1], bj[1]) - min(bi[3], bj[3]))
                     min_gap = max(h_gap, v_gap)
-                    # Both shapes are significant (> 1 sq in each)
                     if area_i > 1.0 and area_j > 1.0:
                         warnings.append(
                             f"TOO CLOSE (gap {min_gap:.2f}\"): "
@@ -140,7 +139,6 @@ def check_slide_overlaps(
                             f"× '{name_j}' at ({bj[0]:.1f},{bj[1]:.1f},{bj[2]:.1f},{bj[3]:.1f})"
                         )
 
-    # Check out-of-bounds
     for s in shapes:
         if _is_small_decorative(s):
             continue
@@ -160,15 +158,15 @@ def check_slide_overlaps(
 
 
 def check_deck_overlaps(pptx_path: str) -> str:
-    """Check all slides in a deck for layout issues.
+    """deck 全体の重なり・はみ出しを報告する.
 
-    Returns a report string. Empty = all clean.
+    戻り値はレポート文字列。空のレポートは `All slides clean…` を返す。
     """
     prs = Presentation(pptx_path)
     slide_w = prs.slide_width / 914400
     slide_h = prs.slide_height / 914400
 
-    all_warnings = []
+    all_warnings: List[str] = []
     for i, slide in enumerate(prs.slides):
         warnings = check_slide_overlaps(
             slide, margin=-0.05,
@@ -181,3 +179,519 @@ def check_deck_overlaps(pptx_path: str) -> str:
         return "All slides clean — no overlaps or out-of-bounds detected."
 
     return f"Found {len(all_warnings)} layout issues:\n" + "\n".join(all_warnings)
+
+
+# ---------------------------------------------------------------------------
+# 拡張バリデーション (Issue #5)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ValidationFinding:
+    """バリデーション検出結果の 1 件分を表す.
+
+    severity: ``"error"`` | ``"warning"`` | ``"info"``
+    category: ``"text_overflow"`` | ``"unreadable_text"``
+        | ``"divider_collision"`` | ``"inconsistent_gap"``
+    """
+
+    severity: str
+    slide_index: int
+    shape_name: str
+    category: str
+    message: str
+    suggested_fix: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """dict 形式で返す (JSON シリアライズ用)."""
+        return asdict(self)
+
+
+# フッタ等の小文字ホワイトリストパターン (unreadable チェックをスキップ)
+_UNREADABLE_WHITELIST_RE = re.compile(r"footer|page_number|source|footnote", re.IGNORECASE)
+
+
+def _emu_to_in(emu: Optional[int]) -> float:
+    """EMU → inches。None は 0 を返す."""
+    if emu is None:
+        return 0.0
+    return emu / 914400
+
+
+def _shape_name(shape, fallback: str = "") -> str:
+    """shape の name を取得する。欠落時は fallback を返す."""
+    try:
+        name = shape.name
+    except Exception:
+        name = None
+    if not name:
+        return fallback
+    return name
+
+
+def _iter_runs(text_frame) -> List[Any]:
+    """text_frame の全 run をフラットに返す."""
+    runs: List[Any] = []
+    for para in text_frame.paragraphs:
+        for run in para.runs:
+            runs.append(run)
+    return runs
+
+
+def _dominant_font_size(text_frame, default_pt: float = 18.0) -> float:
+    """text_frame 内で最大の font.size (pt) を返す.
+
+    いずれの run にも明示サイズが無ければ ``default_pt`` を返す。
+    """
+    max_pt: Optional[float] = None
+    for run in _iter_runs(text_frame):
+        size = run.font.size
+        if size is None:
+            continue
+        pt = size.pt
+        if max_pt is None or pt > max_pt:
+            max_pt = pt
+    if max_pt is None:
+        return default_pt
+    return max_pt
+
+
+def _full_text(text_frame) -> str:
+    """text_frame の全段落テキストを改行結合して返す."""
+    lines: List[str] = []
+    for para in text_frame.paragraphs:
+        lines.append("".join(run.text for run in para.runs))
+    return "\n".join(lines)
+
+
+def check_text_overflow(
+    presentation: Presentation,
+    *,
+    min_readable_pt: float = 8.0,
+    overflow_tolerance_pct: float = 5.0,
+) -> List[ValidationFinding]:
+    """テキストフレームの高さ溢れを検出する.
+
+    各 text frame の幅 (左右 0.05" マージン合計) に基づき、推定文字高さが
+    frame_height × (1 + tolerance/100) を超える場合に ``error`` finding を返す。
+    """
+    findings: List[ValidationFinding] = []
+    tolerance_factor = 1 + overflow_tolerance_pct / 100.0
+
+    for slide_index, slide in enumerate(presentation.slides):
+        for shape_i, shape in enumerate(slide.shapes):
+            if not getattr(shape, "has_text_frame", False):
+                continue
+            if not shape.has_text_frame:
+                continue
+            frame_width = _emu_to_in(shape.width)
+            frame_height = _emu_to_in(shape.height)
+            if frame_width <= 0.1 or frame_height <= 0.05:
+                continue
+
+            tf = shape.text_frame
+            text = _full_text(tf)
+            if not text.strip():
+                continue
+
+            font_size = _dominant_font_size(tf)
+            usable_width = max(0.1, frame_width - 0.10)
+            needed_height = estimate_text_height(text, usable_width, font_size)
+            max_allowed = frame_height * tolerance_factor
+
+            if needed_height > max_allowed:
+                # 収まる最大 pt を 0.5pt 刻みで探索する
+                fit_pt: Optional[float] = None
+                candidate = font_size - 0.5
+                while candidate >= min_readable_pt:
+                    h = estimate_text_height(text, usable_width, candidate)
+                    if h <= frame_height:
+                        fit_pt = candidate
+                        break
+                    candidate -= 0.5
+
+                if fit_pt is not None:
+                    suggested = (
+                        f"reduce font {font_size:.1f}pt → {fit_pt:.1f}pt"
+                    )
+                else:
+                    delta = max(0.05, needed_height - frame_height)
+                    suggested = f'increase box height by {delta:.2f}"'
+
+                name = _shape_name(shape, f"Shape {shape_i}")
+                findings.append(
+                    ValidationFinding(
+                        severity="error",
+                        slide_index=slide_index,
+                        shape_name=name,
+                        category="text_overflow",
+                        message=(
+                            f"text overflow: needed {needed_height:.2f}\" "
+                            f"> frame {frame_height:.2f}\" "
+                            f"(font {font_size:.1f}pt, width {frame_width:.2f}\")"
+                        ),
+                        suggested_fix=suggested,
+                    )
+                )
+
+    return findings
+
+
+def check_unreadable_text(
+    presentation: Presentation,
+    *,
+    min_readable_pt: float = 8.0,
+) -> List[ValidationFinding]:
+    """``min_readable_pt`` 未満の font サイズを警告する.
+
+    shape 名に ``footer`` / ``page_number`` / ``source`` / ``footnote`` を
+    含む shape は (大文字小文字を区別せず) 除外する。
+    """
+    findings: List[ValidationFinding] = []
+
+    for slide_index, slide in enumerate(presentation.slides):
+        for shape_i, shape in enumerate(slide.shapes):
+            if not getattr(shape, "has_text_frame", False):
+                continue
+            if not shape.has_text_frame:
+                continue
+            name = _shape_name(shape, f"Shape {shape_i}")
+            if _UNREADABLE_WHITELIST_RE.search(name or ""):
+                continue
+
+            tf = shape.text_frame
+            smallest: Optional[float] = None
+            for run in _iter_runs(tf):
+                size = run.font.size
+                if size is None:
+                    continue
+                pt = size.pt
+                if pt < min_readable_pt:
+                    if smallest is None or pt < smallest:
+                        smallest = pt
+
+            if smallest is not None:
+                findings.append(
+                    ValidationFinding(
+                        severity="warning",
+                        slide_index=slide_index,
+                        shape_name=name,
+                        category="unreadable_text",
+                        message=(
+                            f"font size {smallest:.1f}pt is below readable "
+                            f"threshold {min_readable_pt:.1f}pt"
+                        ),
+                        suggested_fix=(
+                            f"increase font size to at least {min_readable_pt:.1f}pt"
+                        ),
+                    )
+                )
+
+    return findings
+
+
+def check_divider_collision(
+    presentation: Presentation,
+) -> List[ValidationFinding]:
+    """タイトル直下の divider line にタイトルテキストが食い込まないかを検証する.
+
+    divider 条件: 高さ < 0.05" かつ 幅 > 2"。
+    その上 0.5" 以内に存在する text frame について、推定高さが
+    ``divider.top - 0.02"`` を越えたら ``error`` finding。
+    """
+    findings: List[ValidationFinding] = []
+
+    for slide_index, slide in enumerate(presentation.slides):
+        shapes = list(slide.shapes)
+        dividers: List[Tuple[Any, Tuple[float, float, float, float]]] = []
+        for shape in shapes:
+            w = _emu_to_in(shape.width)
+            h = _emu_to_in(shape.height)
+            if h < 0.05 and w > 2.0:
+                dividers.append((shape, _get_shape_bounds(shape)))
+
+        if not dividers:
+            continue
+
+        for shape_i, shape in enumerate(shapes):
+            if not getattr(shape, "has_text_frame", False):
+                continue
+            if not shape.has_text_frame:
+                continue
+
+            bounds = _get_shape_bounds(shape)
+            s_left, s_top, s_right, s_bottom = bounds
+
+            for div_shape, div_bounds in dividers:
+                if div_shape is shape:
+                    continue
+                d_left, d_top, d_right, d_bottom = div_bounds
+                # divider は text frame より下にあり、かつ text frame 下端から 0.5" 以内
+                if d_top < s_top:
+                    continue
+                if d_top - s_bottom > 0.5:
+                    continue
+
+                tf = shape.text_frame
+                text = _full_text(tf)
+                if not text.strip():
+                    continue
+                frame_width = max(0.1, (s_right - s_left) - 0.10)
+                font_size = _dominant_font_size(tf)
+                needed_height = estimate_text_height(text, frame_width, font_size)
+                projected_bottom = s_top + needed_height
+                limit = d_top - 0.02
+
+                if projected_bottom > limit:
+                    name = _shape_name(shape, f"Shape {shape_i}")
+                    div_name = _shape_name(div_shape, "Divider")
+                    findings.append(
+                        ValidationFinding(
+                            severity="error",
+                            slide_index=slide_index,
+                            shape_name=name,
+                            category="divider_collision",
+                            message=(
+                                f"text extends to {projected_bottom:.2f}\" "
+                                f"overlapping divider '{div_name}' at "
+                                f"{d_top:.2f}\" (limit {limit:.2f}\")"
+                            ),
+                            suggested_fix=(
+                                "reduce title length, shrink font, or "
+                                "move the divider line lower"
+                            ),
+                        )
+                    )
+                    # divider ごとに最大 1 件で十分
+                    break
+
+    return findings
+
+
+def _axis_groups(
+    values: List[Tuple[int, float]],
+    tolerance: float,
+) -> List[List[int]]:
+    """(index, axis_value) を tolerance 以内で clustering して返す.
+
+    返り値は各 group の index リスト。3 要素以上のクラスタのみ返す。
+    """
+    if not values:
+        return []
+    sorted_vals = sorted(values, key=lambda x: x[1])
+    groups: List[List[Tuple[int, float]]] = []
+    current: List[Tuple[int, float]] = [sorted_vals[0]]
+    for item in sorted_vals[1:]:
+        # 現在グループの平均値との差で判定する
+        avg = sum(v for _, v in current) / len(current)
+        if abs(item[1] - avg) <= tolerance:
+            current.append(item)
+        else:
+            groups.append(current)
+            current = [item]
+    groups.append(current)
+    return [[idx for idx, _ in g] for g in groups if len(g) >= 3]
+
+
+def check_inconsistent_gaps(
+    presentation: Presentation,
+    *,
+    axis_tolerance: float = 0.1,
+    gap_tolerance: float = 0.05,
+) -> List[ValidationFinding]:
+    """同じ行・列に並ぶ shape 群の gap のばらつきを検出する.
+
+    行: top が ``axis_tolerance`` 以内で揃う 3 shape 以上。隣接 x gap の
+    stddev または max-min が ``gap_tolerance`` を超えたら ``info`` finding。
+    列: 同様に left 基準で y gap を比較する。
+    """
+    findings: List[ValidationFinding] = []
+
+    for slide_index, slide in enumerate(presentation.slides):
+        shapes = list(slide.shapes)
+        content_shapes: List[Tuple[int, Any, Tuple[float, float, float, float]]] = []
+        for idx, shape in enumerate(shapes):
+            if _is_small_decorative(shape):
+                continue
+            bounds = _get_shape_bounds(shape)
+            content_shapes.append((idx, shape, bounds))
+
+        if len(content_shapes) < 3:
+            continue
+
+        # 行方向 (top 同一)
+        top_values = [(i, b[1]) for i, (_, _, b) in enumerate(content_shapes)]
+        row_groups = _axis_groups(top_values, axis_tolerance)
+        for group in row_groups:
+            # left 順
+            sorted_group = sorted(group, key=lambda ii: content_shapes[ii][2][0])
+            gaps: List[float] = []
+            for a, b in zip(sorted_group, sorted_group[1:]):
+                ba = content_shapes[a][2]
+                bb = content_shapes[b][2]
+                gap = bb[0] - ba[2]
+                gaps.append(gap)
+            if not gaps:
+                continue
+            gap_range = max(gaps) - min(gaps)
+            std = statistics.pstdev(gaps) if len(gaps) > 1 else 0.0
+            if std > gap_tolerance or gap_range > gap_tolerance:
+                names = [
+                    _shape_name(content_shapes[i][1], f"Shape {content_shapes[i][0]}")
+                    for i in sorted_group
+                ]
+                gaps_str = ", ".join(f"{g:.2f}\"" for g in gaps)
+                findings.append(
+                    ValidationFinding(
+                        severity="info",
+                        slide_index=slide_index,
+                        shape_name=names[0],
+                        category="inconsistent_gap",
+                        message=(
+                            f"row of {len(sorted_group)} shapes "
+                            f"({', '.join(names)}) has inconsistent x gaps: "
+                            f"[{gaps_str}]"
+                        ),
+                        suggested_fix=(
+                            "equalise horizontal spacing between shapes"
+                        ),
+                    )
+                )
+
+        # 列方向 (left 同一)
+        left_values = [(i, b[0]) for i, (_, _, b) in enumerate(content_shapes)]
+        col_groups = _axis_groups(left_values, axis_tolerance)
+        for group in col_groups:
+            sorted_group = sorted(group, key=lambda ii: content_shapes[ii][2][1])
+            gaps = []
+            for a, b in zip(sorted_group, sorted_group[1:]):
+                ba = content_shapes[a][2]
+                bb = content_shapes[b][2]
+                gap = bb[1] - ba[3]
+                gaps.append(gap)
+            if not gaps:
+                continue
+            gap_range = max(gaps) - min(gaps)
+            std = statistics.pstdev(gaps) if len(gaps) > 1 else 0.0
+            if std > gap_tolerance or gap_range > gap_tolerance:
+                names = [
+                    _shape_name(content_shapes[i][1], f"Shape {content_shapes[i][0]}")
+                    for i in sorted_group
+                ]
+                gaps_str = ", ".join(f"{g:.2f}\"" for g in gaps)
+                findings.append(
+                    ValidationFinding(
+                        severity="info",
+                        slide_index=slide_index,
+                        shape_name=names[0],
+                        category="inconsistent_gap",
+                        message=(
+                            f"column of {len(sorted_group)} shapes "
+                            f"({', '.join(names)}) has inconsistent y gaps: "
+                            f"[{gaps_str}]"
+                        ),
+                        suggested_fix=(
+                            "equalise vertical spacing between shapes"
+                        ),
+                    )
+                )
+
+    return findings
+
+
+def check_deck_extended(
+    presentation: Presentation,
+    *,
+    min_readable_pt: float = 8.0,
+    overflow_tolerance_pct: float = 5.0,
+    axis_tolerance: float = 0.1,
+    gap_tolerance: float = 0.05,
+) -> Dict[str, Any]:
+    """deck 全体を走査し、既存 + 拡張チェックをまとめて返す.
+
+    戻り値構造::
+
+        {
+            "slides": [
+                {
+                    "index": int,
+                    "overlaps": [...],
+                    "out_of_bounds": [...],
+                    "text_overflow": [...],
+                    "unreadable_text": [...],
+                    "divider_collision": [...],
+                    "inconsistent_gaps": [...],
+                },
+                ...
+            ],
+            "summary": {"errors": int, "warnings": int, "infos": int},
+        }
+
+    既存 ``check_slide_overlaps`` の警告文字列を ``overlaps`` と
+    ``out_of_bounds`` に分割して格納する (既存キーは文字列リストのまま)。
+    """
+    slide_w = presentation.slide_width / 914400
+    slide_h = presentation.slide_height / 914400
+
+    text_overflow = check_text_overflow(
+        presentation,
+        min_readable_pt=min_readable_pt,
+        overflow_tolerance_pct=overflow_tolerance_pct,
+    )
+    unreadable = check_unreadable_text(
+        presentation,
+        min_readable_pt=min_readable_pt,
+    )
+    divider = check_divider_collision(presentation)
+    gaps = check_inconsistent_gaps(
+        presentation,
+        axis_tolerance=axis_tolerance,
+        gap_tolerance=gap_tolerance,
+    )
+
+    # slide index ごとに集約
+    by_slide: Dict[int, Dict[str, List[Any]]] = {}
+    for i, slide in enumerate(presentation.slides):
+        warnings = check_slide_overlaps(
+            slide, margin=-0.05,
+            slide_width=slide_w, slide_height=slide_h,
+        )
+        overlap_warnings = [w for w in warnings if not w.startswith("OUT OF BOUNDS")]
+        oob_warnings = [w for w in warnings if w.startswith("OUT OF BOUNDS")]
+        by_slide[i] = {
+            "index": i,
+            "overlaps": overlap_warnings,
+            "out_of_bounds": oob_warnings,
+            "text_overflow": [],
+            "unreadable_text": [],
+            "divider_collision": [],
+            "inconsistent_gaps": [],
+        }
+
+    def _place(findings: List[ValidationFinding], key: str) -> None:
+        for f in findings:
+            # slide_index がプレゼンテーション範囲外のものはスキップ (防御)
+            if f.slide_index not in by_slide:
+                continue
+            by_slide[f.slide_index][key].append(f.to_dict())
+
+    _place(text_overflow, "text_overflow")
+    _place(unreadable, "unreadable_text")
+    _place(divider, "divider_collision")
+    _place(gaps, "inconsistent_gaps")
+
+    slides_out = [by_slide[i] for i in sorted(by_slide.keys())]
+
+    # summary: ValidationFinding 由来の severity を集計する
+    errors = sum(1 for f in text_overflow + divider if f.severity == "error")
+    warnings_count = sum(1 for f in unreadable if f.severity == "warning")
+    infos = sum(1 for f in gaps if f.severity == "info")
+
+    return {
+        "slides": slides_out,
+        "summary": {
+            "errors": errors,
+            "warnings": warnings_count,
+            "infos": infos,
+        },
+    }

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -43,6 +43,7 @@ from .engine import (
     add_connector,
     add_callout,
     check_deck_overlaps,
+    check_deck_extended,
 )
 
 INSTRUCTIONS = """
@@ -880,11 +881,25 @@ def pptx_render_slide(
 # --- Entry Point --------------------------------------------------
 
 @mcp.tool()
-def pptx_check_layout(file_path: str) -> str:
-    """Validate slide layouts: detect overlapping shapes and out-of-bounds elements.
+def pptx_check_layout(
+    file_path: str,
+    min_readable_pt: float = 8.0,
+    overflow_tolerance_pct: float = 5.0,
+) -> str:
+    """Validate slide layouts: overlaps, out-of-bounds, text overflow,
+    unreadable font, title/divider collision, inconsistent gaps.
+
+    Returns a JSON string with per-slide findings and a summary block.
     Run after building a deck to catch layout issues before delivery."""
     try:
-        return check_deck_overlaps(file_path)
+        from pptx import Presentation
+        prs = Presentation(file_path)
+        result = check_deck_extended(
+            prs,
+            min_readable_pt=min_readable_pt,
+            overflow_tolerance_pct=overflow_tolerance_pct,
+        )
+        return json.dumps(result, ensure_ascii=False, indent=2)
     except Exception as e:
         return _err(e)
 

--- a/tests/test_validation_extended.py
+++ b/tests/test_validation_extended.py
@@ -1,0 +1,273 @@
+"""validation 拡張 (Issue #5) のテスト.
+
+text_overflow / unreadable_text / divider_collision / inconsistent_gap を
+それぞれ独立に検証し、最後に check_deck_extended の集計動作を確認する。
+"""
+
+from __future__ import annotations
+
+import pytest
+from pptx import Presentation
+from pptx.util import Inches, Pt
+
+from pptx_mcp_server.engine.validation import (
+    ValidationFinding,
+    check_deck_extended,
+    check_divider_collision,
+    check_inconsistent_gaps,
+    check_text_overflow,
+    check_unreadable_text,
+)
+
+
+# ---------------------------------------------------------------------------
+# ヘルパ
+# ---------------------------------------------------------------------------
+
+
+def _add_textbox(
+    slide,
+    left_in: float,
+    top_in: float,
+    width_in: float,
+    height_in: float,
+    text: str,
+    font_pt: float | None = None,
+    name: str | None = None,
+):
+    """指定位置に text box を追加し、必要ならフォントサイズと name を設定する."""
+    tb = slide.shapes.add_textbox(
+        Inches(left_in), Inches(top_in), Inches(width_in), Inches(height_in)
+    )
+    tf = tb.text_frame
+    tf.word_wrap = True
+    tf.text = text
+    if font_pt is not None:
+        for para in tf.paragraphs:
+            for run in para.runs:
+                run.font.size = Pt(font_pt)
+    if name is not None:
+        tb.name = name
+    return tb
+
+
+def _add_rect(
+    slide,
+    left_in: float,
+    top_in: float,
+    width_in: float,
+    height_in: float,
+    name: str | None = None,
+):
+    """rectangle auto shape を追加する."""
+    from pptx.enum.shapes import MSO_SHAPE
+
+    sh = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(left_in), Inches(top_in), Inches(width_in), Inches(height_in),
+    )
+    if name is not None:
+        sh.name = name
+    return sh
+
+
+# ---------------------------------------------------------------------------
+# text_overflow
+# ---------------------------------------------------------------------------
+
+
+class TestTextOverflow:
+    """check_text_overflow の挙動を検証する."""
+
+    def test_short_text_in_large_box_no_finding(self, one_slide_prs: Presentation) -> None:
+        slide = one_slide_prs.slides[0]
+        _add_textbox(slide, 1.0, 1.0, 6.0, 3.0, "短いテキスト", font_pt=14)
+        findings = check_text_overflow(one_slide_prs)
+        assert findings == []
+
+    def test_long_japanese_in_small_box_overflows(self, one_slide_prs: Presentation) -> None:
+        slide = one_slide_prs.slides[0]
+        long_jp = (
+            "これは非常に長い日本語のテキストであり、"
+            "指定された小さなテキストボックスには到底収まらないほどの分量を持っている。"
+            "さらに追加の説明文も含めて計測する。"
+        )
+        _add_textbox(slide, 1.0, 1.0, 2.0, 0.5, long_jp, font_pt=18, name="SmallBox")
+        findings = check_text_overflow(one_slide_prs)
+        assert len(findings) >= 1
+        f = findings[0]
+        assert f.category == "text_overflow"
+        assert f.severity == "error"
+        assert f.shape_name == "SmallBox"
+        assert f.suggested_fix != ""
+
+
+# ---------------------------------------------------------------------------
+# unreadable_text
+# ---------------------------------------------------------------------------
+
+
+class TestUnreadableText:
+    """check_unreadable_text の挙動を検証する."""
+
+    def test_6pt_text_warns(self, one_slide_prs: Presentation) -> None:
+        slide = one_slide_prs.slides[0]
+        _add_textbox(slide, 1.0, 1.0, 3.0, 0.5, "tiny", font_pt=6, name="TinyBox")
+        findings = check_unreadable_text(one_slide_prs)
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.category == "unreadable_text"
+        assert f.severity == "warning"
+        assert f.shape_name == "TinyBox"
+
+    def test_9pt_text_no_finding(self, one_slide_prs: Presentation) -> None:
+        slide = one_slide_prs.slides[0]
+        _add_textbox(slide, 1.0, 1.0, 3.0, 0.5, "ok", font_pt=9, name="OkBox")
+        findings = check_unreadable_text(one_slide_prs)
+        assert findings == []
+
+    def test_footer_named_shape_whitelisted(self, one_slide_prs: Presentation) -> None:
+        slide = one_slide_prs.slides[0]
+        _add_textbox(
+            slide, 1.0, 7.0, 3.0, 0.3, "Source: example",
+            font_pt=7, name="Footer_Source",
+        )
+        findings = check_unreadable_text(one_slide_prs)
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# divider_collision
+# ---------------------------------------------------------------------------
+
+
+class TestDividerCollision:
+    """check_divider_collision の挙動を検証する."""
+
+    def test_title_wraps_into_divider(self, one_slide_prs: Presentation) -> None:
+        slide = one_slide_prs.slides[0]
+        # タイトル: width 3.0" に 14pt 長タイトルを入れ 2 行以上に折り返す想定
+        long_title = (
+            "これはスライドのアクションタイトルで必ず折り返される日本語テキスト"
+        )
+        _add_textbox(slide, 0.9, 0.45, 3.0, 0.5, long_title,
+                     font_pt=14, name="Title")
+        # divider: y=0.95" に薄い水平線 (高さ 0.01")
+        _add_rect(slide, 0.9, 0.95, 11.5, 0.02, name="Divider")
+
+        findings = check_divider_collision(one_slide_prs)
+        assert len(findings) >= 1
+        f = findings[0]
+        assert f.category == "divider_collision"
+        assert f.severity == "error"
+        assert f.shape_name == "Title"
+
+    def test_short_title_no_collision(self, one_slide_prs: Presentation) -> None:
+        slide = one_slide_prs.slides[0]
+        # 十分に収まる短いタイトル (12pt 1 行 ≈ 0.20" → top 0.65 + 0.20 = 0.85 < 0.93)
+        _add_textbox(slide, 0.9, 0.65, 11.5, 0.25, "短題",
+                     font_pt=12, name="Title")
+        _add_rect(slide, 0.9, 0.95, 11.5, 0.02, name="Divider")
+        findings = check_divider_collision(one_slide_prs)
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# inconsistent_gap
+# ---------------------------------------------------------------------------
+
+
+class TestInconsistentGap:
+    """check_inconsistent_gaps の挙動を検証する."""
+
+    def test_uneven_row_gaps(self, one_slide_prs: Presentation) -> None:
+        slide = one_slide_prs.slides[0]
+        # 同じ top (=2.0") に 3 shape、幅 1.0"、x gap を [0.15, 0.30] に設定
+        _add_rect(slide, 1.00, 2.0, 1.0, 1.0, name="A")
+        _add_rect(slide, 2.15, 2.0, 1.0, 1.0, name="B")  # gap A→B = 0.15
+        _add_rect(slide, 3.45, 2.0, 1.0, 1.0, name="C")  # gap B→C = 0.30
+        # もう 1 shape で 3 つ目の gap を確保: gaps [0.15, 0.30] 差 = 0.15 > 0.05
+        findings = check_inconsistent_gaps(one_slide_prs)
+        assert len(findings) >= 1
+        assert any(f.category == "inconsistent_gap" for f in findings)
+        assert all(f.severity == "info" for f in findings)
+
+    def test_consistent_row_gaps_no_finding(self, one_slide_prs: Presentation) -> None:
+        slide = one_slide_prs.slides[0]
+        # gaps 0.20, 0.20, 0.20 → 差 0
+        _add_rect(slide, 1.00, 2.0, 1.0, 1.0, name="A")
+        _add_rect(slide, 2.20, 2.0, 1.0, 1.0, name="B")
+        _add_rect(slide, 3.40, 2.0, 1.0, 1.0, name="C")
+        _add_rect(slide, 4.60, 2.0, 1.0, 1.0, name="D")
+        findings = check_inconsistent_gaps(one_slide_prs)
+        # 行方向は一定、列方向も揃っていないので誤検出しない
+        row_findings = [f for f in findings if "row" in f.message]
+        assert row_findings == []
+
+
+# ---------------------------------------------------------------------------
+# check_deck_extended 集計
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDeckExtended:
+    """check_deck_extended が summary を正しく集計することを確認する."""
+
+    def test_aggregated_summary_counts(self, one_slide_prs: Presentation) -> None:
+        slide = one_slide_prs.slides[0]
+        # 1) text_overflow (error)
+        long_jp = (
+            "非常に長い日本語のテキストでありこの幅の箱に収まらない量を持つ。"
+            "追加文章もあるので必ずオーバーフローする。"
+        )
+        _add_textbox(slide, 1.0, 1.0, 2.0, 0.5, long_jp,
+                     font_pt=18, name="Overflow")
+        # 2) unreadable (warning)
+        _add_textbox(slide, 1.0, 5.0, 3.0, 0.3, "tiny",
+                     font_pt=6, name="TinyBox")
+
+        result = check_deck_extended(one_slide_prs)
+
+        assert "slides" in result
+        assert "summary" in result
+        assert len(result["slides"]) == 1
+        slide0 = result["slides"][0]
+        # 後方互換キーの保持を確認
+        assert "overlaps" in slide0
+        assert "out_of_bounds" in slide0
+        # 新キー
+        assert "text_overflow" in slide0
+        assert "unreadable_text" in slide0
+        assert "divider_collision" in slide0
+        assert "inconsistent_gaps" in slide0
+
+        assert len(slide0["text_overflow"]) >= 1
+        assert len(slide0["unreadable_text"]) >= 1
+
+        summary = result["summary"]
+        assert summary["errors"] >= 1
+        assert summary["warnings"] >= 1
+        assert summary["infos"] >= 0
+
+
+# ---------------------------------------------------------------------------
+# ValidationFinding dataclass の簡易確認
+# ---------------------------------------------------------------------------
+
+
+def test_validation_finding_to_dict_shape() -> None:
+    f = ValidationFinding(
+        severity="error",
+        slide_index=0,
+        shape_name="X",
+        category="text_overflow",
+        message="m",
+        suggested_fix="fix",
+    )
+    d = f.to_dict()
+    assert d["severity"] == "error"
+    assert d["slide_index"] == 0
+    assert d["shape_name"] == "X"
+    assert d["category"] == "text_overflow"
+    assert d["message"] == "m"
+    assert d["suggested_fix"] == "fix"


### PR DESCRIPTION
## Summary
- Extend `src/pptx_mcp_server/engine/validation.py` with four new checks built on the `text_metrics` utility: `check_text_overflow` (error), `check_unreadable_text` (warning + shape-name whitelist for footer/page_number/source/footnote), `check_divider_collision` (error), and `check_inconsistent_gaps` (info for row/column spacing).
- Introduce a `ValidationFinding` dataclass (with `to_dict`) and a new `check_deck_extended` orchestrator that returns `{ "slides": [...], "summary": {errors, warnings, infos} }` while preserving the existing `overlaps` and `out_of_bounds` keys verbatim (backward-compatible).
- Update the MCP `pptx_check_layout` tool to call `check_deck_extended` and return JSON. Adds optional `min_readable_pt` and `overflow_tolerance_pct` parameters. The legacy `check_deck_overlaps(pptx_path)` string API is retained.

## Test plan
- [x] `python -m pytest tests/test_validation_extended.py -v` (11 new tests, all green)
- [x] `python -m pytest` (311 tests, no regressions)
- [ ] Manual: point `pptx_check_layout` at a real deck and inspect the JSON output

Closes #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)