### PR TITLE
feat(flex): add flex container with fixed/grow/content sizing (closes #3)

### DIFF
--- a/src/pptx_mcp_server/engine/__init__.py
+++ b/src/pptx_mcp_server/engine/__init__.py
@@ -78,6 +78,11 @@ from .connectors import (
     _add_connector,
     _add_callout,
 )
+from .flex import (
+    FlexItem,
+    add_flex_container,
+    add_flex_container_file,
+)
 from .composites import (
     add_content_slide,
     add_section_divider,
@@ -121,6 +126,8 @@ __all__ = [
     # Composites
     "add_content_slide", "add_section_divider", "add_kpi_row", "add_bullet_block",
     "build_slide", "build_deck",
+    # Flex
+    "FlexItem", "add_flex_container", "add_flex_container_file",
     # Rendering
     "render_slide", "render_slide_to_path",
 ]

--- a/src/pptx_mcp_server/engine/flex.py
+++ b/src/pptx_mcp_server/engine/flex.py
@@ -1,0 +1,387 @@
+"""CSS Flexbox 相当のコンテナプリミティブ.
+
+PPTX レイアウトにおいて、行方向 (``row``) または列方向 (``column``) に
+子要素をサイジング・配置する。CSS Flexbox の ``fixed``・``grow``・
+``content`` 3 種のサイジングモデルをサポートする MVP 実装である。
+
+# 設計メモ
+- 子要素の描画は呼び出し元が指定する ``render(x, y, w, h)`` コールバック
+  に委譲する。flex 自身は形状を生成せず、配置計算のみを担う。
+- ``wrap`` ・ ``justify`` ・ ``align-self`` 等の CSS 機能はスコープ外。
+- cross 軸の実寸 (intrinsic cross size) は測定しないため、非 stretch
+  でも cross サイズは usable_cross を割り当てる (MVP の制約)。
+
+# アルゴリズム概略 (row の場合)
+1. usable_main = width - 2*padding - gap*(n-1)
+2. fixed_total と content_total をまず確定させる。
+3. 残余 ``remain = max(0, usable_main - fixed_total - content_total)`` を
+   grow 項目の ``grow`` 比率で按分する。
+4. 各 grow 項目を ``[min_size, max_size]`` にクランプし、クランプにより
+   余った分を未クランプ項目で再配分する (CSS Flex 方式)。
+5. main 軸方向に padding から積み上げて配置し、cross 軸は padding から
+   usable_cross を割り当てる。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Literal
+
+from .pptx_io import EngineError, ErrorCode, open_pptx, save_pptx, _get_slide
+from .shapes import _add_shape, add_auto_fit_textbox
+
+SizingMode = Literal["fixed", "grow", "content"]
+Direction = Literal["row", "column"]
+Align = Literal["start", "center", "end", "stretch"]
+
+
+@dataclass
+class FlexItem:
+    """Flex コンテナの子要素.
+
+    Attributes:
+        sizing: サイジングモード。``"fixed"``・``"grow"``・``"content"``。
+        render: ``render(x, y, w, h)`` 形式の描画コールバック。実際に
+            shape を生成する責務は呼び出し元にある。
+        size: ``sizing="fixed"`` のときの main 軸サイズ (inches)。
+        grow: ``sizing="grow"`` のときの成長係数。0 以下は 0 扱い。
+        content_size: ``sizing="content"`` のときの main 軸サイズ (inches)。
+            呼び出し元が事前に計測した値を渡す。
+        min_size: クランプ下限 (inches)。主に grow 項目で有効。
+        max_size: クランプ上限 (inches)。主に grow 項目で有効。
+    """
+
+    sizing: SizingMode
+    render: Callable[[float, float, float, float], None]
+    size: float = 0.0
+    grow: float = 1.0
+    content_size: float = 0.0
+    min_size: float = 0.0
+    max_size: float = float("inf")
+
+
+def _item_base_main_size(item: FlexItem) -> float:
+    """grow でない項目の main 軸ベースサイズを返す."""
+    if item.sizing == "fixed":
+        return max(item.size, 0.0)
+    if item.sizing == "content":
+        return max(item.content_size, 0.0)
+    # grow 項目はこの関数の対象外
+    return 0.0
+
+
+def _distribute_grow(
+    items: list[FlexItem],
+    indices: list[int],
+    remain: float,
+) -> dict[int, float]:
+    """grow 項目にサイズを按分する (CSS Flex のクランプ再配分を実装).
+
+    ``indices`` は ``items`` 内で ``sizing=="grow"`` である要素の index。
+    各要素の ``max(grow, 0)`` を係数として ``remain`` を按分する。クランプ
+    が発生した項目は pool から除外し、残余を未クランプ項目で再配分する。
+    この手続きをクランプが発生しなくなるまで繰り返す。
+
+    Returns:
+        index -> 決定サイズ の dict。
+    """
+    result: dict[int, float] = {}
+    pool: list[int] = []
+    for i in indices:
+        g = max(items[i].grow, 0.0)
+        if g <= 0.0:
+            # 成長しない grow 項目は min_size を割り当てる (0 起点の clamp)
+            clamped = max(items[i].min_size, 0.0)
+            result[i] = clamped
+            remain -= clamped
+        else:
+            pool.append(i)
+
+    # pool が空 = クランプ以外で処理済み。
+    while pool:
+        total_grow = sum(max(items[i].grow, 0.0) for i in pool)
+        if total_grow <= 0.0:
+            for i in pool:
+                result[i] = max(items[i].min_size, 0.0)
+            break
+
+        # 分配対象の残余が負なら 0 としてクランプ (縮めない)
+        dist = max(remain, 0.0)
+        newly_clamped: list[int] = []
+        for i in pool:
+            g = max(items[i].grow, 0.0)
+            share = dist * (g / total_grow)
+            if share < items[i].min_size:
+                result[i] = items[i].min_size
+                newly_clamped.append(i)
+            elif share > items[i].max_size:
+                result[i] = items[i].max_size
+                newly_clamped.append(i)
+
+        if not newly_clamped:
+            # 残った pool には純粋な按分値を割り当てる
+            for i in pool:
+                g = max(items[i].grow, 0.0)
+                result[i] = dist * (g / total_grow)
+            break
+
+        # クランプで確定した分を remain から差し引き、pool から除外
+        for i in newly_clamped:
+            remain -= result[i]
+        pool = [i for i in pool if i not in newly_clamped]
+
+    return result
+
+
+def add_flex_container(
+    slide,
+    items: list[FlexItem],
+    *,
+    left: float,
+    top: float,
+    width: float,
+    height: float,
+    direction: Direction = "row",
+    gap: float = 0.15,
+    padding: float = 0.0,
+    align: Align = "stretch",
+) -> list[tuple[float, float, float, float]]:
+    """子要素のサイズ・位置を計算し、各 ``item.render(x, y, w, h)`` を呼ぶ.
+
+    Args:
+        slide: 対象スライド (本関数はスライド自体を参照せず、render 側に委譲する)。
+        items: 子要素のリスト。空リストでも可。
+        left, top, width, height: コンテナの位置・寸法 (inches)。
+        direction: 主軸方向。``"row"`` または ``"column"``。
+        gap: 子要素間のスペース (inches)。
+        padding: コンテナ内側の余白 (inches、全 4 辺に適用)。
+        align: cross 軸方向の整列。``"stretch"`` 以外は現状、cross サイズ
+            自体は stretch と同等に扱う (intrinsic cross 未測定のため MVP)。
+
+    Returns:
+        各 item に割り当てられた ``(left, top, width, height)`` のタプル
+        のリスト。``items`` と同順。
+    """
+    if not items:
+        return []
+
+    n = len(items)
+
+    if direction == "row":
+        usable_main = width - 2 * padding - gap * max(n - 1, 0)
+        usable_cross = height - 2 * padding
+    else:
+        usable_main = height - 2 * padding - gap * max(n - 1, 0)
+        usable_cross = width - 2 * padding
+
+    # fixed + content の合計サイズ
+    fixed_total = sum(
+        max(it.size, 0.0) for it in items if it.sizing == "fixed"
+    )
+    content_total = sum(
+        max(it.content_size, 0.0) for it in items if it.sizing == "content"
+    )
+    remain = max(0.0, usable_main - fixed_total - content_total)
+
+    grow_indices = [i for i, it in enumerate(items) if it.sizing == "grow"]
+    grow_sizes = _distribute_grow(items, grow_indices, remain)
+
+    # 各 item の main 軸サイズを決定
+    main_sizes: list[float] = []
+    for i, it in enumerate(items):
+        if it.sizing == "grow":
+            main_sizes.append(grow_sizes.get(i, 0.0))
+        else:
+            main_sizes.append(_item_base_main_size(it))
+
+    # cross 軸サイズは MVP では常に usable_cross (負にならないようクランプ)
+    cross_size = max(usable_cross, 0.0)
+
+    # 配置
+    allocations: list[tuple[float, float, float, float]] = []
+    if direction == "row":
+        cursor = left + padding
+        cross_origin = top + padding
+        for i, it in enumerate(items):
+            w = main_sizes[i]
+            x = cursor
+            y = cross_origin
+            h = cross_size
+            allocations.append((x, y, w, h))
+            cursor += w + gap
+    else:
+        cursor = top + padding
+        cross_origin = left + padding
+        for i, it in enumerate(items):
+            h = main_sizes[i]
+            x = cross_origin
+            y = cursor
+            w = cross_size
+            allocations.append((x, y, w, h))
+            cursor += h + gap
+
+    # 描画コールバックを呼ぶ
+    for it, (x, y, w, h) in zip(items, allocations):
+        it.render(x, y, w, h)
+
+    return allocations
+
+
+# --- 宣言的 (declarative) 項目からの flex 生成 ---------------------------
+
+_SUPPORTED_ITEM_TYPES = ("text", "rectangle")
+
+
+def _build_declarative_item(
+    slide,
+    spec: dict[str, Any],
+    created_shape_indices: list[dict[str, Any]],
+) -> FlexItem:
+    """MCP 層から渡される dict 仕様から ``FlexItem`` を生成する.
+
+    サポートする ``type``:
+
+    - ``"text"``: ``add_auto_fit_textbox`` を使って描画する。
+    - ``"rectangle"``: ``_add_shape`` で塗りつぶし矩形を描画する。
+
+    描画結果 (shape_index) は ``created_shape_indices`` に追記される。
+    """
+    sizing: SizingMode = spec.get("sizing", "grow")
+    if sizing not in ("fixed", "grow", "content"):
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            f"Unknown sizing mode '{sizing}'. Expected fixed|grow|content.",
+        )
+
+    item_type = spec.get("type")
+    if item_type not in _SUPPORTED_ITEM_TYPES:
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            f"Unknown flex item type '{item_type}'. "
+            f"Supported: {', '.join(_SUPPORTED_ITEM_TYPES)}.",
+        )
+
+    size = float(spec.get("size", 0.0))
+    grow = float(spec.get("grow", 1.0))
+    content_size = float(spec.get("content_size", 0.0))
+    min_size = float(spec.get("min_size", 0.0))
+    max_size_raw = spec.get("max_size", None)
+    max_size = float("inf") if max_size_raw is None else float(max_size_raw)
+
+    if item_type == "text":
+        text = spec.get("text", "")
+        font_name = spec.get("font_name", "Arial")
+        font_size_pt = float(spec.get("font_size_pt", 11))
+        min_size_pt = float(spec.get("min_size_pt", 7))
+        bold = bool(spec.get("bold", False))
+        color_hex = spec.get("color_hex", "333333")
+        align = spec.get("align", "left")
+        vertical_anchor = spec.get("vertical_anchor", "top")
+        truncate = bool(spec.get("truncate_with_ellipsis", True))
+
+        def render_text(x: float, y: float, w: float, h: float) -> None:
+            shape, actual = add_auto_fit_textbox(
+                slide, text, x, y, w, h,
+                font_name=font_name,
+                font_size_pt=font_size_pt,
+                min_size_pt=min_size_pt,
+                bold=bold,
+                color_hex=color_hex,
+                align=align,
+                vertical_anchor=vertical_anchor,
+                truncate_with_ellipsis=truncate,
+            )
+            idx = -1
+            for i, s in enumerate(slide.shapes):
+                if s is shape:
+                    idx = i
+                    break
+            created_shape_indices.append({
+                "type": "text",
+                "shape_index": idx,
+                "actual_font_size": actual,
+            })
+
+        render = render_text
+
+    else:  # rectangle
+        fill_color = spec.get("fill_color")
+        line_color = spec.get("line_color")
+        line_width = spec.get("line_width")
+        no_line = bool(spec.get("no_line", False))
+
+        def render_rect(x: float, y: float, w: float, h: float) -> None:
+            idx = _add_shape(
+                slide, "rectangle", x, y, w, h,
+                fill_color=fill_color,
+                line_color=line_color,
+                line_width=line_width,
+                no_line=no_line,
+            )
+            created_shape_indices.append({
+                "type": "rectangle",
+                "shape_index": idx,
+            })
+
+        render = render_rect
+
+    return FlexItem(
+        sizing=sizing,
+        render=render,
+        size=size,
+        grow=grow,
+        content_size=content_size,
+        min_size=min_size,
+        max_size=max_size,
+    )
+
+
+def add_flex_container_file(
+    file_path: str,
+    slide_index: int,
+    items: list[dict[str, Any]],
+    *,
+    left: float,
+    top: float,
+    width: float,
+    height: float,
+    direction: Direction = "row",
+    gap: float = 0.15,
+    padding: float = 0.0,
+    align: Align = "stretch",
+) -> dict[str, Any]:
+    """File-based wrapper: 宣言的仕様を受け取って flex コンテナを配置する.
+
+    Args:
+        file_path: PPTX ファイルパス。
+        slide_index: 対象スライドの index。
+        items: ``{"sizing": ..., "type": ..., ...}`` 形式の dict のリスト。
+        left, top, width, height: コンテナ寸法 (inches)。
+        direction, gap, padding, align: flex 設定。
+
+    Returns:
+        ``{"allocations": [...], "shapes": [...], "slide_index": int}``
+        を含む dict。``allocations`` は ``(left, top, width, height)`` 4-tuple
+        のリスト、``shapes`` は生成された各子要素の shape 識別情報。
+    """
+    prs = open_pptx(file_path)
+    slide = _get_slide(prs, slide_index)
+
+    created_shape_indices: list[dict[str, Any]] = []
+    flex_items: list[FlexItem] = [
+        _build_declarative_item(slide, s, created_shape_indices)
+        for s in items
+    ]
+
+    allocations = add_flex_container(
+        slide, flex_items,
+        left=left, top=top, width=width, height=height,
+        direction=direction, gap=gap, padding=padding, align=align,
+    )
+
+    save_pptx(prs, file_path)
+    return {
+        "slide_index": slide_index,
+        "allocations": [list(a) for a in allocations],
+        "shapes": created_shape_indices,
+    }

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -19,6 +19,7 @@ from .engine import (
     set_slide_background,
     add_textbox,
     add_auto_fit_textbox_file,
+    add_flex_container_file,
     add_shape,
     add_image,
     edit_text,
@@ -385,6 +386,46 @@ def pptx_add_auto_fit_textbox(
             align=align,
             vertical_anchor=vertical_anchor,
             truncate_with_ellipsis=truncate_with_ellipsis,
+        )
+        return json.dumps(result)
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def pptx_add_flex_container(
+    file_path: str,
+    slide_index: int,
+    items: list,
+    left: float,
+    top: float,
+    width: float,
+    height: float,
+    direction: str = "row",
+    gap: float = 0.15,
+    padding: float = 0.0,
+    align: str = "stretch",
+) -> str:
+    """Add a CSS-flexbox-style container that lays out child items along a main axis.
+
+    `items` is a list of dicts with:
+      - `sizing`: "fixed" | "grow" | "content"
+      - `type`: "text" | "rectangle"
+      - `size` (for fixed), `grow` (for grow, default 1), `content_size` (for content)
+      - optional `min_size`, `max_size`
+      - for type=text: `text`, `font_size_pt`, `bold`, `color_hex`, `align`, `vertical_anchor`, `truncate_with_ellipsis`
+      - for type=rectangle: `fill_color`, `line_color`, `line_width`, `no_line`
+
+    direction: "row" (horizontal) | "column" (vertical). gap and padding in inches.
+    align cross-axis: "stretch" | "start" | "center" | "end" (MVP treats all as stretch for size).
+
+    Returns JSON with allocations (per-item [left, top, width, height]) and shape identifiers created.
+    """
+    try:
+        result = add_flex_container_file(
+            file_path, slide_index, items,
+            left=left, top=top, width=width, height=height,
+            direction=direction, gap=gap, padding=padding, align=align,
         )
         return json.dumps(result)
     except Exception as e:

--- a/tests/test_flex.py
+++ b/tests/test_flex.py
@@ -1,0 +1,286 @@
+"""Flex コンテナのレイアウトテスト.
+
+``add_flex_container`` による main 軸・cross 軸サイズ配分と位置計算の挙動を
+検証する。shape 生成は伴わず、呼び出し履歴を記録するスタブ render を用いる。
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from pptx_mcp_server.engine.flex import FlexItem, add_flex_container
+
+
+EPS = 1e-6
+
+
+def _recorder():
+    """呼び出しを記録する render コールバックを生成する."""
+    calls: list[tuple[float, float, float, float]] = []
+
+    def render(x: float, y: float, w: float, h: float) -> None:
+        calls.append((x, y, w, h))
+
+    return render, calls
+
+
+def _approx(a: float, b: float, tol: float = 1e-6) -> bool:
+    return abs(a - b) <= tol
+
+
+def test_three_fixed_items_row_with_gap():
+    """3 つの固定 2" 項目を 10" コンテナに gap 0.15 で配置する."""
+    renders = [_recorder() for _ in range(3)]
+    items = [
+        FlexItem(sizing="fixed", size=2.0, render=renders[0][0]),
+        FlexItem(sizing="fixed", size=2.0, render=renders[1][0]),
+        FlexItem(sizing="fixed", size=2.0, render=renders[2][0]),
+    ]
+    allocs = add_flex_container(
+        slide=None,
+        items=items,
+        left=0.0, top=0.0, width=10.0, height=1.0,
+        direction="row", gap=0.15, padding=0.0, align="stretch",
+    )
+    assert len(allocs) == 3
+    # 幅は 2.0 ずつ
+    for (x, y, w, h) in allocs:
+        assert _approx(w, 2.0)
+        assert _approx(h, 1.0)
+        assert _approx(y, 0.0)
+    # x 位置: 0, 2.15, 4.30
+    assert _approx(allocs[0][0], 0.0)
+    assert _approx(allocs[1][0], 2.15)
+    assert _approx(allocs[2][0], 4.30)
+    # render が各項目で 1 回ずつ呼ばれている
+    for _, calls in renders:
+        assert len(calls) == 1
+
+
+def test_fixed_plus_two_grow_equal_split():
+    """fixed(2") + grow(1) + grow(1) in 10", gap 0 → grow 各 4.0."""
+    renders = [_recorder() for _ in range(3)]
+    items = [
+        FlexItem(sizing="fixed", size=2.0, render=renders[0][0]),
+        FlexItem(sizing="grow", grow=1.0, render=renders[1][0]),
+        FlexItem(sizing="grow", grow=1.0, render=renders[2][0]),
+    ]
+    allocs = add_flex_container(
+        slide=None,
+        items=items,
+        left=0.0, top=0.0, width=10.0, height=1.0,
+        direction="row", gap=0.0, padding=0.0,
+    )
+    assert _approx(allocs[0][2], 2.0)
+    assert _approx(allocs[1][2], 4.0)
+    assert _approx(allocs[2][2], 4.0)
+    # x 位置の連続性
+    assert _approx(allocs[1][0], 2.0)
+    assert _approx(allocs[2][0], 6.0)
+
+
+def test_fixed_grow_content_mixed():
+    """fixed(2") + grow(1) + content(3") in 10", gap 0 → grow が 5."""
+    renders = [_recorder() for _ in range(3)]
+    items = [
+        FlexItem(sizing="fixed", size=2.0, render=renders[0][0]),
+        FlexItem(sizing="grow", grow=1.0, render=renders[1][0]),
+        FlexItem(sizing="content", content_size=3.0, render=renders[2][0]),
+    ]
+    allocs = add_flex_container(
+        slide=None,
+        items=items,
+        left=0.0, top=0.0, width=10.0, height=1.0,
+        direction="row", gap=0.0, padding=0.0,
+    )
+    assert _approx(allocs[0][2], 2.0)
+    assert _approx(allocs[1][2], 5.0)
+    assert _approx(allocs[2][2], 3.0)
+
+
+def test_grow_ratio_one_to_three():
+    """fixed(2") + grow(1) + grow(3) → 残 8 を 1:3 で分割し 2.0 と 6.0."""
+    renders = [_recorder() for _ in range(3)]
+    items = [
+        FlexItem(sizing="fixed", size=2.0, render=renders[0][0]),
+        FlexItem(sizing="grow", grow=1.0, render=renders[1][0]),
+        FlexItem(sizing="grow", grow=3.0, render=renders[2][0]),
+    ]
+    allocs = add_flex_container(
+        slide=None,
+        items=items,
+        left=0.0, top=0.0, width=10.0, height=1.0,
+        direction="row", gap=0.0, padding=0.0,
+    )
+    assert _approx(allocs[1][2], 2.0)
+    assert _approx(allocs[2][2], 6.0)
+
+
+def test_grow_max_size_clamped_redistributes():
+    """2 つの grow 項目で 1 つが max_size=3 にクランプされると残余が他へ."""
+    # 残余 = 10 (fixed なし、gap=0)、2 つ grow(1:1) なら各 5.0 になるが、
+    # 1 つ目に max_size=3.0 を設定すると 3.0 にクランプされ、2 つ目が 7.0 を受ける。
+    renders = [_recorder() for _ in range(2)]
+    items = [
+        FlexItem(sizing="grow", grow=1.0, max_size=3.0, render=renders[0][0]),
+        FlexItem(sizing="grow", grow=1.0, render=renders[1][0]),
+    ]
+    allocs = add_flex_container(
+        slide=None,
+        items=items,
+        left=0.0, top=0.0, width=10.0, height=1.0,
+        direction="row", gap=0.0, padding=0.0,
+    )
+    assert _approx(allocs[0][2], 3.0)
+    assert _approx(allocs[1][2], 7.0)
+
+
+def test_column_direction_stack_vertically():
+    """direction='column' で 3 つの fixed 項目が縦に積み上がる."""
+    renders = [_recorder() for _ in range(3)]
+    items = [
+        FlexItem(sizing="fixed", size=1.0, render=renders[0][0]),
+        FlexItem(sizing="fixed", size=1.5, render=renders[1][0]),
+        FlexItem(sizing="fixed", size=2.0, render=renders[2][0]),
+    ]
+    allocs = add_flex_container(
+        slide=None,
+        items=items,
+        left=1.0, top=2.0, width=5.0, height=10.0,
+        direction="column", gap=0.2, padding=0.0,
+    )
+    # main 軸 = 縦、cross 軸 = 横
+    assert _approx(allocs[0][1], 2.0)
+    assert _approx(allocs[0][3], 1.0)
+    assert _approx(allocs[1][1], 2.0 + 1.0 + 0.2)
+    assert _approx(allocs[1][3], 1.5)
+    assert _approx(allocs[2][1], 2.0 + 1.0 + 0.2 + 1.5 + 0.2)
+    assert _approx(allocs[2][3], 2.0)
+    # cross 軸 (x, width) は全項目で同じ
+    for (x, y, w, h) in allocs:
+        assert _approx(x, 1.0)
+        assert _approx(w, 5.0)
+
+
+def test_align_center_cross_axis_size():
+    """align='center' の cross サイズは usable_cross と一致する (MVP 仕様)."""
+    renders = [_recorder() for _ in range(1)]
+    items = [
+        FlexItem(sizing="fixed", size=3.0, render=renders[0][0]),
+    ]
+    allocs = add_flex_container(
+        slide=None,
+        items=items,
+        left=0.0, top=0.0, width=10.0, height=2.0,
+        direction="row", gap=0.0, padding=0.0, align="center",
+    )
+    # cross サイズは usable_cross = height - 2*padding = 2.0
+    assert _approx(allocs[0][3], 2.0)
+    # cross 位置は padding から
+    assert _approx(allocs[0][1], 0.0)
+
+
+def test_padding_insets_all_items():
+    """padding=0.2 がコンテナ全周に適用され、各項目が内側に配置される."""
+    renders = [_recorder() for _ in range(2)]
+    items = [
+        FlexItem(sizing="fixed", size=1.0, render=renders[0][0]),
+        FlexItem(sizing="fixed", size=1.0, render=renders[1][0]),
+    ]
+    allocs = add_flex_container(
+        slide=None,
+        items=items,
+        left=1.0, top=2.0, width=5.0, height=3.0,
+        direction="row", gap=0.0, padding=0.2,
+    )
+    # 1 つ目の x は left + padding
+    assert _approx(allocs[0][0], 1.2)
+    # y は top + padding
+    assert _approx(allocs[0][1], 2.2)
+    # cross 高さ = height - 2*padding = 2.6
+    assert _approx(allocs[0][3], 2.6)
+    assert _approx(allocs[1][3], 2.6)
+    # 2 つ目の x は 1 つ目の右端から (gap=0)
+    assert _approx(allocs[1][0], 1.2 + 1.0)
+
+
+def test_grow_only_equal_share():
+    """全項目 grow=1 のみで等分される."""
+    renders = [_recorder() for _ in range(4)]
+    items = [
+        FlexItem(sizing="grow", grow=1.0, render=renders[i][0])
+        for i in range(4)
+    ]
+    allocs = add_flex_container(
+        slide=None,
+        items=items,
+        left=0.0, top=0.0, width=8.0, height=1.0,
+        direction="row", gap=0.0, padding=0.0,
+    )
+    for (x, y, w, h) in allocs:
+        assert _approx(w, 2.0)
+
+
+def test_empty_items_returns_empty_list():
+    """items=[] は空リストを返し、例外を投げない."""
+    allocs = add_flex_container(
+        slide=None,
+        items=[],
+        left=0.0, top=0.0, width=10.0, height=1.0,
+    )
+    assert allocs == []
+
+
+def test_grow_min_size_clamps_up():
+    """min_size でクランプされた項目の不足分は他 grow に割当てられない
+    (通常の flex 動作: min はサイズを増やす方向のクランプ)."""
+    # 残余 = 4.0、grow 項目 2 つ (1:1) なら各 2.0、しかし 1 つ目に min_size=3.5。
+    # クランプで 3.5 を確定、remain=0.5 が 2 つ目へ。
+    renders = [_recorder() for _ in range(2)]
+    items = [
+        FlexItem(sizing="grow", grow=1.0, min_size=3.5, render=renders[0][0]),
+        FlexItem(sizing="grow", grow=1.0, render=renders[1][0]),
+    ]
+    allocs = add_flex_container(
+        slide=None,
+        items=items,
+        left=0.0, top=0.0, width=4.0, height=1.0,
+        direction="row", gap=0.0, padding=0.0,
+    )
+    assert _approx(allocs[0][2], 3.5)
+    assert _approx(allocs[1][2], 0.5)
+
+
+def test_zero_grow_gets_no_share():
+    """grow=0 は分配を受けない (0 として扱う)."""
+    renders = [_recorder() for _ in range(2)]
+    items = [
+        FlexItem(sizing="grow", grow=0.0, render=renders[0][0]),
+        FlexItem(sizing="grow", grow=1.0, render=renders[1][0]),
+    ]
+    allocs = add_flex_container(
+        slide=None,
+        items=items,
+        left=0.0, top=0.0, width=10.0, height=1.0,
+        direction="row", gap=0.0, padding=0.0,
+    )
+    assert _approx(allocs[0][2], 0.0)
+    assert _approx(allocs[1][2], 10.0)
+
+
+def test_render_receives_correct_args():
+    """render コールバックが allocations と一致する引数で呼ばれる."""
+    render, calls = _recorder()
+    items = [
+        FlexItem(sizing="fixed", size=3.0, render=render),
+    ]
+    allocs = add_flex_container(
+        slide=None,
+        items=items,
+        left=0.5, top=0.75, width=5.0, height=1.0,
+        direction="row", gap=0.0, padding=0.0,
+    )
+    assert len(calls) == 1
+    assert calls[0] == allocs[0]


### PR DESCRIPTION
## Summary
- New engine primitive `add_flex_container` (+ `FlexItem` dataclass) in `src/pptx_mcp_server/engine/flex.py` implementing CSS-Flexbox-style layout for PPTX: fixed/grow/content sizing, row/column direction, gap, padding, CSS-style clamp redistribution for grow items hitting `min_size` / `max_size`.
- MCP tool `pptx_add_flex_container` accepts declarative item specs (`type: text | rectangle`) since Python render callbacks cannot cross the MCP boundary; returns allocation rectangles and created shape identifiers.
- 13 tests in `tests/test_flex.py` covering fixed-only, grow equal/ratio split, mixed fixed+grow+content, max-clamp redistribution, min-clamp, zero-grow, column direction, padding inset, center align (MVP cross size), empty list, and render-callback dispatch.

## Deviations
- Cross-axis alignment (`start`/`center`/`end`/`stretch`) currently returns `usable_cross` as the cross-size for all modes — matches the MVP note in the spec (no intrinsic cross measurement).
- `add_flex_container_file` file-level wrapper added to support the MCP tool; exported alongside `add_flex_container`.

## Test plan
- [x] `python -m pytest tests/test_flex.py -v` → 13 passed
- [x] `python -m pytest` → 330 passed (317 pre-existing + 13 new), no regressions

Closes #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)