### PR TITLE
feat(cards): responsive card row with content/max/fill modes

### DIFF
--- a/src/pptx_mcp_server/engine/__init__.py
+++ b/src/pptx_mcp_server/engine/__init__.py
@@ -96,6 +96,11 @@ from .composites import (
     _add_bullet_block,
     _build_slide,
 )
+from .cards import (
+    CardSpec,
+    CardHeightMode,
+    add_responsive_card_row,
+)
 
 __all__ = [
     # I/O
@@ -128,6 +133,8 @@ __all__ = [
     "build_slide", "build_deck",
     # Flex
     "FlexItem", "add_flex_container", "add_flex_container_file",
+    # Cards
+    "CardSpec", "CardHeightMode", "add_responsive_card_row",
     # Rendering
     "render_slide", "render_slide_to_path",
 ]

--- a/src/pptx_mcp_server/engine/cards.py
+++ b/src/pptx_mcp_server/engine/cards.py
@@ -1,0 +1,321 @@
+"""可変高カード行プリミティブ.
+
+横並びの N 枚カードをレイアウトするヘルパを提供する。各カードは content 量に
+応じて自動で高さを決定し、``height_mode`` により「個別 content 高」「全カード
+最大高に揃える」「行高いっぱいに埋める」を切り替える。カードの描画要素は
+背景矩形、任意の左アクセントバー、上から label → title → body の順のテキスト
+ブロックで構成される。
+
+# 設計メモ
+- 各カードの幅 ``width`` は ``(row_width - gap*(n-1)) / n`` で一意に決まる。
+  計算結果は呼び出し元で再利用できるよう ``CardSpec.width`` に書き戻す
+  (入力 dataclass を破壊的に変更する)。
+- 高さ推定は ``estimate_text_height`` を使う。label は単一行想定のため
+  ``label_size_pt * 0.0139`` をそのまま採用する。
+- 各最終高は ``[min_card_height, max_height]`` で clamp する。
+- 単一カード (n == 1) のとき ``gap`` は無視する。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from .shapes import _add_shape, add_auto_fit_textbox
+from .text_metrics import estimate_text_height
+
+CardHeightMode = Literal["content", "max", "fill"]
+
+
+# 1em inches 換算係数 (text_metrics の _CJK_WIDTH_PER_PT に相当)
+_EM_PER_PT: float = 0.0139
+
+# ブロック間の内部余白 (inches)
+_INTRA_GAP: float = 0.05
+
+# 左アクセントバーの幅 (inches)
+_ACCENT_BAR_W: float = 0.08
+
+
+@dataclass
+class CardSpec:
+    """1 枚のカードの内容・スタイル定義.
+
+    Attributes:
+        title: タイトル文字列。空文字列でブロックを省略する。
+        body: 本文文字列。空文字列でブロックを省略する。
+        label: title の上に小さく表示する任意のラベル文字列。単一行想定。
+        accent_color: 左アクセントバーの色 (6 桁 hex、``#`` なし)。空文字列で
+            アクセントバーを描画しない。
+        fill_color: カード背景色 (6 桁 hex)。
+        title_size_pt: タイトル font size (pt)。
+        body_size_pt: 本文 font size (pt)。
+        title_color: タイトル文字色 (6 桁 hex)。
+        body_color: 本文文字色 (6 桁 hex)。
+        label_size_pt: ラベル font size (pt)。
+        label_color: ラベル文字色 (6 桁 hex)。
+        padding: カード内側 padding (inches、上下左右共通)。
+        width: 行レイアウトが計算したカード幅 (inches)。呼び出し側で事前に
+            設定する必要はない。``add_responsive_card_row`` が書き込む。
+    """
+
+    title: str = ""
+    body: str = ""
+    label: str = ""
+    accent_color: str = ""
+    fill_color: str = "F5F7FA"
+    title_size_pt: float = 14
+    body_size_pt: float = 10
+    title_color: str = "051C2C"
+    body_color: str = "333333"
+    label_size_pt: float = 9
+    label_color: str = "666666"
+    padding: float = 0.2
+    width: float = 0.0
+
+
+def _estimate_block_heights(card: CardSpec) -> tuple[float, float, float, int]:
+    """カードの label / title / body それぞれの推定高 (inches) と非空ブロック数を返す.
+
+    label は単一行想定のため ``label_size_pt * 0.0139`` をそのまま使う。
+    title / body は ``estimate_text_height`` により wrap 後の総高を算出する。
+    """
+    inner_w = max(card.width - 2 * card.padding, 0.01)
+
+    label_h = card.label_size_pt * _EM_PER_PT if card.label else 0.0
+    title_h = (
+        estimate_text_height(card.title, inner_w, card.title_size_pt)
+        if card.title
+        else 0.0
+    )
+    body_h = (
+        estimate_text_height(card.body, inner_w, card.body_size_pt)
+        if card.body
+        else 0.0
+    )
+
+    n_blocks = sum(1 for h in (label_h, title_h, body_h) if h > 0)
+    return label_h, title_h, body_h, n_blocks
+
+
+def _content_height(card: CardSpec) -> float:
+    """カードの content 高 (padding 込み、intra_gap 含む) を返す."""
+    label_h, title_h, body_h, n_blocks = _estimate_block_heights(card)
+    if n_blocks == 0:
+        return card.padding * 2
+    return (
+        card.padding * 2
+        + label_h
+        + title_h
+        + body_h
+        + _INTRA_GAP * max(n_blocks - 1, 0)
+    )
+
+
+def _render_card(
+    slide,
+    card: CardSpec,
+    left: float,
+    top: float,
+    w: float,
+    h: float,
+    *,
+    mode: CardHeightMode,
+) -> None:
+    """1 枚のカードを実際に描画する内部ヘルパ.
+
+    描画順:
+        1. 背景矩形 (``fill_color``)
+        2. 任意の左アクセントバー (``accent_color`` が非空のとき)
+        3. label → title → body のテキスト 3 ブロック
+
+    ``mode="fill"`` かつ content が h より短い場合、label は先頭固定のまま
+    title + body のグループを垂直方向に中央揃えで配置する。
+    """
+    # 1) 背景矩形
+    _add_shape(
+        slide,
+        shape_type="rectangle",
+        left=left,
+        top=top,
+        width=w,
+        height=h,
+        fill_color=card.fill_color,
+        no_line=True,
+    )
+
+    # 2) 任意の左アクセントバー
+    if card.accent_color:
+        _add_shape(
+            slide,
+            shape_type="rectangle",
+            left=left,
+            top=top,
+            width=_ACCENT_BAR_W,
+            height=h,
+            fill_color=card.accent_color,
+            no_line=True,
+        )
+
+    # 3) テキストブロック
+    inner_left = left + card.padding
+    inner_w = max(w - 2 * card.padding, 0.01)
+
+    label_h, title_h, body_h, n_blocks = _estimate_block_heights(card)
+
+    # label は常に上端に固定で配置する。
+    cursor = top + card.padding
+    if card.label:
+        add_auto_fit_textbox(
+            slide,
+            card.label,
+            left=inner_left,
+            top=cursor,
+            width=inner_w,
+            height=max(label_h, 0.1),
+            font_size_pt=card.label_size_pt,
+            min_size_pt=max(card.label_size_pt - 2, 6),
+            color_hex=card.label_color,
+            align="left",
+            vertical_anchor="top",
+            truncate_with_ellipsis=True,
+        )
+        cursor += label_h + _INTRA_GAP
+
+    # title + body の配置。fill モードで余白が出る場合のみ中央寄せにする。
+    tb_blocks = [blk for blk in ((card.title, title_h), (card.body, body_h)) if blk[1] > 0]
+    if not tb_blocks:
+        return
+
+    # title + body を合わせた所要高 (intra_gap 込み)
+    tb_total = sum(h for _, h in tb_blocks) + _INTRA_GAP * max(len(tb_blocks) - 1, 0)
+
+    # fill モードで全 content < h の場合のみ中央寄せ。それ以外は cursor をそのまま使う。
+    label_base = top + card.padding + (label_h + _INTRA_GAP if card.label else 0.0)
+    available_from_label = (top + h - card.padding) - label_base
+    if mode == "fill" and tb_total < available_from_label:
+        # title/body グループを label 直下〜底辺までの領域で中央に寄せる
+        cursor = label_base + (available_from_label - tb_total) / 2
+
+    # 底辺を超えないよう残り領域も考慮して各ブロックの height を割り当てる。
+    # body は残余を埋める方針だが、content / max モードでは推定値どおりに積む。
+    if card.title:
+        # title は推定分だけ割り当てる
+        t_h = title_h
+        add_auto_fit_textbox(
+            slide,
+            card.title,
+            left=inner_left,
+            top=cursor,
+            width=inner_w,
+            height=max(t_h, 0.1),
+            font_size_pt=card.title_size_pt,
+            min_size_pt=max(card.title_size_pt - 4, 7),
+            bold=True,
+            color_hex=card.title_color,
+            align="left",
+            vertical_anchor="top",
+            truncate_with_ellipsis=True,
+        )
+        cursor += t_h + (_INTRA_GAP if card.body else 0.0)
+
+    if card.body:
+        # body は残りの垂直領域いっぱい使う。ただし content/max モードで短い
+        # content の場合は推定 body_h をそのまま使えば十分。fill モードの
+        # 中央寄せ時は上で cursor を調整済みのため、body_h を使う。
+        if mode == "fill":
+            b_h = body_h
+        else:
+            # body は残余 (padding 下辺まで) を埋める
+            b_h = max((top + h - card.padding) - cursor, body_h)
+        add_auto_fit_textbox(
+            slide,
+            card.body,
+            left=inner_left,
+            top=cursor,
+            width=inner_w,
+            height=max(b_h, 0.1),
+            font_size_pt=card.body_size_pt,
+            min_size_pt=max(card.body_size_pt - 3, 6),
+            color_hex=card.body_color,
+            align="left",
+            vertical_anchor="top",
+            truncate_with_ellipsis=True,
+        )
+
+
+def add_responsive_card_row(
+    slide,
+    cards: list[CardSpec],
+    *,
+    left: float,
+    top: float,
+    width: float,
+    max_height: float,
+    gap: float = 0.2,
+    height_mode: CardHeightMode = "max",
+    min_card_height: float = 1.0,
+) -> float:
+    """N 枚のカードを横並びで配置する.
+
+    各カードの幅は ``(width - gap * (n - 1)) / n`` で均等分割する
+    (n == 1 のとき ``gap`` は無視される)。計算した幅は入力 ``cards`` の
+    各 ``CardSpec.width`` に書き戻される (dataclass を破壊的に変更する点に注意)。
+
+    Args:
+        slide: 対象スライドオブジェクト。
+        cards: ``CardSpec`` のリスト。空リストなら何も描画せず 0 を返す。
+        left, top: 行の左上座標 (inches)。
+        width: 行全体の幅 (inches)。
+        max_height: 各カードが取り得る最大高 (inches)。``height_mode`` により
+            上限として、または実際の採用高として機能する。
+        gap: カード間の水平ギャップ (inches)。
+        height_mode:
+            - ``"content"``: 各カードが自身の content 高をそのまま使う (高さは
+              カードごとに異なり得る)。``max_height`` は上限として機能する。
+            - ``"max"``: 各カードの content 高を測定し、その最大値を全カードに
+              適用する (底辺が揃う)。
+            - ``"fill"``: ``max_height`` いっぱいを使う。content が短いカードは
+              title/body グループを中央寄せする (label はトップ固定)。
+        min_card_height: 全カードの下限高 (inches)。
+
+    Returns:
+        行が実際に消費した縦サイズ (inches)。height_mode が ``"content"`` の
+        場合は個別カード高の最大値、それ以外は共通カード高と一致する。
+    """
+    n = len(cards)
+    if n == 0:
+        return 0.0
+
+    # 各カードの幅を計算して CardSpec.width に書き戻す
+    effective_gap = gap if n > 1 else 0.0
+    card_w = (width - effective_gap * (n - 1)) / n
+    for card in cards:
+        card.width = card_w
+
+    # 各カードの content 高を事前測定する
+    content_heights = [_content_height(card) for card in cards]
+
+    # height_mode に応じて各カードの最終高を決定する
+    final_heights: list[float] = []
+    if height_mode == "content":
+        for ch in content_heights:
+            h = max(min(ch, max_height), min_card_height)
+            final_heights.append(h)
+    elif height_mode == "max":
+        max_ch = max(content_heights)
+        common_h = max(min(max_ch, max_height), min_card_height)
+        final_heights = [common_h] * n
+    elif height_mode == "fill":
+        common_h = max(max_height, min_card_height)
+        final_heights = [common_h] * n
+    else:  # 型的にはここには来ないが、防御的分岐
+        final_heights = [min(max(ch, min_card_height), max_height) for ch in content_heights]
+
+    # 各カードを描画
+    x = left
+    for card, h in zip(cards, final_heights):
+        _render_card(slide, card, x, top, card.width, h, mode=height_mode)
+        x += card.width + effective_gap
+
+    return max(final_heights)

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -46,7 +46,10 @@ from .engine import (
     add_callout,
     check_deck_overlaps,
     check_deck_extended,
+    CardSpec,
+    add_responsive_card_row,
 )
+from .engine.pptx_io import open_pptx, save_pptx, _get_slide
 
 INSTRUCTIONS = """
 # pptx-editor — Professional Presentation Builder
@@ -731,6 +734,82 @@ def pptx_add_bullet_block(
         result = add_bullet_block(file_path, slide_index, items_json, left, top, width, height)
         result += _auto_render(file_path, slide_index)
         return result
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def pptx_add_responsive_card_row(
+    file_path: str,
+    slide_index: int,
+    cards_json: str,
+    left: float,
+    top: float,
+    width: float,
+    max_height: float,
+    gap: float = 0.2,
+    height_mode: str = "max",
+    min_card_height: float = 1.0,
+) -> str:
+    """Add a row of variable-height cards that auto-size to content and align to the max content height.
+
+    cards_json: JSON array of card dicts. Each card supports keys: title, body, label,
+    accent_color (hex, "" disables bar), fill_color, title_size_pt, body_size_pt,
+    title_color, body_color, label_size_pt, label_color, padding.
+
+    height_mode:
+      - "content": each card uses its own content height (heights may differ).
+      - "max":     all cards take the max individual content height (bottoms align).
+      - "fill":    all cards fill max_height (short content is centered vertically).
+
+    Returns a JSON object: {"cards": [{"left","top","width","height"}, ...], "consumed_height": float}.
+    Auto-renders a preview PNG.
+    """
+    try:
+        card_dicts = json.loads(cards_json) if isinstance(cards_json, str) else cards_json
+        cards = [CardSpec(**d) for d in card_dicts]
+        prs = open_pptx(file_path)
+        slide = _get_slide(prs, slide_index)
+
+        consumed = add_responsive_card_row(
+            slide,
+            cards,
+            left=left, top=top, width=width, max_height=max_height,
+            gap=gap,
+            height_mode=height_mode,  # type: ignore[arg-type]
+            min_card_height=min_card_height,
+        )
+        save_pptx(prs, file_path)
+
+        # 各カードの (left, top, width, height) を計算する。行の左端 + 累積幅+ gap。
+        n = len(cards)
+        effective_gap = gap if n > 1 else 0.0
+        placements: list[dict] = []
+        x = left
+        # 実際の各カードの高さを cards と height_mode から再現する
+        from .engine.cards import _content_height  # 内部ヘルパを利用
+
+        if height_mode == "content":
+            heights = [max(min(_content_height(c), max_height), min_card_height) for c in cards]
+        else:
+            heights = [consumed] * n
+
+        for card, h in zip(cards, heights):
+            placements.append({
+                "left": x,
+                "top": top,
+                "width": card.width,
+                "height": h,
+            })
+            x += card.width + effective_gap
+
+        result = {
+            "cards": placements,
+            "consumed_height": consumed,
+        }
+        out = json.dumps(result)
+        out += _auto_render(file_path, slide_index)
+        return out
     except Exception as e:
         return _err(e)
 

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -1,0 +1,230 @@
+"""可変高カード行プリミティブのテスト.
+
+``add_responsive_card_row`` の 3 つの ``height_mode`` (content / max / fill)
+と、単一カード・最小高 clamp・アクセントバー描画・消費高返却の各挙動を
+網羅する。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pptx_mcp_server.engine.cards import (
+    CardSpec,
+    add_responsive_card_row,
+    _content_height,
+)
+
+
+# EMU (914400 per inch) → inches 換算ユーティリティ
+def _in(emu: int) -> float:
+    return emu / 914400
+
+
+def _shape_bbox(shape) -> tuple[float, float, float, float]:
+    """shape の (left, top, width, height) を inches で返す."""
+    return _in(shape.left), _in(shape.top), _in(shape.width), _in(shape.height)
+
+
+# 各カードの先頭 shape (背景矩形) の bbox がそのカード全体の bbox になる。
+# アクセントバーや textbox もそこから派生するため、背景矩形を頼りに検証する。
+def _card_background_heights(slide, n_cards: int, has_accent: bool) -> list[float]:
+    """各カードの背景矩形の高さを順に取り出す.
+
+    ``add_responsive_card_row`` は各カードにつき最初に背景矩形 (AUTO_SHAPE) を
+    追加する。その後、任意で accent bar (AUTO_SHAPE)、label/title/body
+    (TEXT_BOX) を追加する。本テストでは shape 追加順・種別に基づき「各カード
+    ごとに最初に現れる AUTO_SHAPE で、かつ label/title/body の TextBox より幅が
+    広いもの」を拾う。簡易に、先頭から走査して AUTO_SHAPE が現れた時点の高さを
+    採用し、同一 left の次の AUTO_SHAPE (accent bar) は無視する。
+    """
+    from pptx.enum.shapes import MSO_SHAPE_TYPE
+
+    heights: list[float] = []
+    seen_lefts: set[float] = set()
+    for s in slide.shapes:
+        if s.shape_type != MSO_SHAPE_TYPE.AUTO_SHAPE:
+            continue
+        key = round(_in(s.left), 3)
+        if key in seen_lefts:
+            # 同じ left で 2 つ目の AUTO_SHAPE は accent bar のためスキップ
+            continue
+        seen_lefts.add(key)
+        heights.append(_in(s.height))
+        if len(heights) == n_cards:
+            break
+    return heights
+
+
+def test_max_mode_identical_content(slide):
+    """3 カードで同一の title/body を持ち height_mode='max' ならすべて同じ高さになる."""
+    cards = [
+        CardSpec(title="Strategy", body="Short body text."),
+        CardSpec(title="Strategy", body="Short body text."),
+        CardSpec(title="Strategy", body="Short body text."),
+    ]
+    consumed = add_responsive_card_row(
+        slide, cards,
+        left=0.5, top=1.0, width=12.0, max_height=4.0,
+        gap=0.2, height_mode="max", min_card_height=0.5,
+    )
+
+    heights = _card_background_heights(slide, n_cards=3, has_accent=False)
+    assert len(heights) == 3
+    assert heights[0] == pytest.approx(heights[1], abs=1e-4)
+    assert heights[1] == pytest.approx(heights[2], abs=1e-4)
+    # 消費高 == 各カード高
+    assert consumed == pytest.approx(heights[0], abs=1e-4)
+
+
+def test_max_mode_different_content_lengths_align(slide):
+    """3 カード + content 長さ差 + height_mode='max' で全カード同一高 (= 最大 content 高)."""
+    short = CardSpec(title="T", body="Short.")
+    medium = CardSpec(title="T", body="Medium body text that wraps.")
+    long_body = "This is a very long body text that will wrap to many lines. " * 6
+    long_card = CardSpec(title="T", body=long_body)
+
+    cards = [short, medium, long_card]
+    consumed = add_responsive_card_row(
+        slide, cards,
+        left=0.5, top=1.0, width=12.0, max_height=6.0,
+        gap=0.2, height_mode="max",
+    )
+
+    heights = _card_background_heights(slide, n_cards=3, has_accent=False)
+    # 全カード同一
+    assert heights[0] == pytest.approx(heights[1], abs=1e-4)
+    assert heights[1] == pytest.approx(heights[2], abs=1e-4)
+    # 高さ == 最大 content 高
+    max_content = max(_content_height(c) for c in cards)
+    assert heights[0] == pytest.approx(max_content, abs=1e-3)
+    assert consumed == pytest.approx(heights[0], abs=1e-4)
+
+
+def test_content_mode_heights_differ(slide):
+    """height_mode='content' では短い/長いカードで高さが異なる."""
+    short = CardSpec(title="T", body="Short.")
+    long_body = "Long body text that wraps across multiple lines. " * 8
+    long_card = CardSpec(title="T", body=long_body)
+    medium = CardSpec(title="T", body="Medium sample body.")
+
+    cards = [short, medium, long_card]
+    add_responsive_card_row(
+        slide, cards,
+        left=0.5, top=1.0, width=12.0, max_height=6.0,
+        gap=0.2, height_mode="content", min_card_height=0.2,
+    )
+
+    heights = _card_background_heights(slide, n_cards=3, has_accent=False)
+    # 短いカードと長いカードの高さは明確に異なる
+    assert heights[0] != pytest.approx(heights[2], abs=0.1)
+    assert heights[2] > heights[0]
+
+
+def test_fill_mode_uses_max_height(slide):
+    """height_mode='fill' で max_height=5" ならすべてのカード高が 5" になる."""
+    cards = [
+        CardSpec(title="A", body="Short body."),
+        CardSpec(title="B", body="Short body."),
+        CardSpec(title="C", body="Short body."),
+    ]
+    consumed = add_responsive_card_row(
+        slide, cards,
+        left=0.5, top=0.5, width=12.0, max_height=5.0,
+        gap=0.2, height_mode="fill",
+    )
+
+    heights = _card_background_heights(slide, n_cards=3, has_accent=False)
+    for h in heights:
+        assert h == pytest.approx(5.0, abs=1e-4)
+    assert consumed == pytest.approx(5.0, abs=1e-4)
+
+
+def test_min_card_height_clamp(slide):
+    """min_card_height=2 なら content が ~1" でも全カード 2" に clamp される."""
+    # padding+title+body だけの軽いカード (~1" 程度)
+    cards = [
+        CardSpec(title="X", body="One line."),
+        CardSpec(title="Y", body="One line."),
+    ]
+    add_responsive_card_row(
+        slide, cards,
+        left=0.5, top=0.5, width=10.0, max_height=6.0,
+        gap=0.2, height_mode="max", min_card_height=2.0,
+    )
+
+    heights = _card_background_heights(slide, n_cards=2, has_accent=False)
+    for h in heights:
+        assert h == pytest.approx(2.0, abs=1e-4)
+
+
+def test_single_card_fills_row_width(slide):
+    """単一カード (n == 1): gap を無視し行幅すべてをそのカードが占める."""
+    cards = [CardSpec(title="Only", body="Alone in the row.")]
+    add_responsive_card_row(
+        slide, cards,
+        left=1.0, top=1.0, width=8.0, max_height=4.0,
+        gap=0.5, height_mode="max",
+    )
+
+    # 単一カードの width 書き戻し
+    assert cards[0].width == pytest.approx(8.0, abs=1e-4)
+
+    # 先頭 shape = 背景矩形。width が 8.0 に一致
+    first_shape = list(slide.shapes)[0]
+    _, _, w, _ = _shape_bbox(first_shape)
+    assert w == pytest.approx(8.0, abs=1e-3)
+
+
+def test_accent_bar_drawn_with_expected_bbox(slide):
+    """accent_color 非空のとき、card left と同じ位置に width ≈ 0.08" のバーが生成される."""
+    cards = [CardSpec(title="T", body="Body", accent_color="FF0000")]
+    add_responsive_card_row(
+        slide, cards,
+        left=2.0, top=1.0, width=4.0, max_height=3.0,
+        gap=0.2, height_mode="max",
+    )
+
+    shapes = list(slide.shapes)
+    # 背景矩形 → アクセントバー → 任意のテキストの順
+    bg = shapes[0]
+    accent = shapes[1]
+    bg_l, bg_t, bg_w, bg_h = _shape_bbox(bg)
+    ac_l, ac_t, ac_w, ac_h = _shape_bbox(accent)
+
+    assert bg_l == pytest.approx(2.0, abs=1e-3)
+    assert bg_w == pytest.approx(4.0, abs=1e-3)
+
+    # アクセントバー: 左端一致、幅 0.08"、高さは card と一致
+    assert ac_l == pytest.approx(bg_l, abs=1e-3)
+    assert ac_t == pytest.approx(bg_t, abs=1e-3)
+    assert ac_w == pytest.approx(0.08, abs=1e-3)
+    assert ac_h == pytest.approx(bg_h, abs=1e-3)
+
+
+def test_consumed_height_matches_max_for_max_and_fill(slide, one_slide_prs):
+    """consumed_height == max/fill モードの共通カード高."""
+    # max モード
+    cards_max = [CardSpec(title="T", body="Body A"), CardSpec(title="T", body="Body B")]
+    consumed_max = add_responsive_card_row(
+        slide, cards_max,
+        left=0.5, top=0.5, width=10.0, max_height=6.0,
+        gap=0.2, height_mode="max",
+    )
+    heights_max = _card_background_heights(slide, n_cards=2, has_accent=False)
+    assert consumed_max == pytest.approx(max(heights_max), abs=1e-4)
+
+    # fill モード (別スライド用意)
+    layout = one_slide_prs.slide_layouts[6]
+    one_slide_prs.slides.add_slide(layout)
+    slide2 = one_slide_prs.slides[1]
+    cards_fill = [CardSpec(title="T", body="A"), CardSpec(title="T", body="B")]
+    consumed_fill = add_responsive_card_row(
+        slide2, cards_fill,
+        left=0.5, top=0.5, width=10.0, max_height=4.5,
+        gap=0.2, height_mode="fill",
+    )
+    heights_fill = _card_background_heights(slide2, n_cards=2, has_accent=False)
+    assert consumed_fill == pytest.approx(4.5, abs=1e-4)
+    for h in heights_fill:
+        assert h == pytest.approx(4.5, abs=1e-4)


### PR DESCRIPTION
## Summary
- Add new `cards.py` engine module with `CardSpec` dataclass and `add_responsive_card_row` that lays out N cards horizontally with auto-sized heights
- Three height modes: `content` (individual), `max` (all equal to max content height), `fill` (all equal to max_height with short content centered)
- Each card renders background rect, optional left accent bar, and label/title/body via `add_auto_fit_textbox`
- Register `pptx_add_responsive_card_row` MCP tool returning per-card placements + `consumed_height`

Closes #4.

## Test plan
- [x] `python -m pytest tests/test_cards.py -v` — 8 new cases, all pass
- [x] `python -m pytest` — 325 tests pass (no regressions)
- [ ] Manual smoke test via MCP tool against a real deck (visual verification pending reviewer preference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)