### PR TITLE
fix(flex): raise on over-budget container (closes #25)

### DIFF
--- a/src/pptx_mcp_server/engine/flex.py
+++ b/src/pptx_mcp_server/engine/flex.py
@@ -181,7 +181,35 @@ def add_flex_container(
     content_total = sum(
         max(it.content_size, 0.0) for it in items if it.sizing == "content"
     )
-    remain = max(0.0, usable_main - fixed_total - content_total)
+
+    # 非 grow 項目の合計が usable_main を超える over-budget を検出する。
+    # 従来は ``remain`` を 0 でフロアしていたため、3 つの ``fixed(5)`` を
+    # 10" コンテナに入れても例外が発生せず、3 つ目がコンテナ外 (スライド
+    # 外になり得る位置) にサイレントに配置されていた (#25)。
+    # サイジング指定の誤りは呼び出し元のロジックバグであるため、0 フロア
+    # を外し、明示的に ``INVALID_PARAMETER`` で失敗させる。
+    declared_total = fixed_total + content_total
+    # 浮動小数の丸め誤差を許容する微小な閾値
+    _OVER_BUDGET_EPS = 1e-9
+    if declared_total > usable_main + _OVER_BUDGET_EPS:
+        gap_total = gap * max(n - 1, 0)
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            (
+                "Flex container over-budget: "
+                f"fixed_total={fixed_total:.2f} + "
+                f"content_total={content_total:.2f} = "
+                f"{declared_total:.2f} exceeds "
+                f"usable_main={usable_main:.2f} "
+                f"(= {'width' if direction == 'row' else 'height'}="
+                f"{(width if direction == 'row' else height):.2f} "
+                f"- 2*padding={2 * padding:.2f} "
+                f"- gap*(n-1)={gap_total:.2f}). "
+                "Reduce sizes or increase container width."
+            ),
+        )
+
+    remain = max(0.0, usable_main - declared_total)
 
     grow_indices = [i for i, it in enumerate(items) if it.sizing == "grow"]
     grow_sizes = _distribute_grow(items, grow_indices, remain)

--- a/tests/test_flex.py
+++ b/tests/test_flex.py
@@ -11,6 +11,7 @@ import math
 import pytest
 
 from pptx_mcp_server.engine.flex import FlexItem, add_flex_container
+from pptx_mcp_server.engine.pptx_io import EngineError, ErrorCode
 
 
 EPS = 1e-6
@@ -268,6 +269,129 @@ def test_zero_grow_gets_no_share():
     )
     assert _approx(allocs[0][2], 0.0)
     assert _approx(allocs[1][2], 10.0)
+
+
+def test_over_budget_three_fixed_raises():
+    """3 × fixed(5) in 10" コンテナ (padding=0, gap=0) は INVALID_PARAMETER で失敗する (#25)."""
+    renders = [_recorder() for _ in range(3)]
+    items = [
+        FlexItem(sizing="fixed", size=5.0, render=renders[0][0]),
+        FlexItem(sizing="fixed", size=5.0, render=renders[1][0]),
+        FlexItem(sizing="fixed", size=5.0, render=renders[2][0]),
+    ]
+    with pytest.raises(EngineError) as excinfo:
+        add_flex_container(
+            slide=None,
+            items=items,
+            left=0.0, top=0.0, width=10.0, height=1.0,
+            direction="row", gap=0.0, padding=0.0,
+        )
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMETER
+    # エラーメッセージには過剰な合計値と usable_main が含まれる (デバッグ用)
+    msg = str(excinfo.value)
+    assert "15.00" in msg
+    assert "10.00" in msg
+    # render は一度も呼ばれていない
+    for _, calls in renders:
+        assert calls == []
+
+
+def test_fixed_plus_grow_with_gap_just_fits():
+    """fixed(4) + fixed(4) + grow(1) in 10" (gap=0.5): fixed 8 + gap 1 = 9 ≤ 10, grow は 1."""
+    renders = [_recorder() for _ in range(3)]
+    items = [
+        FlexItem(sizing="fixed", size=4.0, render=renders[0][0]),
+        FlexItem(sizing="fixed", size=4.0, render=renders[1][0]),
+        FlexItem(sizing="grow", grow=1.0, render=renders[2][0]),
+    ]
+    allocs = add_flex_container(
+        slide=None,
+        items=items,
+        left=0.0, top=0.0, width=10.0, height=1.0,
+        direction="row", gap=0.5, padding=0.0,
+    )
+    assert _approx(allocs[0][2], 4.0)
+    assert _approx(allocs[1][2], 4.0)
+    assert _approx(allocs[2][2], 1.0)
+
+
+def test_fixed_plus_content_exactly_fits():
+    """fixed(4) + content(5) in 10" (gap=0): 9 ≤ 10、余り 1 は grow がないので未使用."""
+    renders = [_recorder() for _ in range(2)]
+    items = [
+        FlexItem(sizing="fixed", size=4.0, render=renders[0][0]),
+        FlexItem(sizing="content", content_size=5.0, render=renders[1][0]),
+    ]
+    allocs = add_flex_container(
+        slide=None,
+        items=items,
+        left=0.0, top=0.0, width=10.0, height=1.0,
+        direction="row", gap=0.0, padding=0.0,
+    )
+    assert _approx(allocs[0][2], 4.0)
+    assert _approx(allocs[1][2], 5.0)
+
+
+def test_fixed_content_fixed_over_budget_raises():
+    """fixed(4) + content(5) + fixed(2) in 10" (gap=0): 11 > 10 で raises."""
+    renders = [_recorder() for _ in range(3)]
+    items = [
+        FlexItem(sizing="fixed", size=4.0, render=renders[0][0]),
+        FlexItem(sizing="content", content_size=5.0, render=renders[1][0]),
+        FlexItem(sizing="fixed", size=2.0, render=renders[2][0]),
+    ]
+    with pytest.raises(EngineError) as excinfo:
+        add_flex_container(
+            slide=None,
+            items=items,
+            left=0.0, top=0.0, width=10.0, height=1.0,
+            direction="row", gap=0.0, padding=0.0,
+        )
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMETER
+    msg = str(excinfo.value)
+    assert "11.00" in msg
+    assert "10.00" in msg
+
+
+def test_padding_tight_fit_ok_then_over_budget():
+    """padding=0.5 エッジケース: usable = 10 - 1 = 9.
+
+    - fixed(4)+fixed(4) なら fixed_total=8 ≤ 9 で OK
+    - fixed(4)+fixed(4)+fixed(1.5) なら 9.5 > 9 で raises
+    """
+    # 境界内ケース
+    renders_ok = [_recorder() for _ in range(2)]
+    items_ok = [
+        FlexItem(sizing="fixed", size=4.0, render=renders_ok[0][0]),
+        FlexItem(sizing="fixed", size=4.0, render=renders_ok[1][0]),
+    ]
+    allocs = add_flex_container(
+        slide=None,
+        items=items_ok,
+        left=0.0, top=0.0, width=10.0, height=1.0,
+        direction="row", gap=0.0, padding=0.5,
+    )
+    assert _approx(allocs[0][2], 4.0)
+    assert _approx(allocs[1][2], 4.0)
+
+    # 境界外ケース
+    renders_bad = [_recorder() for _ in range(3)]
+    items_bad = [
+        FlexItem(sizing="fixed", size=4.0, render=renders_bad[0][0]),
+        FlexItem(sizing="fixed", size=4.0, render=renders_bad[1][0]),
+        FlexItem(sizing="fixed", size=1.5, render=renders_bad[2][0]),
+    ]
+    with pytest.raises(EngineError) as excinfo:
+        add_flex_container(
+            slide=None,
+            items=items_bad,
+            left=0.0, top=0.0, width=10.0, height=1.0,
+            direction="row", gap=0.0, padding=0.5,
+        )
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMETER
+    msg = str(excinfo.value)
+    assert "9.50" in msg
+    assert "9.00" in msg
 
 
 def test_render_receives_correct_args():


### PR DESCRIPTION
## Summary

Fix #25: `add_flex_container` previously floored the post-distribution remainder at 0 when `fixed_total + content_total > usable_main`, so the offending non-grow items were silently placed outside the container (and typically off-slide) with no error. This PR adds an explicit over-budget check that raises `EngineError(INVALID_PARAMETER)` with a diagnostic message reporting `fixed_total`, `content_total`, their sum, and `usable_main` with its decomposition (`width/height - 2*padding - gap*(n-1)`), so an LLM agent debugging its own layout spec can see exactly which budget was exceeded and by how much.

The check sits after `usable_main` and the declared totals are computed and before grow distribution, so all in-budget layouts behave identically. Server-side plumbing is unchanged: `pptx_add_flex_container` already routes `EngineError` through `_err`, which surfaces as `[INVALID_PARAMETER] <message>`.

Optional `strict=False` permissive-warn kwarg was NOT added — would have required threading a kwarg through both `add_flex_container` and `add_flex_container_file` plus the MCP tool, exceeding the 15 LOC budget for something the issue flags as nice-to-have.

## Test plan

- [x] New: `3 × fixed(5)` in 10" → raises `INVALID_PARAMETER`, render never called
- [x] New: `fixed(4) + fixed(4) + grow(1)` in 10" with `gap=0.5` → fits (regression for exact-fit boundary)
- [x] New: `fixed(4) + content(5)` in 10" → fits
- [x] New: `fixed(4) + content(5) + fixed(2)` in 10" → raises
- [x] New: `padding=0.5` edge case — `fixed(4)+fixed(4)` fits, adding `fixed(1.5)` raises (boundary on both sides)
- [x] Error message contains the over-budget sum and the `usable_main` value
- [x] `python -m pytest tests/test_flex.py -v` → 18/18 green (13 existing + 5 new)
- [x] `python -m pytest` → 343/343 green, no regressions

Closes #25