### PR TITLE
fix(validation): axis drift + summary undercount + paragraph-level font sizing

### DIFF
--- a/src/pptx_mcp_server/engine/validation.py
+++ b/src/pptx_mcp_server/engine/validation.py
@@ -238,17 +238,83 @@ def _iter_runs(text_frame) -> List[Any]:
     return runs
 
 
-def _dominant_font_size(text_frame, default_pt: float = 18.0) -> float:
-    """text_frame 内で最大の font.size (pt) を返す.
+# OOXML DrawingML 名前空間。pPr / defRPr の lxml 検索で使う。
+_A_NS = "http://schemas.openxmlformats.org/drawingml/2006/main"
 
-    いずれの run にも明示サイズが無ければ ``default_pt`` を返す。
+
+def _pptx_defrpr_size(paragraph) -> Optional[float]:
+    """``<a:pPr><a:defRPr sz="2400"/></a:pPr>`` から pt 値を解決する.
+
+    OOXML では ``sz`` は 1/100 pt 単位。未設定の場合は ``None`` を返す。
     """
-    max_pt: Optional[float] = None
-    for run in _iter_runs(text_frame):
+    try:
+        p_pr = paragraph._pPr  # type: ignore[attr-defined]
+    except Exception:
+        p_pr = None
+    if p_pr is None:
+        return None
+    defrpr = p_pr.find(f"{{{_A_NS}}}defRPr")
+    if defrpr is None:
+        return None
+    sz = defrpr.get("sz")
+    if sz is None:
+        return None
+    try:
+        return int(sz) / 100.0
+    except (TypeError, ValueError):
+        return None
+
+
+def _effective_paragraph_size(paragraph, default_pt: float = 18.0) -> float:
+    """paragraph の実効フォントサイズ (pt) を解決する.
+
+    優先順:
+        1. paragraph 内 run の最大 ``font.size`` (run に明示されたもの)
+        2. ``paragraph.font.size`` (paragraph の ``rPr`` 由来)
+        3. ``pPr/defRPr/@sz`` (段落既定値)
+        4. ``default_pt`` (フォールバック)
+
+    ``add_auto_fit_textbox`` のように ``defRPr`` にのみサイズを書き込む
+    経路でも正しく pt を抽出できるよう (3) を明示的にサポートする。
+    """
+    # (1) run レベル
+    max_run_pt: Optional[float] = None
+    for run in paragraph.runs:
         size = run.font.size
         if size is None:
             continue
         pt = size.pt
+        if max_run_pt is None or pt > max_run_pt:
+            max_run_pt = pt
+    if max_run_pt is not None:
+        return max_run_pt
+
+    # (2) paragraph.font.size
+    try:
+        pf_size = paragraph.font.size
+    except Exception:
+        pf_size = None
+    if pf_size is not None:
+        return pf_size.pt
+
+    # (3) pPr/defRPr/@sz
+    defrpr_pt = _pptx_defrpr_size(paragraph)
+    if defrpr_pt is not None:
+        return defrpr_pt
+
+    # (4) デフォルト
+    return default_pt
+
+
+def _dominant_font_size(text_frame, default_pt: float = 18.0) -> float:
+    """text_frame 内の段落で最大の実効フォントサイズ (pt) を返す.
+
+    段落単位の解決には ``_effective_paragraph_size`` を利用する。メッセージ
+    文字列の表示用 (代表サイズ) に残してあるユーティリティである。
+    """
+    max_pt: Optional[float] = None
+    for para in text_frame.paragraphs:
+        pt = _effective_paragraph_size(para, default_pt=default_pt)
         if max_pt is None or pt > max_pt:
             max_pt = pt
     if max_pt is None:
@@ -264,6 +330,39 @@ def _full_text(text_frame) -> str:
     return "\n".join(lines)
 
 
+def _paragraph_text(paragraph) -> str:
+    """paragraph 内の全 run テキストを連結して返す."""
+    return "".join(run.text for run in paragraph.runs)
+
+
+def _estimate_frame_needed_height(
+    text_frame,
+    usable_width: float,
+    default_pt: float = 18.0,
+) -> Tuple[float, float]:
+    """段落単位で推定高さを合算した ``(total_in, max_pt)`` を返す.
+
+    段落ごとに ``_effective_paragraph_size`` で実効 pt を解決し、その pt
+    で ``estimate_text_height`` を呼び合算する。空段落も 1 行分の高さ
+    (pt × 0.0139 × 1.2) を確保する。代表サイズとして最大 pt も返す。
+    """
+    total = 0.0
+    max_pt: Optional[float] = None
+    paragraphs = list(text_frame.paragraphs)
+    for para in paragraphs:
+        pt = _effective_paragraph_size(para, default_pt=default_pt)
+        if max_pt is None or pt > max_pt:
+            max_pt = pt
+        text = _paragraph_text(para)
+        if text:
+            total += estimate_text_height(text, usable_width, pt)
+        else:
+            total += pt * 0.0139 * 1.2
+    if max_pt is None:
+        max_pt = default_pt
+    return total, max_pt
+
+
 def check_text_overflow(
     presentation: Presentation,
     *,
@@ -272,8 +371,10 @@ def check_text_overflow(
 ) -> List[ValidationFinding]:
     """テキストフレームの高さ溢れを検出する.
 
-    各 text frame の幅 (左右 0.05" マージン合計) に基づき、推定文字高さが
-    frame_height × (1 + tolerance/100) を超える場合に ``error`` finding を返す。
+    各 text frame の幅 (左右 0.05" マージン合計) に基づき、段落単位で
+    有効フォントサイズを解決し、段落ごとの推定高さを合算する。合計が
+    frame_height × (1 + tolerance/100) を超える場合に ``error`` finding
+    を返す。
     """
     findings: List[ValidationFinding] = []
     tolerance_factor = 1 + overflow_tolerance_pct / 100.0
@@ -294,18 +395,20 @@ def check_text_overflow(
             if not text.strip():
                 continue
 
-            font_size = _dominant_font_size(tf)
             usable_width = max(0.1, frame_width - 0.10)
-            needed_height = estimate_text_height(text, usable_width, font_size)
+            needed_height, font_size = _estimate_frame_needed_height(
+                tf, usable_width
+            )
             max_allowed = frame_height * tolerance_factor
 
             if needed_height > max_allowed:
-                # 収まる最大 pt を 0.5pt 刻みで探索する
+                # 収まる最大代表 pt を 0.5pt 刻みで探索する。段落間の比率を
+                # 保って一様スケールする想定で needed_height に線形近似する。
                 fit_pt: Optional[float] = None
                 candidate = font_size - 0.5
                 while candidate >= min_readable_pt:
-                    h = estimate_text_height(text, usable_width, candidate)
-                    if h <= frame_height:
+                    scale = candidate / font_size if font_size > 0 else 1.0
+                    if needed_height * scale <= frame_height:
                         fit_pt = candidate
                         break
                     candidate -= 0.5
@@ -328,7 +431,7 @@ def check_text_overflow(
                         message=(
                             f"text overflow: needed {needed_height:.2f}\" "
                             f"> frame {frame_height:.2f}\" "
-                            f"(font {font_size:.1f}pt, width {frame_width:.2f}\")"
+                            f"(max font {font_size:.1f}pt, width {frame_width:.2f}\")"
                         ),
                         suggested_fix=suggested,
                     )
@@ -361,14 +464,26 @@ def check_unreadable_text(
 
             tf = shape.text_frame
             smallest: Optional[float] = None
-            for run in _iter_runs(tf):
-                size = run.font.size
-                if size is None:
-                    continue
-                pt = size.pt
-                if pt < min_readable_pt:
-                    if smallest is None or pt < smallest:
-                        smallest = pt
+            # run に明示された size を優先、無い場合は段落の実効サイズを見る
+            for para in tf.paragraphs:
+                seen_run_size = False
+                for run in para.runs:
+                    size = run.font.size
+                    if size is None:
+                        continue
+                    seen_run_size = True
+                    pt = size.pt
+                    if pt < min_readable_pt:
+                        if smallest is None or pt < smallest:
+                            smallest = pt
+                if not seen_run_size:
+                    # 段落レベル (paragraph.font.size / defRPr) を評価する
+                    # defRPr 経路で書かれた小フォントも確実に検出する
+                    eff_pt = _effective_paragraph_size(para, default_pt=min_readable_pt)
+                    # default_pt に閾値を入れているので defRPr 等で明示されない限り検出しない
+                    if eff_pt < min_readable_pt:
+                        if smallest is None or eff_pt < smallest:
+                            smallest = eff_pt
 
             if smallest is not None:
                 findings.append(
@@ -437,8 +552,9 @@ def check_divider_collision(
                 if not text.strip():
                     continue
                 frame_width = max(0.1, (s_right - s_left) - 0.10)
-                font_size = _dominant_font_size(tf)
-                needed_height = estimate_text_height(text, frame_width, font_size)
+                needed_height, font_size = _estimate_frame_needed_height(
+                    tf, frame_width
+                )
                 projected_bottom = s_top + needed_height
                 limit = d_top - 0.02
 
@@ -475,6 +591,11 @@ def _axis_groups(
     """(index, axis_value) を tolerance 以内で clustering して返す.
 
     返り値は各 group の index リスト。3 要素以上のクラスタのみ返す。
+
+    clustering は group 先頭 (anchor) との差分で single-linkage 判定を
+    行う。running-mean 更新はドリフトを生む (例: tolerance=0.1 で
+    ``[0.0, 0.05, 0.10, 0.15, 0.20]`` が全て同一 group に吸収される)
+    ため採用しない。
     """
     if not values:
         return []
@@ -482,9 +603,8 @@ def _axis_groups(
     groups: List[List[Tuple[int, float]]] = []
     current: List[Tuple[int, float]] = [sorted_vals[0]]
     for item in sorted_vals[1:]:
-        # 現在グループの平均値との差で判定する
-        avg = sum(v for _, v in current) / len(current)
-        if abs(item[1] - avg) <= tolerance:
+        anchor = current[0][1]
+        if abs(item[1] - anchor) <= tolerance:
             current.append(item)
         else:
             groups.append(current)
@@ -629,6 +749,22 @@ def check_deck_extended(
 
     既存 ``check_slide_overlaps`` の警告文字列を ``overlaps`` と
     ``out_of_bounds`` に分割して格納する (既存キーは文字列リストのまま)。
+
+    Severity mapping — ``summary`` の各カウンタに寄与するカテゴリは以下のとおり:
+
+    - ``errors``:
+        - ``overlaps`` (``check_slide_overlaps`` 由来の overlap 警告)
+        - ``out_of_bounds`` (slide 外に出ている shape)
+        - ``text_overflow`` (``check_text_overflow``)
+        - ``divider_collision`` (``check_divider_collision``)
+    - ``warnings``:
+        - ``unreadable_text`` (``check_unreadable_text``)
+    - ``infos``:
+        - ``inconsistent_gaps`` (``check_inconsistent_gaps``)
+
+    CI ゲートで ``summary.errors == 0`` を要求する場合、overlap / out_of_bounds
+    を含めて error と扱う必要があるため、本関数は legacy の文字列リスト長も
+    errors に加算する。
     """
     slide_w = presentation.slide_width / 914400
     slide_h = presentation.slide_height / 914400
@@ -682,8 +818,12 @@ def check_deck_extended(
 
     slides_out = [by_slide[i] for i in sorted(by_slide.keys())]
 
-    # summary: ValidationFinding 由来の severity を集計する
+    # summary: ValidationFinding 由来 + legacy (overlaps / out_of_bounds) を集計する。
+    # 詳細な severity mapping は docstring 参照。
     errors = sum(1 for f in text_overflow + divider if f.severity == "error")
+    for slide_data in slides_out:
+        errors += len(slide_data["overlaps"])
+        errors += len(slide_data["out_of_bounds"])
     warnings_count = sum(1 for f in unreadable if f.severity == "warning")
     infos = sum(1 for f in gaps if f.severity == "info")
 

--- a/tests/test_validation_extended.py
+++ b/tests/test_validation_extended.py
@@ -12,6 +12,8 @@ from pptx.util import Inches, Pt
 
 from pptx_mcp_server.engine.validation import (
     ValidationFinding,
+    _axis_groups,
+    _effective_paragraph_size,
     check_deck_extended,
     check_divider_collision,
     check_inconsistent_gaps,
@@ -271,3 +273,175 @@ def test_validation_finding_to_dict_shape() -> None:
     assert d["category"] == "text_overflow"
     assert d["message"] == "m"
     assert d["suggested_fix"] == "fix"
+
+
+# ---------------------------------------------------------------------------
+# _axis_groups drift (Issue #21)
+# ---------------------------------------------------------------------------
+
+
+class TestAxisGroupsDrift:
+    """``_axis_groups`` が running-mean drift で誤吸収しないことを確認する."""
+
+    def test_linear_drift_not_one_group(self) -> None:
+        # tops = [0.0, 0.05, 0.10, 0.15, 0.20] は anchor 基準だと
+        # 0.0 基準で tolerance 0.1 を超える要素 (0.15, 0.20) が別 group になる
+        values = [
+            (0, 0.0),
+            (1, 0.05),
+            (2, 0.10),
+            (3, 0.15),
+            (4, 0.20),
+        ]
+        groups = _axis_groups(values, tolerance=0.1)
+        # 5 要素が全部 1 group にまとめられる (= running-mean drift) ことは
+        # あってはならない
+        assert not (len(groups) == 1 and len(groups[0]) == 5)
+
+    def test_tight_cluster_is_one_group(self) -> None:
+        # anchor 1.0 で全要素が tolerance 0.1 以内 → 1 group
+        values = [(0, 1.0), (1, 1.0), (2, 1.09)]
+        groups = _axis_groups(values, tolerance=0.1)
+        assert groups == [[0, 1, 2]]
+
+    def test_boundary_split_into_two_groups(self) -> None:
+        # 1.0 と 1.18 は tolerance 0.1 を超えるので別 group
+        values = [(0, 1.0), (1, 1.18)]
+        groups = _axis_groups(values, tolerance=0.1)
+        # どちらも 3 要素未満なので返却されず、空リストになる
+        assert groups == []
+
+    def test_regression_3kpi_uneven_gaps_still_flagged(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # gaps [0.15, 0.15, 0.30] を持つ 4-KPI row が引き続き inconsistent
+        # と判定されることを担保する (drift 修正でも既存動作が崩れない)
+        slide = one_slide_prs.slides[0]
+        _add_rect(slide, 1.00, 2.0, 1.0, 1.0, name="A")
+        _add_rect(slide, 2.15, 2.0, 1.0, 1.0, name="B")  # gap 0.15
+        _add_rect(slide, 3.30, 2.0, 1.0, 1.0, name="C")  # gap 0.15
+        _add_rect(slide, 4.60, 2.0, 1.0, 1.0, name="D")  # gap 0.30
+        findings = check_inconsistent_gaps(one_slide_prs)
+        assert any(f.category == "inconsistent_gap" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# check_deck_extended summary aggregation (Issue #22)
+# ---------------------------------------------------------------------------
+
+
+class TestSummaryAggregation:
+    """``summary`` が legacy overlaps / out_of_bounds も含めて集計することを確認する."""
+
+    def test_clean_deck_all_zeros(self, one_slide_prs: Presentation) -> None:
+        # 何も置かないスライドは summary 全 0
+        result = check_deck_extended(one_slide_prs)
+        assert result["summary"] == {"errors": 0, "warnings": 0, "infos": 0}
+
+    def test_single_overlap_counts_as_error(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        slide = one_slide_prs.slides[0]
+        # 大きく重なる 2 つの矩形 (overlap area >= 0.15 sq in)
+        _add_rect(slide, 1.0, 1.0, 3.0, 2.0, name="A")
+        _add_rect(slide, 2.0, 1.5, 3.0, 2.0, name="B")
+        result = check_deck_extended(one_slide_prs)
+        slide0 = result["slides"][0]
+        assert len(slide0["overlaps"]) == 1
+        assert result["summary"]["errors"] == 1
+
+    def test_two_overlaps_and_one_unreadable(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        slide = one_slide_prs.slides[0]
+        # 2 つの overlap 警告が生じる 3-way 重なり配置 (A-B, A-C, B-C の 3 組みで
+        # すべて大きな area を持つように調整)
+        _add_rect(slide, 1.0, 1.0, 3.0, 2.0, name="A")
+        _add_rect(slide, 2.0, 1.5, 3.0, 2.0, name="B")
+        _add_rect(slide, 6.0, 1.0, 3.0, 2.0, name="C")
+        _add_rect(slide, 7.0, 1.5, 3.0, 2.0, name="D")
+        # unreadable 警告 (6pt)
+        _add_textbox(slide, 0.5, 6.0, 3.0, 0.3, "tiny", font_pt=6, name="TinyBox")
+
+        result = check_deck_extended(one_slide_prs)
+        slide0 = result["slides"][0]
+        assert len(slide0["overlaps"]) == 2
+        assert result["summary"]["errors"] == 2
+        assert result["summary"]["warnings"] == 1
+
+
+# ---------------------------------------------------------------------------
+# paragraph-level font sizing (Issue #23)
+# ---------------------------------------------------------------------------
+
+
+class TestParagraphSizeResolution:
+    """段落単位の font サイズ解決と overflow 判定."""
+
+    def test_mixed_size_paragraphs_no_false_overflow(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # 24pt 1行 + 10pt 1行 が収まる十分な高さの box
+        # 24pt → ≒ 0.40" 、10pt → ≒ 0.17"、合計 ≒ 0.57"
+        # 旧実装は 24pt × 2 行で ≒ 0.80" と過大評価し false overflow になる。
+        slide = one_slide_prs.slides[0]
+        tb = slide.shapes.add_textbox(
+            Inches(1.0), Inches(1.0), Inches(6.0), Inches(1.0)
+        )
+        tf = tb.text_frame
+        tf.word_wrap = True
+        # 最初の paragraph を 24pt タイトル
+        tf.text = "Title"
+        tf.paragraphs[0].runs[0].font.size = Pt(24)
+        # 2 段落目を 10pt body
+        p2 = tf.add_paragraph()
+        r2 = p2.add_run()
+        r2.text = "body"
+        r2.font.size = Pt(10)
+        tb.name = "MixedBox"
+
+        findings = check_text_overflow(one_slide_prs)
+        # MixedBox に text_overflow finding は出てはならない
+        matched = [f for f in findings if f.shape_name == "MixedBox"]
+        assert matched == []
+
+    def test_defrpr_only_size_detected(self, one_slide_prs: Presentation) -> None:
+        from lxml import etree
+
+        slide = one_slide_prs.slides[0]
+        tb = slide.shapes.add_textbox(
+            Inches(1.0), Inches(1.0), Inches(6.0), Inches(1.0)
+        )
+        tf = tb.text_frame
+        tf.text = "hello"
+        para = tf.paragraphs[0]
+        # run レベル size を除去
+        for run in para.runs:
+            run.font.size = None
+        # <a:pPr><a:defRPr sz="2400"/></a:pPr> を手動で付与 (24pt)
+        a_ns = "http://schemas.openxmlformats.org/drawingml/2006/main"
+        nsmap = {"a": a_ns}
+        p_elem = para._p
+        # 既存 pPr を削除してから新たに差し込む
+        for existing in p_elem.findall(f"{{{a_ns}}}pPr"):
+            p_elem.remove(existing)
+        p_pr = etree.SubElement(p_elem, f"{{{a_ns}}}pPr")
+        p_elem.insert(0, p_pr)
+        etree.SubElement(p_pr, f"{{{a_ns}}}defRPr", {"sz": "2400"})
+
+        # helper が defRPr 経由で 24pt を返すこと
+        eff = _effective_paragraph_size(para, default_pt=18.0)
+        assert eff == pytest.approx(24.0)
+
+    def test_single_size_frame_still_detects_overflow(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # 既存挙動の回帰: 18pt 長文が小さな box からあふれる
+        slide = one_slide_prs.slides[0]
+        long_jp = (
+            "これは非常に長い日本語のテキストであり、"
+            "指定された小さなテキストボックスには到底収まらない分量である。"
+        )
+        _add_textbox(slide, 1.0, 1.0, 2.0, 0.5, long_jp, font_pt=18, name="OverflowBox")
+        findings = check_text_overflow(one_slide_prs)
+        assert any(f.shape_name == "OverflowBox" for f in findings)


### PR DESCRIPTION
## Summary

Fixes three related silent-wrong-output bugs in `src/pptx_mcp_server/engine/validation.py`:

- **#21** `_axis_groups` running-mean drift — switch to single-linkage against the group anchor (first element). `tops=[0.0, 0.05, 0.10, 0.15, 0.20]` no longer collapses into one row under `tolerance=0.1`.
- **#22** `check_deck_extended.summary` undercounted errors — the legacy `overlaps` / `out_of_bounds` lists are now included in `summary.errors`, so CI gates on `summary.errors == 0` stop silently green-lighting broken decks. Severity mapping is documented in the return-schema docstring.
- **#23** `_dominant_font_size` over-estimated heights — `check_text_overflow` now walks paragraphs individually and sums per-paragraph heights at the paragraph's effective size. New helper `_effective_paragraph_size(paragraph)` resolves size via (1) max `run.font.size`, (2) `paragraph.font.size`, (3) `pPr/defRPr/@sz`, (4) default, so frames written via `defRPr` (e.g. `add_auto_fit_textbox`) are handled correctly.

Public API signatures (`check_text_overflow`, `check_unreadable_text`, `check_divider_collision`, `check_inconsistent_gaps`, `check_deck_extended`, `check_slide_overlaps`, `check_deck_overlaps`, `ValidationFinding`) and the `check_deck_extended` return-schema keys are preserved.

Closes #21
Closes #22
Closes #23

## Test plan

- [x] `python -m pytest tests/test_validation_extended.py -v` — 21 passing (11 existing + 10 new)
- [x] `python -m pytest` — 348 passing, no regressions
- [x] Drift test: `tops=[0.0, 0.05, 0.10, 0.15, 0.20]` with tol=0.1 no longer merges
- [x] Tight cluster: `tops=[1.0, 1.0, 1.09]` stays one group
- [x] Regression: 3-KPI uneven gaps still flagged
- [x] Summary: 1 overlap -> `errors=1`; 2 overlaps + 1 unreadable -> `errors=2, warnings=1`; clean deck -> all zeros
- [x] Mixed-size frame (24pt + 10pt) fits without false overflow
- [x] `defRPr`-only size is detected via `_effective_paragraph_size`
- [x] Existing single-size overflow test still fires

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)