### PR TITLE
fix(cards): CardSpec mutation + unknown height_mode + padding double-count (closes #26, #27)

### DIFF
--- a/src/pptx_mcp_server/engine/__init__.py
+++ b/src/pptx_mcp_server/engine/__init__.py
@@ -99,6 +99,7 @@ from .composites import (
 from .cards import (
     CardSpec,
     CardHeightMode,
+    CardPlacement,
     add_responsive_card_row,
 )
 
@@ -134,7 +135,7 @@ __all__ = [
     # Flex
     "FlexItem", "add_flex_container", "add_flex_container_file",
     # Cards
-    "CardSpec", "CardHeightMode", "add_responsive_card_row",
+    "CardSpec", "CardHeightMode", "CardPlacement", "add_responsive_card_row",
     # Rendering
     "render_slide", "render_slide_to_path",
 ]

--- a/src/pptx_mcp_server/engine/cards.py
+++ b/src/pptx_mcp_server/engine/cards.py
@@ -8,10 +8,14 @@
 
 # 設計メモ
 - 各カードの幅 ``width`` は ``(row_width - gap*(n-1)) / n`` で一意に決まる。
-  計算結果は呼び出し元で再利用できるよう ``CardSpec.width`` に書き戻す
-  (入力 dataclass を破壊的に変更する)。
+  計算結果は **呼び出し元の ``CardSpec`` には書き戻さない** (dataclass を
+  破壊的に変更しない)。同じ ``CardSpec`` リストを複数行で再利用する呼び出し
+  側が安心して使えるよう、内部の ``_CardLayout`` として保持する。
 - 高さ推定は ``estimate_text_height`` を使う。label は単一行想定のため
   ``label_size_pt * 0.0139`` をそのまま採用する。
+- 高さ推定で使う usable width は ``add_auto_fit_textbox`` と同じ
+  ``inner_w - 2 * _AUTO_FIT_PADDING_PER_SIDE`` を使う (二重 padding 防止)。
+- 残差吸収のため推定ブロック高に ``_BLOCK_HEIGHT_SLACK`` (= 1.05) を掛ける。
 - 各最終高は ``[min_card_height, max_height]`` で clamp する。
 - 単一カード (n == 1) のとき ``gap`` は無視する。
 """
@@ -21,10 +25,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-from .shapes import _add_shape, add_auto_fit_textbox
+from .pptx_io import EngineError, ErrorCode
+from .shapes import _AUTO_FIT_PADDING_PER_SIDE, _add_shape, add_auto_fit_textbox
 from .text_metrics import estimate_text_height
 
 CardHeightMode = Literal["content", "max", "fill"]
+
+# 有効な height_mode 値の集合 (ランタイム検証用)。JSON 入力経由の未知値を
+# ここで弾くため、``Literal`` とは別に明示的に保持する。
+_VALID_HEIGHT_MODES: tuple[str, ...] = ("content", "max", "fill")
 
 
 # 1em inches 換算係数 (text_metrics の _CJK_WIDTH_PER_PT に相当)
@@ -35,6 +44,10 @@ _INTRA_GAP: float = 0.05
 
 # 左アクセントバーの幅 (inches)
 _ACCENT_BAR_W: float = 0.08
+
+# 推定ブロック高に掛ける slack。auto-fit 側の行高倍率や文字幅推定の残差を
+# 吸収し、PowerPoint 実描画でのクリップを避けるためのマージン。
+_BLOCK_HEIGHT_SLACK: float = 1.05
 
 
 @dataclass
@@ -55,8 +68,8 @@ class CardSpec:
         label_size_pt: ラベル font size (pt)。
         label_color: ラベル文字色 (6 桁 hex)。
         padding: カード内側 padding (inches、上下左右共通)。
-        width: 行レイアウトが計算したカード幅 (inches)。呼び出し側で事前に
-            設定する必要はない。``add_responsive_card_row`` が書き込む。
+        width: ``add_responsive_card_row`` では読み書きしない (後方互換のため
+            フィールド自体は残す)。レイアウト幅は行幅から一意に算出される。
     """
 
     title: str = ""
@@ -74,33 +87,67 @@ class CardSpec:
     width: float = 0.0
 
 
-def _estimate_block_heights(card: CardSpec) -> tuple[float, float, float, int]:
+@dataclass
+class CardPlacement:
+    """実際に描画された 1 枚のカードの位置情報 (inches).
+
+    ``add_responsive_card_row`` がカードごとに 1 つ返す。呼び出し側 (MCP
+    ツール層など) がスライド内の下流要素を配置する際に利用する。
+    """
+
+    left: float
+    top: float
+    width: float
+    height: float
+
+
+def _estimate_block_heights(
+    card: CardSpec, width: float
+) -> tuple[float, float, float, int]:
     """カードの label / title / body それぞれの推定高 (inches) と非空ブロック数を返す.
 
     label は単一行想定のため ``label_size_pt * 0.0139`` をそのまま使う。
     title / body は ``estimate_text_height`` により wrap 後の総高を算出する。
+
+    ``add_auto_fit_textbox`` が内部で左右 ``_AUTO_FIT_PADDING_PER_SIDE`` を
+    差し引くため、ここでも同じ usable width を使う (以前は二重 padding で
+    推定 < 実描画となり、PowerPoint でクリップしていた)。また残差吸収のため
+    title / body の推定高に ``_BLOCK_HEIGHT_SLACK`` 倍を掛ける。
     """
-    inner_w = max(card.width - 2 * card.padding, 0.01)
+    inner_w = max(width - 2 * card.padding, 0.01)
+    # add_auto_fit_textbox と同じ usable width で測る
+    usable_inner_w = max(inner_w - 2 * _AUTO_FIT_PADDING_PER_SIDE, 0.01)
 
     label_h = card.label_size_pt * _EM_PER_PT if card.label else 0.0
-    title_h = (
-        estimate_text_height(card.title, inner_w, card.title_size_pt)
+    title_h_raw = (
+        estimate_text_height(card.title, usable_inner_w, card.title_size_pt)
         if card.title
         else 0.0
     )
-    body_h = (
-        estimate_text_height(card.body, inner_w, card.body_size_pt)
+    body_h_raw = (
+        estimate_text_height(card.body, usable_inner_w, card.body_size_pt)
         if card.body
         else 0.0
     )
+
+    # 推定残差を吸収する slack (label は単一行想定なのでそのまま)
+    title_h = title_h_raw * _BLOCK_HEIGHT_SLACK if title_h_raw > 0 else 0.0
+    body_h = body_h_raw * _BLOCK_HEIGHT_SLACK if body_h_raw > 0 else 0.0
 
     n_blocks = sum(1 for h in (label_h, title_h, body_h) if h > 0)
     return label_h, title_h, body_h, n_blocks
 
 
-def _content_height(card: CardSpec) -> float:
-    """カードの content 高 (padding 込み、intra_gap 含む) を返す."""
-    label_h, title_h, body_h, n_blocks = _estimate_block_heights(card)
+def _content_height(card: CardSpec, width: float | None = None) -> float:
+    """カードの content 高 (padding 込み、intra_gap 含む) を返す.
+
+    Args:
+        card: 対象カード。
+        width: カード幅 (inches)。``None`` の場合は ``card.width`` を使う
+            (後方互換のための挙動だが、呼び出し側で明示するのが推奨)。
+    """
+    w = width if width is not None else card.width
+    label_h, title_h, body_h, n_blocks = _estimate_block_heights(card, w)
     if n_blocks == 0:
         return card.padding * 2
     return (
@@ -161,7 +208,7 @@ def _render_card(
     inner_left = left + card.padding
     inner_w = max(w - 2 * card.padding, 0.01)
 
-    label_h, title_h, body_h, n_blocks = _estimate_block_heights(card)
+    label_h, title_h, body_h, n_blocks = _estimate_block_heights(card, w)
 
     # label は常に上端に固定で配置する。
     cursor = top + card.padding
@@ -255,16 +302,18 @@ def add_responsive_card_row(
     gap: float = 0.2,
     height_mode: CardHeightMode = "max",
     min_card_height: float = 1.0,
-) -> float:
+) -> tuple[list[CardPlacement], float]:
     """N 枚のカードを横並びで配置する.
 
     各カードの幅は ``(width - gap * (n - 1)) / n`` で均等分割する
-    (n == 1 のとき ``gap`` は無視される)。計算した幅は入力 ``cards`` の
-    各 ``CardSpec.width`` に書き戻される (dataclass を破壊的に変更する点に注意)。
+    (n == 1 のとき ``gap`` は無視される)。計算した幅は内部で保持するのみで
+    **呼び出し側の ``CardSpec`` には書き戻さない**。同じ ``CardSpec`` リストを
+    複数回の呼び出しで再利用できる。
 
     Args:
         slide: 対象スライドオブジェクト。
-        cards: ``CardSpec`` のリスト。空リストなら何も描画せず 0 を返す。
+        cards: ``CardSpec`` のリスト。空リストなら何も描画せず空の placement と
+            ``0.0`` を返す。
         left, top: 行の左上座標 (inches)。
         width: 行全体の幅 (inches)。
         max_height: 各カードが取り得る最大高 (inches)。``height_mode`` により
@@ -280,42 +329,61 @@ def add_responsive_card_row(
         min_card_height: 全カードの下限高 (inches)。
 
     Returns:
-        行が実際に消費した縦サイズ (inches)。height_mode が ``"content"`` の
-        場合は個別カード高の最大値、それ以外は共通カード高と一致する。
+        ``(placements, consumed_height)`` のタプル。
+
+        - ``placements``: 各カードの ``CardPlacement`` (left/top/width/height)。
+          入力 ``cards`` と同じ順序で、長さも同じ。
+        - ``consumed_height``: 行が実際に消費した縦サイズ (inches)。
+          ``"content"`` モードでは個別カード高の最大値、それ以外は共通カード高
+          と一致する。
+
+    Raises:
+        EngineError: ``height_mode`` が ``"content" | "max" | "fill"`` 以外の
+            値 (例: JSON 入力経由の ``"auto"`` やタイポ) の場合。
     """
+    # height_mode の実行時検証 (JSON 入力経由の未知値を弾く)
+    if height_mode not in _VALID_HEIGHT_MODES:
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            (
+                f"height_mode must be one of {list(_VALID_HEIGHT_MODES)}; "
+                f"got {height_mode!r}"
+            ),
+        )
+
     n = len(cards)
     if n == 0:
-        return 0.0
+        return [], 0.0
 
-    # 各カードの幅を計算して CardSpec.width に書き戻す
+    # 各カードの幅を計算する (呼び出し元の CardSpec には書き戻さない)
     effective_gap = gap if n > 1 else 0.0
     card_w = (width - effective_gap * (n - 1)) / n
-    for card in cards:
-        card.width = card_w
 
     # 各カードの content 高を事前測定する
-    content_heights = [_content_height(card) for card in cards]
+    content_heights = [_content_height(card, card_w) for card in cards]
 
     # height_mode に応じて各カードの最終高を決定する
-    final_heights: list[float] = []
+    final_heights: list[float]
     if height_mode == "content":
-        for ch in content_heights:
-            h = max(min(ch, max_height), min_card_height)
-            final_heights.append(h)
+        final_heights = [
+            max(min(ch, max_height), min_card_height) for ch in content_heights
+        ]
     elif height_mode == "max":
         max_ch = max(content_heights)
         common_h = max(min(max_ch, max_height), min_card_height)
         final_heights = [common_h] * n
-    elif height_mode == "fill":
+    else:  # "fill" — 上の検証で他の値は到達不能
         common_h = max(max_height, min_card_height)
         final_heights = [common_h] * n
-    else:  # 型的にはここには来ないが、防御的分岐
-        final_heights = [min(max(ch, min_card_height), max_height) for ch in content_heights]
 
-    # 各カードを描画
+    # 各カードを描画しつつ placement を組み立てる
+    placements: list[CardPlacement] = []
     x = left
     for card, h in zip(cards, final_heights):
-        _render_card(slide, card, x, top, card.width, h, mode=height_mode)
-        x += card.width + effective_gap
+        _render_card(slide, card, x, top, card_w, h, mode=height_mode)
+        placements.append(
+            CardPlacement(left=x, top=top, width=card_w, height=h)
+        )
+        x += card_w + effective_gap
 
-    return max(final_heights)
+    return placements, max(final_heights)

--- a/src/pptx_mcp_server/engine/shapes.py
+++ b/src/pptx_mcp_server/engine/shapes.py
@@ -474,9 +474,13 @@ def list_shapes(file_path, slide_index):
 
 # ── Auto-fit textbox ────────────────────────────────────────────
 
-# 内側 padding (inches)。左右に同量の padding を見込むため、usable width は
-# width - 2 * _AUTO_FIT_PADDING となる。
-_AUTO_FIT_PADDING: float = 0.05
+# 内側 padding (inches、左右各側)。左右に同量の padding を見込むため、
+# usable width は width - 2 * _AUTO_FIT_PADDING_PER_SIDE となる。
+# cards.py など他モジュールからも参照できるよう module-level の定数として公開する。
+_AUTO_FIT_PADDING_PER_SIDE: float = 0.05
+
+# 後方互換のための別名 (旧名)。新規コードは _AUTO_FIT_PADDING_PER_SIDE を使うこと。
+_AUTO_FIT_PADDING: float = _AUTO_FIT_PADDING_PER_SIDE
 
 # font size 縮小ステップ (pt)
 _AUTO_FIT_STEP_PT: float = 0.5

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -771,7 +771,7 @@ def pptx_add_responsive_card_row(
         prs = open_pptx(file_path)
         slide = _get_slide(prs, slide_index)
 
-        consumed = add_responsive_card_row(
+        placements, consumed = add_responsive_card_row(
             slide,
             cards,
             left=left, top=top, width=width, max_height=max_height,
@@ -781,30 +781,17 @@ def pptx_add_responsive_card_row(
         )
         save_pptx(prs, file_path)
 
-        # 各カードの (left, top, width, height) を計算する。行の左端 + 累積幅+ gap。
-        n = len(cards)
-        effective_gap = gap if n > 1 else 0.0
-        placements: list[dict] = []
-        x = left
-        # 実際の各カードの高さを cards と height_mode から再現する
-        from .engine.cards import _content_height  # 内部ヘルパを利用
-
-        if height_mode == "content":
-            heights = [max(min(_content_height(c), max_height), min_card_height) for c in cards]
-        else:
-            heights = [consumed] * n
-
-        for card, h in zip(cards, heights):
-            placements.append({
-                "left": x,
-                "top": top,
-                "width": card.width,
-                "height": h,
-            })
-            x += card.width + effective_gap
-
+        # CardPlacement を JSON 化可能な dict に変換する
         result = {
-            "cards": placements,
+            "cards": [
+                {
+                    "left": p.left,
+                    "top": p.top,
+                    "width": p.width,
+                    "height": p.height,
+                }
+                for p in placements
+            ],
             "consumed_height": consumed,
         }
         out = json.dumps(result)

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -2,18 +2,24 @@
 
 ``add_responsive_card_row`` の 3 つの ``height_mode`` (content / max / fill)
 と、単一カード・最小高 clamp・アクセントバー描画・消費高返却の各挙動を
-網羅する。
+網羅する。また #26 (CardSpec mutation + unknown height_mode) と
+#27 (padding 二重計上 → text clip) の再発防止テストを含む。
 """
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from pptx_mcp_server.engine.cards import (
+    CardPlacement,
     CardSpec,
-    add_responsive_card_row,
     _content_height,
+    _estimate_block_heights,
+    add_responsive_card_row,
 )
+from pptx_mcp_server.engine.pptx_io import EngineError, ErrorCode
 
 
 # EMU (914400 per inch) → inches 換算ユーティリティ
@@ -63,7 +69,7 @@ def test_max_mode_identical_content(slide):
         CardSpec(title="Strategy", body="Short body text."),
         CardSpec(title="Strategy", body="Short body text."),
     ]
-    consumed = add_responsive_card_row(
+    placements, consumed = add_responsive_card_row(
         slide, cards,
         left=0.5, top=1.0, width=12.0, max_height=4.0,
         gap=0.2, height_mode="max", min_card_height=0.5,
@@ -75,6 +81,10 @@ def test_max_mode_identical_content(slide):
     assert heights[1] == pytest.approx(heights[2], abs=1e-4)
     # 消費高 == 各カード高
     assert consumed == pytest.approx(heights[0], abs=1e-4)
+    # placements の長さ/高さ一致
+    assert len(placements) == 3
+    for p, h in zip(placements, heights):
+        assert p.height == pytest.approx(h, abs=1e-4)
 
 
 def test_max_mode_different_content_lengths_align(slide):
@@ -85,7 +95,7 @@ def test_max_mode_different_content_lengths_align(slide):
     long_card = CardSpec(title="T", body=long_body)
 
     cards = [short, medium, long_card]
-    consumed = add_responsive_card_row(
+    placements, consumed = add_responsive_card_row(
         slide, cards,
         left=0.5, top=1.0, width=12.0, max_height=6.0,
         gap=0.2, height_mode="max",
@@ -95,8 +105,9 @@ def test_max_mode_different_content_lengths_align(slide):
     # 全カード同一
     assert heights[0] == pytest.approx(heights[1], abs=1e-4)
     assert heights[1] == pytest.approx(heights[2], abs=1e-4)
-    # 高さ == 最大 content 高
-    max_content = max(_content_height(c) for c in cards)
+    # 高さ == 最大 content 高 (placement の width で測る)
+    card_w = placements[0].width
+    max_content = max(_content_height(c, card_w) for c in cards)
     assert heights[0] == pytest.approx(max_content, abs=1e-3)
     assert consumed == pytest.approx(heights[0], abs=1e-4)
 
@@ -128,7 +139,7 @@ def test_fill_mode_uses_max_height(slide):
         CardSpec(title="B", body="Short body."),
         CardSpec(title="C", body="Short body."),
     ]
-    consumed = add_responsive_card_row(
+    placements, consumed = add_responsive_card_row(
         slide, cards,
         left=0.5, top=0.5, width=12.0, max_height=5.0,
         gap=0.2, height_mode="fill",
@@ -138,6 +149,8 @@ def test_fill_mode_uses_max_height(slide):
     for h in heights:
         assert h == pytest.approx(5.0, abs=1e-4)
     assert consumed == pytest.approx(5.0, abs=1e-4)
+    for p in placements:
+        assert p.height == pytest.approx(5.0, abs=1e-4)
 
 
 def test_min_card_height_clamp(slide):
@@ -161,14 +174,14 @@ def test_min_card_height_clamp(slide):
 def test_single_card_fills_row_width(slide):
     """単一カード (n == 1): gap を無視し行幅すべてをそのカードが占める."""
     cards = [CardSpec(title="Only", body="Alone in the row.")]
-    add_responsive_card_row(
+    placements, _ = add_responsive_card_row(
         slide, cards,
         left=1.0, top=1.0, width=8.0, max_height=4.0,
         gap=0.5, height_mode="max",
     )
 
-    # 単一カードの width 書き戻し
-    assert cards[0].width == pytest.approx(8.0, abs=1e-4)
+    # placement の width が 8.0 と一致 (CardSpec.width には書き戻さない仕様)
+    assert placements[0].width == pytest.approx(8.0, abs=1e-4)
 
     # 先頭 shape = 背景矩形。width が 8.0 に一致
     first_shape = list(slide.shapes)[0]
@@ -206,7 +219,7 @@ def test_consumed_height_matches_max_for_max_and_fill(slide, one_slide_prs):
     """consumed_height == max/fill モードの共通カード高."""
     # max モード
     cards_max = [CardSpec(title="T", body="Body A"), CardSpec(title="T", body="Body B")]
-    consumed_max = add_responsive_card_row(
+    _, consumed_max = add_responsive_card_row(
         slide, cards_max,
         left=0.5, top=0.5, width=10.0, max_height=6.0,
         gap=0.2, height_mode="max",
@@ -219,7 +232,7 @@ def test_consumed_height_matches_max_for_max_and_fill(slide, one_slide_prs):
     one_slide_prs.slides.add_slide(layout)
     slide2 = one_slide_prs.slides[1]
     cards_fill = [CardSpec(title="T", body="A"), CardSpec(title="T", body="B")]
-    consumed_fill = add_responsive_card_row(
+    _, consumed_fill = add_responsive_card_row(
         slide2, cards_fill,
         left=0.5, top=0.5, width=10.0, max_height=4.5,
         gap=0.2, height_mode="fill",
@@ -228,3 +241,216 @@ def test_consumed_height_matches_max_for_max_and_fill(slide, one_slide_prs):
     assert consumed_fill == pytest.approx(4.5, abs=1e-4)
     for h in heights_fill:
         assert h == pytest.approx(4.5, abs=1e-4)
+
+
+# ── #26: CardSpec mutation + unknown height_mode ───────────────
+
+
+def test_cardspec_not_mutated_between_calls(slide, one_slide_prs):
+    """同じ ``CardSpec`` リストを 2 つの ``add_responsive_card_row`` に渡しても
+    2 回目の widths が 1 回目と一致し (幅リーク無し)、``CardSpec.width`` は
+    既定値 (0.0) のまま変わらない (#26 Problem A)."""
+    cards = [
+        CardSpec(title="A", body="Short."),
+        CardSpec(title="B", body="Short."),
+        CardSpec(title="C", body="Short."),
+    ]
+
+    # 1 回目の呼び出し
+    placements1, _ = add_responsive_card_row(
+        slide, cards,
+        left=0.5, top=0.5, width=12.0, max_height=3.0,
+        gap=0.2, height_mode="max",
+    )
+    widths1 = [p.width for p in placements1]
+    # 入力 CardSpec は mutation されない
+    for c in cards:
+        assert c.width == 0.0
+
+    # 同じリストで 2 枚目のスライドにもう 1 回レイアウト
+    layout = one_slide_prs.slide_layouts[6]
+    one_slide_prs.slides.add_slide(layout)
+    slide2 = one_slide_prs.slides[1]
+    placements2, _ = add_responsive_card_row(
+        slide2, cards,
+        left=0.5, top=0.5, width=12.0, max_height=3.0,
+        gap=0.2, height_mode="max",
+    )
+    widths2 = [p.width for p in placements2]
+
+    # 幅は一致
+    assert widths1 == pytest.approx(widths2, abs=1e-6)
+    # 入力 CardSpec はまだ変わっていない
+    for c in cards:
+        assert c.width == 0.0
+
+
+def test_unknown_height_mode_raises(slide):
+    """未知の ``height_mode`` (例: JSON 入力経由の ``'auto'``) は
+    ``EngineError(INVALID_PARAMETER)`` を投げる (#26 Problem B)."""
+    cards = [CardSpec(title="A", body="a")]
+    with pytest.raises(EngineError) as excinfo:
+        add_responsive_card_row(
+            slide, cards,
+            left=0.5, top=0.5, width=10.0, max_height=3.0,
+            gap=0.2, height_mode="auto",  # type: ignore[arg-type]
+            min_card_height=1.0,
+        )
+    err = excinfo.value
+    assert err.code == ErrorCode.INVALID_PARAMETER
+    msg = str(err)
+    assert "height_mode" in msg
+    assert "auto" in msg
+
+
+@pytest.mark.parametrize("mode", ["content", "max", "fill"])
+def test_valid_modes_still_work(blank_prs, mode):
+    """``content`` / ``max`` / ``fill`` は従来通り動作する (#26 回帰防止)."""
+    layout = blank_prs.slide_layouts[6]
+    blank_prs.slides.add_slide(layout)
+    slide = blank_prs.slides[0]
+
+    cards = [CardSpec(title="T", body="B"), CardSpec(title="T", body="B")]
+    placements, consumed = add_responsive_card_row(
+        slide, cards,
+        left=0.5, top=0.5, width=10.0, max_height=3.0,
+        gap=0.2, height_mode=mode,  # type: ignore[arg-type]
+        min_card_height=1.0,
+    )
+    assert len(placements) == 2
+    assert consumed > 0.0
+
+
+def test_placements_cover_row_width(slide):
+    """``CardPlacement`` の ``left/width`` がギャップを考慮して行全体を覆う."""
+    cards = [CardSpec(title=f"T{i}", body="Body") for i in range(3)]
+    placements, _ = add_responsive_card_row(
+        slide, cards,
+        left=1.0, top=1.0, width=12.0, max_height=3.0,
+        gap=0.2, height_mode="max",
+    )
+    assert len(placements) == 3
+    # 1 枚目の left と 3 枚目の right が行全体と一致
+    assert placements[0].left == pytest.approx(1.0, abs=1e-6)
+    last = placements[-1]
+    assert last.left + last.width == pytest.approx(1.0 + 12.0, abs=1e-3)
+    # top は全カード一致
+    for p in placements:
+        assert p.top == pytest.approx(1.0, abs=1e-6)
+
+
+# ── #27: padding 二重計上 → text clip 防止 ────────────────────
+
+
+def test_no_text_overflow_for_japanese_body(one_slide_prs):
+    """3 枚カード × 日本語 80 字 body / 幅 3" で、実描画された body textbox が
+    ``estimate_text_height`` ベースで overflow しない (#27 回帰防止).
+
+    ``check_text_overflow`` は font-size を run 単位で読むため、python-pptx
+    において paragraph-level の font 設定が run に反映されない既知の挙動
+    (本 PR のスコープ外) に引きずられる。そのため本テストでは
+    ``check_text_overflow`` の出力にそのまま依存せず、実描画された body
+    textbox の ``width × height`` と実際の body font size
+    (``CardSpec.body_size_pt``) で ``estimate_text_height`` を再計算し、
+    必要高 ≤ frame 高 × tolerance となっていることを直接検証する。
+    """
+    from pptx.enum.shapes import MSO_SHAPE_TYPE
+
+    from pptx_mcp_server.engine.text_metrics import estimate_text_height
+
+    slide = one_slide_prs.slides[0]
+    # 日本語 80 文字
+    body = "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんがぎぐげござじずぜぞだぢづでどばびぶべぼぱぴぷぺぽ"[:80]
+    body_pt = 10.0
+    cards = [
+        CardSpec(title=f"カード{i}", body=body, body_size_pt=body_pt)
+        for i in range(3)
+    ]
+    # 3 枚 × 3" + gap 0.2" × 2 = 9.4"
+    add_responsive_card_row(
+        slide, cards,
+        left=0.5, top=0.5, width=9.4, max_height=4.0,
+        gap=0.2, height_mode="max", min_card_height=1.0,
+    )
+
+    # TEXT_BOX は各カードごとに (label なし、) title → body の順に追加される。
+    # 3 カード × 2 ブロック = 6 個。奇数 index が body。
+    text_shapes = [
+        s for s in slide.shapes if s.shape_type == MSO_SHAPE_TYPE.TEXT_BOX
+    ]
+    assert len(text_shapes) == 6
+    body_shapes = text_shapes[1::2]
+
+    for bs in body_shapes:
+        frame_w = bs.width / 914400
+        frame_h = bs.height / 914400
+        # validator と同じく左右 0.05" マージン合計 (0.10") を usable_width から引く
+        usable = max(0.1, frame_w - 0.10)
+        needed = estimate_text_height(body, usable, body_pt)
+        # 5% tolerance (validator と同じ)
+        assert needed <= frame_h * 1.05 + 1e-6, (
+            f"body overflow: needed {needed:.3f}\" > frame {frame_h:.3f}\" × 1.05 "
+            f"(width {frame_w:.3f}\", font {body_pt}pt)"
+        )
+
+
+def test_estimate_not_under_observed_body_height(slide):
+    """``_estimate_block_heights`` の body 推定高が、実描画後の body textbox
+    高さを下回らないこと (allocate >= observed、非過小評価)."""
+    from pptx.enum.shapes import MSO_SHAPE_TYPE
+
+    # 日本語 ~60 字で 3" 幅のカード
+    body = "これはカードの本文テキストで、日本語の折り返しが発生するだけの長さを持つサンプル文字列である。" * 1
+    card = CardSpec(title="見出し", body=body)
+
+    # 行幅 3" = 単一カード
+    placements, _ = add_responsive_card_row(
+        slide, [card],
+        left=0.5, top=0.5, width=3.0, max_height=5.0,
+        gap=0.2, height_mode="content", min_card_height=0.2,
+    )
+    placement_w = placements[0].width
+
+    # 推定 body 高
+    _, _, body_h_est, _ = _estimate_block_heights(card, placement_w)
+
+    # 実描画された body textbox の高さを取得 (最後の TEXT_BOX が body)
+    text_shapes = [
+        s for s in slide.shapes if s.shape_type == MSO_SHAPE_TYPE.TEXT_BOX
+    ]
+    body_shape = text_shapes[-1]
+    observed_body_h = _in(body_shape.height)
+
+    # 推定 ≥ 観測 (過小評価しない)。小さなトレランスを許容する。
+    assert body_h_est + 1e-3 >= observed_body_h or observed_body_h - body_h_est < 0.02
+
+
+# ── MCP tool boundary (#26 B) ─────────────────────────────────
+
+
+def test_mcp_tool_rejects_unknown_height_mode(pptx_file):
+    """``pptx_add_responsive_card_row`` MCP ツール側でも ``height_mode='auto'``
+    は既存 invalid-param エラー形式で弾かれる (#26 Problem B、境界側)."""
+    from pptx_mcp_server.server import pptx_add_responsive_card_row
+
+    cards_json = json.dumps([{"title": "A", "body": "a"}])
+    out = pptx_add_responsive_card_row(
+        file_path=pptx_file,
+        slide_index=0,
+        cards_json=cards_json,
+        left=0.5,
+        top=0.5,
+        width=10.0,
+        max_height=3.0,
+        gap=0.2,
+        height_mode="auto",
+        min_card_height=1.0,
+    )
+    # _err フォーマットに INVALID_PARAMETER が含まれる
+    assert "INVALID_PARAMETER" in out or "height_mode" in out
+
+
+def test_card_placement_dataclass_shape():
+    """``CardPlacement`` は left/top/width/height の 4 フィールドを持つ."""
+    p = CardPlacement(left=1.0, top=2.0, width=3.0, height=4.0)
+    assert (p.left, p.top, p.width, p.height) == (1.0, 2.0, 3.0, 4.0)


### PR DESCRIPTION
## Summary

Bundles two related silent-failure bugs in `src/pptx_mcp_server/engine/cards.py`.

### #26 — CardSpec mutation + height_mode silent fall-through

- **Problem A (mutation):** `add_responsive_card_row` wrote `card.width = computed_width` into the caller's `CardSpec` dataclass. Consumers who reused the same `CardSpec` list across multiple rows (legitimate pattern) saw widths leak between calls.
- **Problem B (silent fall-through):** The final `else:` branch silently implemented a 4th algorithm for unknown `height_mode` strings. `Literal` is a static-only check; MCP JSON input with `height_mode="auto"` or a typo bypassed it.

**Fix:**
- No more writing to `CardSpec.width`. Width is computed locally and passed to `_render_card` / `_estimate_block_heights` explicitly. `CardSpec.width` remains as a dataclass field for back-compat but is read-only from this function's perspective.
- At function entry, `height_mode not in ("content", "max", "fill")` now raises `EngineError(ErrorCode.INVALID_PARAMETER, ...)`. The stray `else:` branch is gone.
- New return shape: `tuple[list[CardPlacement], float]` (placements, consumed_height). `server.py::pptx_add_responsive_card_row` now consumes this and no longer needs the private `_content_height` import. `CardPlacement` is exported from `pptx_mcp_server.engine`.

### #27 — Double-counted padding → text clips in PowerPoint

- `_estimate_block_heights` computed body_h using `inner_w = w - 2*padding`, but `add_auto_fit_textbox` internally subtracts another `2 * _AUTO_FIT_PADDING = 0.10"`. Effective usable width at render was narrower than the estimator used; Japanese bodies near card width wrapped one line later than expected and clipped.

**Fix:**
- `_AUTO_FIT_PADDING_PER_SIDE = 0.05` is now a module-level constant in `shapes.py` (the old `_AUTO_FIT_PADDING` is retained as an alias for back-compat). `cards.py::_estimate_block_heights` imports it and uses `usable_inner_w = inner_w - 2 * _AUTO_FIT_PADDING_PER_SIDE` to measure text — single source of truth, matching what auto-fit will actually do.
- Added `_BLOCK_HEIGHT_SLACK = 1.05` applied to title/body estimates to absorb residual heuristic error (label is single-line and unaffected).

## Back-compat / API changes

- `add_responsive_card_row` return type changed from `float` to `tuple[list[CardPlacement], float]`. Direct Python callers must update. The MCP tool `pptx_add_responsive_card_row` JSON return shape is **unchanged** (`{"cards": [...], "consumed_height": ...}`).
- `CardSpec.width` is no longer mutated by `add_responsive_card_row`. The field remains on the dataclass to preserve the public shape.
- `CardPlacement` dataclass is newly exported from `pptx_mcp_server.engine`.

## Files touched

- `src/pptx_mcp_server/engine/cards.py` — main fixes
- `src/pptx_mcp_server/engine/shapes.py` — promoted `_AUTO_FIT_PADDING_PER_SIDE` module-level constant (value unchanged)
- `src/pptx_mcp_server/engine/__init__.py` — export `CardPlacement`
- `src/pptx_mcp_server/server.py::pptx_add_responsive_card_row` — consume new return; drop private `_content_height` import
- `tests/test_cards.py` — updated for new return shape + new regression tests

## Test plan

- [x] `python -m pytest tests/test_cards.py -v` → 18 passed (10 new)
- [x] `python -m pytest` → 348 passed, no regressions
- [x] #26: re-use same `CardSpec` list in two calls → widths identical, `CardSpec.width` stays 0.0
- [x] #26: `height_mode="auto"` → `EngineError(INVALID_PARAMETER)` both at engine and MCP tool boundary
- [x] #26: `content`/`max`/`fill` still work
- [x] #26: `CardPlacement` left/top/width/height correct, covers row
- [x] #27: 3 cards × 80-char Japanese body at ~3" width → body textbox `estimate_text_height(usable=w-0.10)` ≤ frame height × 1.05
- [x] #27: padding-consistency — `_estimate_block_heights` body is ≥ observed rendered body height

## Note on "validator reports 0 findings"

Issue #27 acceptance criterion mentions `check_text_overflow` reporting zero findings. In practice there is an orthogonal pre-existing issue in `shapes.py::_add_textbox` where `font.size` is applied at paragraph level but the validator's `_dominant_font_size` reads run-level only, falling back to 18pt when no run-level size is present. That interaction is out of scope for this PR (task explicitly forbids changes to `validation.py` / `text_metrics.py` and only allows limited `shapes.py` touches — promoting the padding constant). Instead the regression test directly verifies the underlying invariant: rendered body frame height ≥ `estimate_text_height(w - 0.10, body_size_pt)` with 5% tolerance, i.e. the exact condition #27 targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)