### PR TITLE
fix(text_metrics): extend is_cjk, half-width kana width, zero-width handling (closes #30)

### DIFF
--- a/src/pptx_mcp_server/engine/text_metrics.py
+++ b/src/pptx_mcp_server/engine/text_metrics.py
@@ -9,10 +9,12 @@
 - フォントファミリ差は現時点で無視する (引数は将来拡張のため保持)。
 - プロポーショナルフォントであっても全 ASCII 文字を同一の平均幅として扱う。
 - イタリック・装飾体の幅差分は無視する。Bold のみ 1.05 倍の補正を行う。
-- 合字・結合文字・絵文字の幅は保証しない。
+- 合字・絵文字の幅は保証しない。結合マーク・ゼロ幅文字は 0 幅で扱う。
 """
 
 from __future__ import annotations
+
+import unicodedata
 
 # ASCII 平均文字幅 (size_pt あたりの inches 係数)
 _ASCII_WIDTH_PER_PT: float = 0.0083
@@ -24,17 +26,46 @@ _CJK_WIDTH_PER_PT: float = 0.0139
 _BOLD_MULTIPLIER: float = 1.05
 
 
+# CJK スクリプトに属する Unicode 範囲 (全角相当の幅を持つもの).
+# 半角カタカナ U+FF61–U+FF9F は CJK スクリプトではあるが幅は ASCII 相当のため
+# `_HALF_WIDTH_KANA_RANGE` として別途管理し、この表から除外する。
+_CJK_RANGES: tuple[tuple[int, int], ...] = (
+    (0x2E80, 0x2EFF),  # CJK Radicals Supplement
+    (0x2F00, 0x2FDF),  # Kangxi Radicals
+    (0x3000, 0x303F),  # CJK Symbols and Punctuation
+    (0x3040, 0x309F),  # Hiragana
+    (0x30A0, 0x30FF),  # Katakana (full-width)
+    (0x3400, 0x4DBF),  # CJK Unified Ideographs Extension A
+    (0x4E00, 0x9FFF),  # CJK Unified Ideographs
+    (0xF900, 0xFAFF),  # CJK Compatibility Ideographs
+    (0xFF01, 0xFF60),  # Fullwidth ASCII + symbols (pre half-width kana)
+    (0xFFE0, 0xFFEF),  # Fullwidth symbols (post half-width kana)
+    (0x20000, 0x2FFFF),  # SIP: CJK Ext B/C/D/E/F + Compat Ideographs Supplement
+)
+
+# 半角カタカナの範囲 (CJK スクリプトだが幅は ASCII 相当).
+_HALF_WIDTH_KANA_RANGE: tuple[int, int] = (0xFF61, 0xFF9F)
+
+
 def is_cjk(char: str) -> bool:
-    """CJK Unified / Hiragana / Katakana / 全角句読点・記号を判定する.
+    """CJK スクリプトに属する文字かを判定する.
 
-    判定対象の Unicode 範囲:
-    - CJK Unified Ideographs: U+4E00 – U+9FFF
-    - Hiragana: U+3040 – U+309F
-    - Katakana: U+30A0 – U+30FF
+    判定対象の Unicode 範囲 (全角相当 + 半角カタカナ):
+
+    - CJK Radicals Supplement: U+2E80 – U+2EFF
+    - Kangxi Radicals: U+2F00 – U+2FDF
     - CJK Symbols and Punctuation: U+3000 – U+303F
-    - Halfwidth and Fullwidth Forms: U+FF00 – U+FFEF
+    - Hiragana: U+3040 – U+309F
+    - Katakana (full-width): U+30A0 – U+30FF
+    - CJK Unified Ideographs Extension A: U+3400 – U+4DBF
+    - CJK Unified Ideographs: U+4E00 – U+9FFF
+    - CJK Compatibility Ideographs: U+F900 – U+FAFF
+    - Halfwidth and Fullwidth Forms: U+FF01 – U+FF60, U+FF61 – U+FF9F, U+FFE0 – U+FFEF
+    - Supplementary Ideographic Plane (Ext B/C/D/E/F): U+20000 – U+2FFFF
 
-    改行文字 (``\\n`` など) は False を返す。
+    空文字列および ``\\n`` / ``\\r`` / ``\\t`` は False を返す。
+    半角カタカナは CJK スクリプトの一部であるため True を返すが、字幅は
+    ASCII 相当である点に注意すること (:func:`estimate_char_width` で別処理)。
     """
     if not char:
         return False
@@ -42,15 +73,52 @@ def is_cjk(char: str) -> bool:
     if char in ("\n", "\r", "\t"):
         return False
     code = ord(char[0])
-    if 0x4E00 <= code <= 0x9FFF:
+    # 半角カタカナは CJK スクリプト扱いとする (字幅は別管理)。
+    if _HALF_WIDTH_KANA_RANGE[0] <= code <= _HALF_WIDTH_KANA_RANGE[1]:
         return True
-    if 0x3040 <= code <= 0x309F:
+    for start, end in _CJK_RANGES:
+        if start <= code <= end:
+            return True
+    return False
+
+
+def is_half_width_kana(char: str) -> bool:
+    """半角カタカナ (U+FF61 – U+FF9F) かを判定する.
+
+    半角カタカナは CJK スクリプトに属するものの、実描画では ASCII 相当の
+    ~0.5em 幅となる。``estimate_char_width`` 側で CJK 全角幅ではなく
+    ASCII 幅を割り当てるためにこの述語を利用する。空文字列は False を返す。
+    """
+    if not char:
+        return False
+    code = ord(char[0])
+    return _HALF_WIDTH_KANA_RANGE[0] <= code <= _HALF_WIDTH_KANA_RANGE[1]
+
+
+def is_zero_width(char: str) -> bool:
+    """描画上の前進幅を持たない文字かを判定する.
+
+    以下の文字を 0 幅として扱う:
+
+    - U+200B (ZERO WIDTH SPACE)
+    - U+200C (ZERO WIDTH NON-JOINER)
+    - U+200D (ZERO WIDTH JOINER)
+    - U+2060 (WORD JOINER)
+    - U+FEFF (ZERO WIDTH NO-BREAK SPACE / BOM)
+    - U+FE00 – U+FE0F (Variation Selectors)
+    - ``unicodedata.combining(ch) != 0`` を満たす結合マーク全般
+
+    空文字列は False を返す。
+    """
+    if not char:
+        return False
+    ch = char[0]
+    code = ord(ch)
+    if code in (0x200B, 0x200C, 0x200D, 0x2060, 0xFEFF):
         return True
-    if 0x30A0 <= code <= 0x30FF:
+    if 0xFE00 <= code <= 0xFE0F:
         return True
-    if 0x3000 <= code <= 0x303F:
-        return True
-    if 0xFF00 <= code <= 0xFFEF:
+    if unicodedata.combining(ch) != 0:
         return True
     return False
 
@@ -58,12 +126,22 @@ def is_cjk(char: str) -> bool:
 def estimate_char_width(char: str, size_pt: float, font: str = "Arial") -> float:
     """単一文字の推定描画幅 (inches) を返す.
 
-    CJK 全角は ``size_pt * 0.0139`` (1em)、ASCII 相当は ``size_pt * 0.0083``
-    (平均幅) として近似する。``font`` は将来拡張のため引数に残すが、現状は
-    Arial/Helvetica を前提として無視される。
+    判定優先順位:
+
+    1. ゼロ幅文字 (``is_zero_width``) は 0.0 を返す。
+    2. 半角カタカナ (``is_half_width_kana``) は ASCII 相当の ``size_pt * 0.0083``。
+    3. CJK 全角 (``is_cjk``) は ``size_pt * 0.0139`` (1em)。
+    4. それ以外の ASCII 相当は ``size_pt * 0.0083`` (平均幅)。
+
+    ``font`` は将来拡張のため引数に残すが、現状は Arial/Helvetica を前提
+    として無視される。
     """
     if not char:
         return 0.0
+    if is_zero_width(char):
+        return 0.0
+    if is_half_width_kana(char):
+        return size_pt * _ASCII_WIDTH_PER_PT
     if is_cjk(char):
         return size_pt * _CJK_WIDTH_PER_PT
     return size_pt * _ASCII_WIDTH_PER_PT

--- a/tests/test_text_metrics.py
+++ b/tests/test_text_metrics.py
@@ -12,6 +12,8 @@ from pptx_mcp_server.engine.text_metrics import (
     estimate_text_height,
     estimate_text_width,
     is_cjk,
+    is_half_width_kana,
+    is_zero_width,
     wrap_text,
 )
 
@@ -45,6 +47,87 @@ class TestIsCjk:
 
     def test_empty_is_not_cjk(self) -> None:
         assert is_cjk("") is False
+
+    def test_cjk_ext_a(self) -> None:
+        # 人名漢字など CJK Ext A (U+3400–U+4DBF)
+        assert is_cjk("㐂") is True
+
+    def test_cjk_sip_plane2(self) -> None:
+        # SIP (U+20000–U+2FFFF) の 1 コードポイント
+        assert is_cjk(chr(0x2000B)) is True  # 𠀋
+
+    def test_cjk_compat_ideographs(self) -> None:
+        # CJK Compatibility Ideographs (U+F900–U+FAFF)
+        assert is_cjk(chr(0xF900)) is True
+
+    def test_cjk_radicals(self) -> None:
+        # CJK Radicals Supplement / Kangxi Radicals
+        assert is_cjk(chr(0x2E80)) is True
+        assert is_cjk(chr(0x2F00)) is True
+
+    def test_half_width_kana_is_cjk(self) -> None:
+        # 半角カタカナも CJK スクリプト扱い (幅は ASCII 相当だが判定は True)
+        assert is_cjk("ｶ") is True
+
+    def test_zwsp_is_not_cjk(self) -> None:
+        assert is_cjk("\u200B") is False
+
+
+class TestIsHalfWidthKana:
+    """is_half_width_kana の判定."""
+
+    def test_half_width_kana(self) -> None:
+        assert is_half_width_kana("ｶ") is True
+        assert is_half_width_kana("ﾀ") is True
+        assert is_half_width_kana("ﾅ") is True
+
+    def test_full_width_kana_is_not_half(self) -> None:
+        assert is_half_width_kana("カ") is False
+        assert is_half_width_kana("ア") is False
+
+    def test_ascii_is_not_half_width_kana(self) -> None:
+        assert is_half_width_kana("a") is False
+        assert is_half_width_kana("1") is False
+
+    def test_empty_string(self) -> None:
+        assert is_half_width_kana("") is False
+
+
+class TestIsZeroWidth:
+    """is_zero_width の判定."""
+
+    def test_zwsp(self) -> None:
+        assert is_zero_width("\u200B") is True
+
+    def test_zwnj_zwj(self) -> None:
+        assert is_zero_width("\u200C") is True
+        assert is_zero_width("\u200D") is True
+
+    def test_word_joiner(self) -> None:
+        assert is_zero_width("\u2060") is True
+
+    def test_bom_zwnbsp(self) -> None:
+        assert is_zero_width("\uFEFF") is True
+
+    def test_variation_selector(self) -> None:
+        assert is_zero_width("\uFE00") is True
+        assert is_zero_width("\uFE0F") is True
+
+    def test_combining_mark(self) -> None:
+        # 結合濁点 (U+3099) は unicodedata.combining != 0 のため 0 幅扱い。
+        # なお U+309B は spacing voiced sound mark で combining ではない。
+        assert is_zero_width("\u3099") is True
+        # 他の結合マーク例: COMBINING ACUTE ACCENT
+        assert is_zero_width("\u0301") is True
+
+    def test_ascii_is_not_zero_width(self) -> None:
+        assert is_zero_width("a") is False
+
+    def test_cjk_is_not_zero_width(self) -> None:
+        assert is_zero_width("あ") is False
+
+    def test_empty_string(self) -> None:
+        assert is_zero_width("") is False
 
 
 class TestEstimateTextWidth:
@@ -100,6 +183,69 @@ class TestEstimateCharWidth:
 
     def test_empty_char_zero(self) -> None:
         assert estimate_char_width("", 10) == 0.0
+
+    def test_half_width_kana_is_ascii_width(self) -> None:
+        # 半角カタカナは CJK 全角ではなく ASCII 相当の幅を使う。
+        assert estimate_char_width("ｶ", 10) == pytest.approx(
+            estimate_char_width("a", 10), abs=0.0001
+        )
+
+    def test_full_width_kana_is_em_width(self) -> None:
+        # 全角カタカナは 1em 幅 (0.0139"/pt)
+        assert estimate_char_width("カ", 10) == pytest.approx(10 * 0.0139, abs=0.0001)
+
+    def test_half_width_kana_half_of_full(self) -> None:
+        # 半角は全角のおおよそ半分 (ASCII 0.0083 vs CJK 0.0139)
+        assert estimate_char_width("ｶ", 10) < estimate_char_width("カ", 10)
+
+    def test_zero_width_space(self) -> None:
+        assert estimate_char_width("\u200B", 10) == 0.0
+
+    def test_variation_selector(self) -> None:
+        assert estimate_char_width("\uFE0F", 10) == 0.0
+
+    def test_combining_mark_zero_width(self) -> None:
+        # U+3099 は結合濁点 → 0 幅
+        assert estimate_char_width("\u3099", 10) == 0.0
+
+    def test_cjk_ext_a_is_em_width(self) -> None:
+        # 人名漢字 U+3400–U+4DBF も 1em 扱い (従来は ASCII 扱いで過小評価)
+        assert estimate_char_width("㐂", 10) == pytest.approx(10 * 0.0139, abs=0.0001)
+
+    def test_sip_is_em_width(self) -> None:
+        # SIP 面のコードポイントも 1em 扱い
+        assert estimate_char_width(chr(0x2000B), 10) == pytest.approx(
+            10 * 0.0139, abs=0.0001
+        )
+
+
+class TestEstimateTextWidthExtended:
+    """is_cjk 拡張後の幅推定検証."""
+
+    def test_combining_mark_adds_no_width(self) -> None:
+        # "か" + 結合濁点 の幅は "か" 単独と同じ
+        with_combining = estimate_text_width("か\u3099", 10)
+        without = estimate_text_width("か", 10)
+        assert with_combining == pytest.approx(without, abs=0.0001)
+
+    def test_cjk_ext_a_triple(self) -> None:
+        # 実プロダクションの日本人氏名ケース: "㐂㐂㐂" は 3 × CJK 幅。
+        # 旧実装では ASCII 扱いで 3 × 0.0083 と過小評価されていた。
+        width = estimate_text_width("㐂㐂㐂", 10)
+        expected = 3 * 10 * 0.0139
+        assert width == pytest.approx(expected, abs=0.001)
+
+    def test_half_width_kana_string(self) -> None:
+        # ｶﾀｶﾅ = 4 × ASCII 幅 (旧実装では 4 × CJK 幅で過大評価されていた)
+        width = estimate_text_width("ｶﾀｶﾅ", 10)
+        expected = 4 * 10 * 0.0083
+        assert width == pytest.approx(expected, abs=0.001)
+
+    def test_zwsp_does_not_add_width(self) -> None:
+        # ZWSP を含む文字列は含まないものと同じ幅
+        assert estimate_text_width("ab\u200Bcd", 10) == pytest.approx(
+            estimate_text_width("abcd", 10), abs=0.0001
+        )
 
 
 class TestWrapText:


### PR DESCRIPTION
## Summary

Closes #30.

- Extend `is_cjk` to cover CJK Ext A (U+3400-U+4DBF), Compatibility Ideographs (U+F900-U+FAFF), CJK/Kangxi Radicals (U+2E80-U+2FDF), and the Supplementary Ideographic Plane (U+20000-U+2FFFF). Real-production Japanese personal names (e.g. jinmeiyo kanji like `㐂`, plane-2 codepoints like `𠀋`) are no longer under-estimated as ASCII.
- Half-width katakana (U+FF61-U+FF9F) now correctly use ASCII-equivalent width (`size_pt * 0.0083`) via new `is_half_width_kana` predicate, instead of being over-estimated at full 1em. They remain classified as CJK by `is_cjk` so the char-break wrapping path still protects against runaway lines.
- New `is_zero_width` predicate covers ZWSP/ZWNJ/ZWJ/word-joiner/BOM, variation selectors (U+FE00-U+FE0F), and `unicodedata.combining` marks. `estimate_char_width` now returns `0.0` for these.
- CJK ranges refactored into a named module-level tuple for clarity.

Public signatures of `is_cjk`, `estimate_char_width`, `estimate_text_width`, `wrap_text`, and `estimate_text_height` are preserved. No callers were modified; only `text_metrics.py` and its tests changed.

## Test plan

- [x] `python -m pytest tests/test_text_metrics.py -v` → 66 passed (35 existing + 31 new)
- [x] `python -m pytest` → 400 passed, zero regressions
- [x] Regression: `estimate_text_width("プレミアムモルツ", 9, bold=True)` unchanged (Katakana range 0x30A0-0x30FF preserved)
- [x] Regression: `wrap_text("父の日ギフトシーンで安定露出も定番2位に留まる", 2.0, 10)` still returns 2-3 lines
- [x] New: `is_cjk("㐂")`, `is_cjk(chr(0x2000B))`, `is_cjk("ｶ")` → True
- [x] New: `estimate_char_width("ｶ", 10) == estimate_char_width("a", 10)` (ASCII width, not full-em)
- [x] New: `estimate_text_width("㐂㐂㐂", 10) ≈ 3 × CJK width` — the real-production personal-name case

## Notes

- The task prompt mentioned `is_zero_width("\u309B")` should be True as "combining dakuten", but U+309B is actually the spacing voiced sound mark (`unicodedata.combining` returns 0). The true combining dakuten is U+3099. Tests assert U+3099 → True accordingly, with a code comment explaining the distinction.
- No pre-existing assertion required adjustment. The previously-passing Katakana test (`プレミアムモルツ`) continues to pass because the full-width Katakana block U+30A0-U+30FF was already correct and remains unchanged.

Generated with [Claude Code](https://claude.com/claude-code)