### PR TITLE
fix(shapes): rPr font size + grapheme truncation + east-asian typeface + bodyPr anchor

### DIFF
--- a/src/pptx_mcp_server/engine/shapes.py
+++ b/src/pptx_mcp_server/engine/shapes.py
@@ -4,11 +4,14 @@ Shape operations -- add textbox, add shape, edit text, add paragraph, delete, li
 
 from __future__ import annotations
 
+import unicodedata
+
 from pptx import Presentation
 from pptx.util import Inches, Pt, Emu
 from pptx.enum.text import PP_ALIGN, MSO_ANCHOR
 from pptx.enum.shapes import MSO_SHAPE
 from pptx.dml.color import RGBColor
+from pptx.oxml.ns import qn
 
 from .pptx_io import (
     EngineError, ErrorCode,
@@ -17,6 +20,9 @@ from .pptx_io import (
 from .text_metrics import estimate_text_height, estimate_text_width, wrap_text
 
 from ..theme import Theme, resolve_color
+
+# DrawingML 名前空間 (OOXML 直接操作用)。
+_A_NS = "http://schemas.openxmlformats.org/drawingml/2006/main"
 
 # Mapping of alignment strings to enums
 _ALIGN_MAP = {
@@ -54,6 +60,20 @@ _SHAPE_MAP = {
 # ── Internal helpers ────────────────────────────────────────────
 
 
+def _set_east_asian_font(run, typeface: str) -> None:
+    """run の ``<a:rPr>`` に ``<a:ea typeface="..."/>`` を設定する.
+
+    python-pptx は east-asian typeface を直接公開しないため、lxml で
+    ``rPr`` 要素を取得し ``<a:ea>`` 子要素を差し替える。既存の ``<a:ea>``
+    は削除してから新しく追加することで重複を避ける。
+    """
+    rPr = run._r.get_or_add_rPr()
+    for existing in rPr.findall(qn("a:ea")):
+        rPr.remove(existing)
+    ea = rPr.makeelement(qn("a:ea"), {"typeface": typeface})
+    rPr.append(ea)
+
+
 def _apply_font(
     paragraph,
     font_name=None,
@@ -63,8 +83,21 @@ def _apply_font(
     italic=None,
     underline=None,
     theme=None,
+    east_asian_font=None,
 ):
-    """Apply font formatting to a paragraph's font."""
+    """paragraph とその全 run に font 書式を適用する.
+
+    挙動:
+        - paragraph レベル (``pPr/defRPr`` 経由) にも値を書き込むが、
+          authoritative な値は各 run の ``<a:rPr>`` に直接書き込む。これに
+          より Keynote / Google Slides / PowerPoint Online のような
+          ``defRPr`` を異なる優先順位で解決するクライアントでも意図した
+          サイズ・フォントで描画される (issue #28)。
+        - ``east_asian_font`` を指定した場合、各 run の ``rPr`` に
+          ``<a:ea typeface="…"/>`` を追加する (issue #40)。
+        - paragraph に run が存在しない場合は run レベル書き込みを skip する
+          (caller 側で p.text 等により run を追加している想定)。
+    """
     font = paragraph.font
     if font_name is not None:
         font.name = font_name
@@ -79,6 +112,26 @@ def _apply_font(
         font.italic = italic
     if underline is not None:
         font.underline = underline
+
+    # run レベルにも同じ属性を書き込む。これにより ``<a:r><a:rPr sz="…"/>``
+    # が確実に emit され、クライアント依存の resolve 経路に左右されない。
+    for run in paragraph.runs:
+        rfont = run.font
+        if font_name is not None:
+            rfont.name = font_name
+        if font_size is not None:
+            rfont.size = Pt(font_size)
+        if font_color is not None:
+            color_hex = resolve_color(theme, font_color) if theme else font_color
+            rfont.color.rgb = _parse_color(color_hex)
+        if bold is not None:
+            rfont.bold = bold
+        if italic is not None:
+            rfont.italic = italic
+        if underline is not None:
+            rfont.underline = underline
+        if east_asian_font is not None:
+            _set_east_asian_font(run, east_asian_font)
 
 
 def _apply_paragraph(
@@ -114,10 +167,17 @@ def _add_textbox(
     line_spacing=None,
     underline=None,
     theme=None,
+    east_asian_font=None,
 ):
-    """In-memory: add textbox to an existing slide object. Returns shape_index."""
+    """In-memory: add textbox to an existing slide object. Returns shape_index.
+
+    ``vertical_anchor`` は python-pptx の ``tf.vertical_anchor`` 経由で設定
+    する (issue #41)。直接 ``bodyPr.set("anchor", ...)`` を呼ぶと round-trip
+    で属性が重複する危険があるため、lxml 直接操作はしない。
+    """
     if theme:
         font_name = font_name or theme.fonts.get("body")
+        east_asian_font = east_asian_font or theme.fonts.get("east_asian")
         if font_color:
             font_color = resolve_color(theme, font_color)
 
@@ -128,15 +188,15 @@ def _add_textbox(
     tf.word_wrap = word_wrap
 
     if vertical_anchor and vertical_anchor in _ANCHOR_MAP:
-        from pptx.oxml.ns import qn
-        bodyPr = tf._txBody.find(qn("a:bodyPr"))
-        anchor_val = {"top": "t", "middle": "ctr", "bottom": "b"}[vertical_anchor]
-        bodyPr.set("anchor", anchor_val)
+        tf.vertical_anchor = _ANCHOR_MAP[vertical_anchor]
 
     p = tf.paragraphs[0]
     p.text = text
 
-    _apply_font(p, font_name, font_size, font_color, bold, italic, underline, theme=theme)
+    _apply_font(
+        p, font_name, font_size, font_color, bold, italic, underline,
+        theme=theme, east_asian_font=east_asian_font,
+    )
     _apply_paragraph(p, alignment, line_spacing)
 
     return len(list(slide.shapes)) - 1
@@ -525,6 +585,70 @@ def _fit_font_size(
     return min_size, height_est <= height
 
 
+def _strip_last_grapheme(s: str) -> str:
+    """``s`` の末尾 grapheme cluster (近似) を 1 つ除去した文字列を返す.
+
+    Unicode の正式な grapheme cluster は ``regex`` の ``\\X`` や ICU が必要
+    だが、stdlib のみで ``_truncate_to_fit`` が壊しやすいケース (ZWJ emoji
+    sequence / 結合文字 / variation selector) を安全に扱えるよう近似実装
+    する。具体的には:
+
+        1. 末尾から結合マーク (``unicodedata.combining(ch) != 0``)、
+           ZWJ/ZWNJ (``\u200C`` / ``\u200D``) を飛ばす。
+        2. その直前が base 文字なら 1 文字削る。さらに再度 (1) を行い、
+           削った base に付随する combining 系列も丸ごと落とす。
+        3. 削った結果に末尾 ZWJ が残る (ZWJ emoji sequence の途中) 場合
+           はそれも除去する。
+
+    Args:
+        s: 対象文字列。
+
+    Returns:
+        末尾 grapheme を除去した文字列。空文字列は空文字列を返す。
+
+    Issue:
+        #29 — code-unit ベースの切り詰めが ZWJ emoji や濁点などを半端に
+        残すのを防ぐ。
+    """
+    if not s:
+        return s
+
+    # (1) 末尾の combining / ZW-joiner / variation selector を飛ばして base を探す。
+    i = len(s)
+    while i > 0:
+        ch = s[i - 1]
+        cp = ord(ch)
+        if (
+            unicodedata.combining(ch) != 0
+            or cp in (0x200C, 0x200D)
+            or 0xFE00 <= cp <= 0xFE0F
+        ):
+            i -= 1
+            continue
+        break
+
+    # (2) base 文字を 1 つ落とす。全部 combiner だった場合は全削除となる。
+    if i > 0:
+        i -= 1
+
+    # (3) 残った末尾に ZWJ 等の「次の cluster を期待する」文字が残って
+    # いる場合はさらに剥がす (例: `A<ZWJ>B` を右から削るとき `A<ZWJ>`
+    # が中途半端に残らないようにする)。
+    while i > 0:
+        ch = s[i - 1]
+        cp = ord(ch)
+        if (
+            unicodedata.combining(ch) != 0
+            or cp in (0x200C, 0x200D)
+            or 0xFE00 <= cp <= 0xFE0F
+        ):
+            i -= 1
+            continue
+        break
+
+    return s[:i]
+
+
 def _truncate_to_fit(
     text: str,
     usable_width: float,
@@ -538,8 +662,8 @@ def _truncate_to_fit(
     方針:
     - まず wrap_text で折り返し結果を得る。
     - 高さが許す行数 ``max_lines`` を算出する。
-    - 最終行は末尾から 1 文字ずつ削りながら ``line + 省略記号`` の幅が
-      ``usable_width`` 以下になるまで縮める。
+    - 最終行は末尾から 1 grapheme cluster ずつ削りながら ``line + 省略記号``
+      の幅が ``usable_width`` 以下になるまで縮める (issue #29)。
     - ``max_lines == 0`` の場合は空文字列を返す。
     """
     line_h = size_pt * 0.0139 * _AUTO_FIT_LINE_HEIGHT
@@ -559,9 +683,14 @@ def _truncate_to_fit(
 
     retained = lines[:max_lines]
     last = retained[-1]
-    # last + ellipsis が usable_width を超える間、末尾から 1 文字ずつ削る。
+    # last + ellipsis が usable_width を超える間、末尾から grapheme
+    # cluster 単位で削る (code-unit 単位だと ZWJ emoji / 結合文字を壊す)。
     while last and estimate_text_width(last + _ELLIPSIS, size_pt, font_name) > usable_width:
-        last = last[:-1]
+        new_last = _strip_last_grapheme(last)
+        if new_last == last:
+            # 保険: 進まない場合は code unit で 1 文字削る。
+            new_last = last[:-1]
+        last = new_last
     retained[-1] = (last + _ELLIPSIS) if last else _ELLIPSIS
     return "\n".join(retained)
 
@@ -582,6 +711,7 @@ def add_auto_fit_textbox(
     align: str = "left",
     vertical_anchor: str = "top",
     truncate_with_ellipsis: bool = True,
+    east_asian_font: str | None = None,
 ) -> tuple[object, float]:
     """指定 box に収まる最大 font size でテキストを描画する.
 
@@ -639,6 +769,7 @@ def add_auto_fit_textbox(
         word_wrap=True,
         line_spacing=None,
         underline=None,
+        east_asian_font=east_asian_font,
     )
 
     shape = slide.shapes[idx]

--- a/src/pptx_mcp_server/theme.py
+++ b/src/pptx_mcp_server/theme.py
@@ -131,6 +131,9 @@ MCKINSEY = Theme(
     fonts={
         "title": "Arial",
         "body": "Arial",
+        # 明示的に east-asian typeface を指定し、非 JP Windows での中国語
+        # フォントへの自動 fallback を防ぐ (issue #40)。
+        "east_asian": "Yu Gothic",
     },
     sizes={
         "title": 22,
@@ -207,6 +210,9 @@ DELOITTE = Theme(
     fonts={
         "title": "Arial",
         "body": "Arial",
+        # 明示的に east-asian typeface を指定し、非 JP Windows での中国語
+        # フォントへの自動 fallback を防ぐ (issue #40)。
+        "east_asian": "Yu Gothic",
     },
     sizes={
         "title": 22,
@@ -276,6 +282,9 @@ NEUTRAL = Theme(
     fonts={
         "title": "Arial",
         "body": "Arial",
+        # 明示的に east-asian typeface を指定し、非 JP Windows での中国語
+        # フォントへの自動 fallback を防ぐ (issue #40)。
+        "east_asian": "Yu Gothic",
     },
     sizes={
         "title": 22,

--- a/tests/test_shapes_rendering.py
+++ b/tests/test_shapes_rendering.py
@@ -1,0 +1,279 @@
+"""shapes.py の rendering-quality 修正 (#28, #29, #40, #41) のテスト.
+
+1. 実 rPr への font size 書き込み (#28)
+2. grapheme-cluster 安全な truncation (#29)
+3. 明示的 east-asian typeface (#40)
+4. bodyPr anchor を python-pptx API 経由で設定 (#41)
+"""
+
+from __future__ import annotations
+
+import zipfile
+
+import pytest
+from pptx import Presentation
+from pptx.enum.text import MSO_ANCHOR
+from pptx.util import Inches
+
+from pptx_mcp_server.engine.pptx_io import save_pptx
+from pptx_mcp_server.engine.shapes import (
+    _A_NS,
+    _apply_font,
+    _strip_last_grapheme,
+    _truncate_to_fit,
+    _add_textbox,
+    add_auto_fit_textbox,
+)
+from pptx_mcp_server.engine.validation import _dominant_font_size
+from pptx_mcp_server.theme import MCKINSEY, DELOITTE, NEUTRAL
+
+
+# ── Issue #28: rPr に font size が書かれるか ───────────────────────
+
+
+def test_issue28_auto_fit_writes_run_level_font_size(slide):
+    """``add_auto_fit_textbox`` で生成した shape の全 run に
+    ``font.size`` が None でない値で設定されていること."""
+    shape, actual = add_auto_fit_textbox(
+        slide,
+        "Hello world",
+        left=1.0, top=1.0, width=5.0, height=2.0,
+        font_size_pt=10, min_size_pt=7,
+    )
+    assert actual == 10.0
+    runs = [r for p in shape.text_frame.paragraphs for r in p.runs]
+    assert runs, "shape には少なくとも 1 つ run が存在すべき"
+    for run in runs:
+        assert run.font.size is not None
+        assert run.font.size.pt == 10.0
+
+
+def test_issue28_saved_pptx_has_sz_on_every_rpr(tmp_path, slide, one_slide_prs):
+    """保存 → unzip → XML 検査で ``<a:r>`` 配下に ``<a:rPr sz="1000"/>`` が
+    毎回存在することを確認する."""
+    add_auto_fit_textbox(
+        slide,
+        "run level size test",
+        left=1.0, top=1.0, width=5.0, height=2.0,
+        font_size_pt=10, min_size_pt=7,
+    )
+    path = tmp_path / "out.pptx"
+    save_pptx(one_slide_prs, str(path))
+
+    import xml.etree.ElementTree as ET
+    ns = {"a": _A_NS}
+    with zipfile.ZipFile(str(path)) as zf:
+        xml_bytes = zf.read("ppt/slides/slide1.xml")
+    root = ET.fromstring(xml_bytes)
+    runs = root.findall(".//a:r", ns)
+    assert runs, "slide XML に run が 1 つ以上存在するはず"
+    for r in runs:
+        rPr = r.find("a:rPr", ns)
+        assert rPr is not None, "各 run に rPr が必要"
+        assert rPr.get("sz") == "1000", f"sz 属性が 1000 (=10pt) であるべき: {rPr.get('sz')}"
+
+
+def test_issue28_dominant_font_size_from_runs(slide):
+    """auto-fit で書いた shape に対し validator の ``_dominant_font_size``
+    が run 経由で正しく pt を返す (18 default に落ちない)."""
+    shape, actual = add_auto_fit_textbox(
+        slide,
+        "validator regression",
+        left=1.0, top=1.0, width=5.0, height=2.0,
+        font_size_pt=9, min_size_pt=7,
+    )
+    pt = _dominant_font_size(shape.text_frame, default_pt=18.0)
+    assert pt == 9.0
+
+
+# ── Issue #29: grapheme-cluster 安全な truncation ──────────────────
+
+
+def test_issue29_strip_last_grapheme_zwj_emoji():
+    """ZWJ emoji (家族絵文字) を末尾から 1 grapheme 削っても途中の
+    ``\\u200D`` が残らない."""
+    s = "hello 👨\u200D👩\u200D👧"
+    stripped = _strip_last_grapheme(s)
+    # 末尾が ZWJ で終わっていないこと。
+    assert not stripped.endswith("\u200D")
+    # ZWNJ も残らないこと。
+    assert not stripped.endswith("\u200C")
+
+
+def test_issue29_strip_last_grapheme_combining_mark():
+    """結合可能な濁点 ``\\u309B`` が単独で残らない."""
+    # `か` + 結合マーク U+3099 (濁点) = `が` の decomposed 表現。
+    s = "日本語か\u3099"
+    stripped = _strip_last_grapheme(s)
+    # 削った結果、末尾に combining 文字だけが残ることはない。
+    if stripped:
+        import unicodedata
+        assert unicodedata.combining(stripped[-1]) == 0
+
+
+def test_issue29_strip_last_grapheme_variation_selector():
+    """variation selector (U+FE0F) が単独で残らない."""
+    s = "A\u2764\ufe0f"  # ハート + VS-16
+    stripped = _strip_last_grapheme(s)
+    if stripped:
+        cp = ord(stripped[-1])
+        assert not (0xFE00 <= cp <= 0xFE0F)
+
+
+def test_issue29_strip_last_grapheme_plain_ascii():
+    """単純な ASCII では末尾 1 文字が削られる."""
+    assert _strip_last_grapheme("abcde") == "abcd"
+    assert _strip_last_grapheme("a") == ""
+    assert _strip_last_grapheme("") == ""
+
+
+def test_issue29_truncate_does_not_leave_zwj_dangling():
+    """``_truncate_to_fit`` に ZWJ emoji sequence を含むテキストを与え、
+    切り詰めた結果が dangling ZWJ で終わらない."""
+    text = "normal text 👨\u200D👩\u200D👧"
+    # 極端に狭い box で確実に truncate させる。
+    result = _truncate_to_fit(text, usable_width=0.5, height=0.2,
+                              font_name="Arial", size_pt=10)
+    # 末尾が ellipsis であればその直前に ZWJ が残っていないこと。
+    if result.endswith("\u2026"):
+        before_ellipsis = result[:-1]
+        assert not before_ellipsis.endswith("\u200D")
+        assert not before_ellipsis.endswith("\u200C")
+
+
+def test_issue29_truncate_plain_ascii_regression(slide):
+    """プレーン ASCII の切り詰めが従来どおり動作する (regression)."""
+    result = _truncate_to_fit("abcdefghijklmnopqrstuvwxyz" * 4,
+                              usable_width=0.5, height=0.2,
+                              font_name="Arial", size_pt=10)
+    # 1 行以内に丸められ ellipsis で終わる。
+    assert result.endswith("\u2026")
+
+
+# ── Issue #40: 明示的 east-asian typeface ─────────────────────────
+
+
+def test_issue40_theme_slots_populated():
+    """McKinsey / Deloitte / Neutral テーマに east_asian が設定済み."""
+    for theme in (MCKINSEY, DELOITTE, NEUTRAL):
+        assert "east_asian" in theme.fonts
+        assert theme.fonts["east_asian"]
+
+
+def test_issue40_apply_font_emits_ea(slide):
+    """``_apply_font(..., east_asian_font=...)`` が各 run の rPr に
+    ``<a:ea typeface="…"/>`` を設定する."""
+    from pptx_mcp_server.engine.shapes import _add_textbox
+    _add_textbox(slide, 1.0, 1.0, 5.0, 1.0, text="日本語テキスト")
+    # 再度 apply_font で east-asian を設定。
+    shape = slide.shapes[-1]
+    p = shape.text_frame.paragraphs[0]
+    _apply_font(p, font_name="Arial", east_asian_font="Yu Gothic")
+    for run in p.runs:
+        rPr = run._r.find(f"{{{_A_NS}}}rPr")
+        assert rPr is not None
+        ea = rPr.find(f"{{{_A_NS}}}ea")
+        assert ea is not None
+        assert ea.get("typeface") == "Yu Gothic"
+
+
+def test_issue40_auto_fit_with_east_asian_font(slide):
+    """auto-fit textbox に east_asian_font を渡すと runs に emit される."""
+    shape, _ = add_auto_fit_textbox(
+        slide,
+        "日本語テスト",
+        left=1.0, top=1.0, width=5.0, height=2.0,
+        font_size_pt=11, min_size_pt=7,
+        east_asian_font="Meiryo",
+    )
+    runs = [r for p in shape.text_frame.paragraphs for r in p.runs]
+    assert runs
+    for run in runs:
+        rPr = run._r.find(f"{{{_A_NS}}}rPr")
+        assert rPr is not None
+        ea = rPr.find(f"{{{_A_NS}}}ea")
+        assert ea is not None
+        assert ea.get("typeface") == "Meiryo"
+
+
+def test_issue40_no_ea_when_not_requested(slide):
+    """``east_asian_font=None`` のデフォルト挙動では ``<a:ea>`` を
+    emit しない (後方互換)."""
+    shape, _ = add_auto_fit_textbox(
+        slide,
+        "no ea expected",
+        left=1.0, top=1.0, width=5.0, height=2.0,
+        font_size_pt=11, min_size_pt=7,
+    )
+    runs = [r for p in shape.text_frame.paragraphs for r in p.runs]
+    for run in runs:
+        rPr = run._r.find(f"{{{_A_NS}}}rPr")
+        if rPr is None:
+            continue
+        ea = rPr.find(f"{{{_A_NS}}}ea")
+        assert ea is None
+
+
+def test_issue40_add_textbox_picks_east_asian_from_theme(slide, mckinsey_theme):
+    """``_add_textbox`` に theme を渡すと ``theme.fonts['east_asian']``
+    が自動で適用される."""
+    _add_textbox(
+        slide, 1.0, 1.0, 5.0, 1.0,
+        text="テーマからの ea",
+        theme=mckinsey_theme,
+    )
+    shape = slide.shapes[-1]
+    runs = [r for p in shape.text_frame.paragraphs for r in p.runs]
+    assert runs
+    for run in runs:
+        rPr = run._r.find(f"{{{_A_NS}}}rPr")
+        assert rPr is not None
+        ea = rPr.find(f"{{{_A_NS}}}ea")
+        assert ea is not None
+        assert ea.get("typeface") == mckinsey_theme.fonts["east_asian"]
+
+
+# ── Issue #41: bodyPr anchor を python-pptx API 経由で設定 ───────
+
+
+@pytest.mark.parametrize("anchor,expected", [
+    ("top", MSO_ANCHOR.TOP),
+    ("middle", MSO_ANCHOR.MIDDLE),
+    ("bottom", MSO_ANCHOR.BOTTOM),
+])
+def test_issue41_anchor_set_via_python_pptx_api(slide, anchor, expected):
+    """3 つの anchor 値が MSO_ANCHOR enum 経由で設定される."""
+    _add_textbox(slide, 1.0, 1.0, 5.0, 1.0,
+                 text="anchor test", vertical_anchor=anchor)
+    shape = slide.shapes[-1]
+    assert shape.text_frame.vertical_anchor == expected
+
+
+def test_issue41_anchor_round_trip(tmp_path, slide, one_slide_prs):
+    """save → reopen で anchor 値が保持される."""
+    _add_textbox(slide, 1.0, 1.0, 5.0, 1.0,
+                 text="roundtrip", vertical_anchor="middle")
+    path = tmp_path / "anchor.pptx"
+    save_pptx(one_slide_prs, str(path))
+
+    reopened = Presentation(str(path))
+    tf = reopened.slides[0].shapes[-1].text_frame
+    assert tf.vertical_anchor == MSO_ANCHOR.MIDDLE
+
+
+def test_issue41_no_duplicate_anchor_attrs(tmp_path, slide, one_slide_prs):
+    """保存 XML 内の ``<a:bodyPr>`` に anchor 属性が重複しない."""
+    _add_textbox(slide, 1.0, 1.0, 5.0, 1.0,
+                 text="dup check", vertical_anchor="middle")
+    path = tmp_path / "dup.pptx"
+    save_pptx(one_slide_prs, str(path))
+
+    import xml.etree.ElementTree as ET
+    ns = {"a": _A_NS}
+    with zipfile.ZipFile(str(path)) as zf:
+        xml_bytes = zf.read("ppt/slides/slide1.xml")
+    root = ET.fromstring(xml_bytes)
+    for bodyPr in root.findall(".//a:bodyPr", ns):
+        # attribute key の duplicates はそもそも XML として成立しないが、
+        # anchor 属性が 1 つだけ、値が想定通りであることを確認する。
+        assert bodyPr.get("anchor") in (None, "t", "ctr", "b")


### PR DESCRIPTION
## Summary

Bundle of four cross-client rendering-quality fixes for `engine/shapes.py` (+ one theme slot).

- **#28** — `_apply_font` now writes size/name/color/bold/italic/underline on each run's `<a:rPr>`, not just `pPr/defRPr`. Restores correct rendering under Keynote / Google Slides / PowerPoint Online and lets the validator's `_dominant_font_size` resolve via `run.font.size`.
- **#29** — `_truncate_to_fit` trims by grapheme-cluster approximation (`_strip_last_grapheme` walks back past combining marks, ZWJ/ZWNJ, and variation selectors) so ZWJ emoji sequences and decomposed dakuten no longer leave dangling halves. Stdlib-only; no `regex` dep.
- **#40** — New `_set_east_asian_font` helper appends `<a:ea typeface="…"/>` via lxml. `_apply_font` / `_add_textbox` / `add_auto_fit_textbox` take an optional `east_asian_font` kwarg (default `None` = don't emit `<a:ea>`). Themes gain `fonts["east_asian"] = "Yu Gothic"` for the three built-ins, and `_add_textbox` pulls it from the theme automatically when one is supplied.
- **#41** — `_add_textbox` replaces the direct `bodyPr.set("anchor", ...)` lxml call with `tf.vertical_anchor = _ANCHOR_MAP[...]`, matching the pattern `add_auto_fit_textbox` already used.

All public signatures remain backward compatible.

## Test plan

- [x] `tests/test_shapes_rendering.py` — 19 new tests covering all four issues (run-level `sz`, ZWJ/combining-mark truncation, `<a:ea>` emission, anchor round-trip).
- [x] Full suite: `python -m pytest -q` → **388 passed** (369 prior + 19 new).
- [x] Validator regression: body shapes on a responsive card row now report the actual small `pt` (10pt) via `_dominant_font_size`, instead of falling back to 18pt default.

Closes #28
Closes #29
Closes #40
Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)