### PR TITLE
fix(packaging): move mcp to optional extras (closes #36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,22 @@ composite layouts, and slide rendering -- all accessible via the Model Context P
 
 ## Installation
 
+`pptx-mcp-server` ships with two install paths: a minimal library install for
+driving the engine programmatically, and an `[mcp]` extra for running the MCP
+server CLI.
+
 ```bash
+# Library usage (no MCP runtime — only python-pptx + lxml):
 pip install pptx-mcp-server
+
+# MCP server (includes the mcp SDK):
+pip install 'pptx-mcp-server[mcp]'
 ```
+
+The MCP SDK lives behind the `[mcp]` extra so that pure-library consumers do
+not pay for the MCP SDK + anyio transitive dependencies at install time. The
+`pptx-mcp-server` CLI and `pptx_mcp_server.server` module require the `[mcp]`
+extra; importing them without it raises a clear ImportError pointing back here.
 
 ## Claude Desktop Configuration
 
@@ -44,13 +57,14 @@ without starting an MCP server. The `engine` and `theme` modules have no
 dependency on the MCP SDK at import time, so you can build decks from scripts,
 notebooks, or batch jobs.
 
-Install it the same way you would any other package:
+Install it the same way you would any other package — the bare install does
+not pull the MCP SDK:
 
 ```bash
-# From PyPI (once published)
+# From PyPI (once published) — library only:
 pip install pptx-mcp-server
 
-# From a local checkout (editable install during development)
+# From a local checkout (editable install during development):
 pip install -e /path/to/pptx-mcp-server
 ```
 
@@ -79,9 +93,12 @@ prs = open_pptx(out)
 print(f"Slides: {len(prs.slides)}")
 ```
 
-The `mcp` SDK is still listed in `dependencies` so that the `pptx-mcp-server`
-entry point works out of the box, but nothing in `pptx_mcp_server.engine` or
-`pptx_mcp_server.theme` imports it — a CI guardrail test enforces this.
+The `mcp` SDK is an **optional** extra (`pip install 'pptx-mcp-server[mcp]'`)
+and is only required when launching the `pptx-mcp-server` CLI / importing
+`pptx_mcp_server.server`. Nothing in `pptx_mcp_server.engine` or
+`pptx_mcp_server.theme` imports it — an AST-level CI guardrail in
+`tests/test_library_usage.py` enforces that, and
+`tests/test_packaging_extras.py` enforces the packaging side of the split.
 
 ## Tools
 
@@ -142,11 +159,17 @@ entry point works out of the box, but nothing in `pptx_mcp_server.engine` or
 
 ## Dependencies
 
+Required (installed by `pip install pptx-mcp-server`):
+
 - [python-pptx](https://python-pptx.readthedocs.io/) -- PPTX file manipulation
 - [lxml](https://lxml.de/) -- XML processing
-- [mcp](https://modelcontextprotocol.io/) -- Model Context Protocol SDK
 
-### Optional
+Optional extra (installed by `pip install 'pptx-mcp-server[mcp]'`):
+
+- [mcp](https://modelcontextprotocol.io/) -- Model Context Protocol SDK
+  (required only for the `pptx-mcp-server` CLI / `pptx_mcp_server.server`)
+
+### System tools
 
 - **LibreOffice** -- required for `pptx_render_slide` (PPTX to PDF conversion).
   Install with `brew install --cask libreoffice` (macOS) or your system package manager.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,12 @@ classifiers = [
     "Topic :: Office/Business",
 ]
 dependencies = [
-    "mcp>=1.0.0",
     "python-pptx>=1.0.0",
     "lxml>=4.0.0",
 ]
+
+[project.optional-dependencies]
+mcp = ["mcp>=1.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/knorq/pptx-mcp-server"

--- a/src/pptx_mcp_server/__init__.py
+++ b/src/pptx_mcp_server/__init__.py
@@ -1,5 +1,17 @@
+from __future__ import annotations
+
+
 def main():
-    from .server import main as _main
-    _main()
+    try:
+        from .server import main as _server_main
+    except ImportError as e:
+        if "mcp" in str(e).lower():
+            raise ImportError(
+                "pptx-mcp-server CLI requires the 'mcp' extra. "
+                "Install with: pip install 'pptx-mcp-server[mcp]'"
+            ) from e
+        raise
+    return _server_main()
+
 
 __all__ = ["main"]

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -5,7 +5,13 @@ pptx-mcp-server -- MCP server for PPTX presentation editing.
 
 import json
 
-from mcp.server.fastmcp import FastMCP
+try:
+    from mcp.server.fastmcp import FastMCP
+except ImportError as e:
+    raise ImportError(
+        "pptx_mcp_server.server requires the 'mcp' package. "
+        "Install with: pip install 'pptx-mcp-server[mcp]'"
+    ) from e
 
 from .engine import (
     EngineError,

--- a/tests/test_packaging_extras.py
+++ b/tests/test_packaging_extras.py
@@ -1,0 +1,187 @@
+"""
+Packaging guardrail tests for the ``mcp`` optional extra (issue #36).
+
+These tests back up the AST-level decoupling in ``tests/test_library_usage.py``
+with install-time assertions, so that ``pip install pptx-mcp-server`` stays
+lean for library consumers and only ``pip install 'pptx-mcp-server[mcp]'``
+pulls the MCP SDK + anyio transitive deps.
+
+Limitation
+----------
+In this test environment the ``mcp`` package IS importable (it is installed
+for the MCP server test suite), so we cannot truly simulate a fresh venv
+without ``mcp``. The AST guardrail in ``test_library_usage.py`` already proves
+source-level decoupling; the subprocess-based test below shadows the ``mcp``
+import to verify the helpful error path surfaces.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+
+def _load_pyproject() -> dict:
+    return tomllib.loads(PYPROJECT.read_text())
+
+
+def test_pyproject_declares_mcp_optional_extra() -> None:
+    """``[project.optional-dependencies]`` must define an ``mcp`` entry."""
+    data = _load_pyproject()
+    extras = data.get("project", {}).get("optional-dependencies", {})
+    assert "mcp" in extras, (
+        "expected [project.optional-dependencies] to define an 'mcp' extra; "
+        f"got keys: {sorted(extras)}"
+    )
+    mcp_extra = extras["mcp"]
+    assert any(req.startswith("mcp") for req in mcp_extra), (
+        f"'mcp' extra must pin the mcp package; got: {mcp_extra!r}"
+    )
+
+
+def test_pyproject_required_dependencies_exclude_mcp() -> None:
+    """``mcp`` must not appear in required ``[project] dependencies``."""
+    data = _load_pyproject()
+    deps = data.get("project", {}).get("dependencies", [])
+    offenders = [d for d in deps if d.split()[0].split(">=")[0].split("==")[0].strip() == "mcp"]
+    assert not offenders, (
+        "mcp must be an optional extra, not a required dependency; "
+        f"found in [project] dependencies: {offenders!r}"
+    )
+
+
+def test_pyproject_keeps_core_dependencies_required() -> None:
+    """``python-pptx`` and ``lxml`` must remain required (not moved to extras)."""
+    data = _load_pyproject()
+    deps = data.get("project", {}).get("dependencies", [])
+    roots = {d.split(">=")[0].split("==")[0].strip() for d in deps}
+    assert "python-pptx" in roots, f"python-pptx must stay required; got {deps!r}"
+    assert "lxml" in roots, f"lxml must stay required; got {deps!r}"
+
+
+@pytest.mark.parametrize(
+    "dotted",
+    [
+        "pptx_mcp_server.engine.shapes",
+        "pptx_mcp_server.theme",
+        "pptx_mcp_server.engine.text_metrics",
+    ],
+)
+def test_library_consumer_modules_import_without_mcp_reference(dotted: str) -> None:
+    """Library-path modules must import successfully standalone.
+
+    NOTE: this test environment already has ``mcp`` installed, so this check
+    cannot prove dependency-free behaviour on its own. The AST guardrail in
+    ``tests/test_library_usage.py::test_engine_has_no_mcp_imports`` proves the
+    source-level split; this test is a simple smoke check that the dotted
+    module paths still resolve.
+    """
+    mod = importlib.import_module(dotted)
+    assert mod is not None
+
+
+def test_server_import_without_mcp_raises_helpful_error() -> None:
+    """If ``mcp`` is absent, importing ``pptx_mcp_server.server`` must raise a
+    clear ImportError pointing at ``pip install 'pptx-mcp-server[mcp]'``.
+
+    We simulate absence via a subprocess that injects a ``sitecustomize``-style
+    import hook that makes any ``mcp``/``mcp.*`` import fail with
+    ``ModuleNotFoundError``.
+    """
+    script = r"""
+import sys
+import importlib.abc
+import importlib.machinery
+
+
+class _BlockMcp(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "mcp" or fullname.startswith("mcp."):
+            raise ModuleNotFoundError(f"No module named {fullname!r}")
+        return None
+
+
+# Purge any already-cached mcp modules, then install the blocker first.
+for name in list(sys.modules):
+    if name == "mcp" or name.startswith("mcp."):
+        del sys.modules[name]
+sys.meta_path.insert(0, _BlockMcp())
+
+try:
+    import pptx_mcp_server.server  # noqa: F401
+except ImportError as e:
+    msg = str(e)
+    assert "mcp" in msg.lower(), f"error message missing 'mcp' hint: {msg!r}"
+    assert "pptx-mcp-server[mcp]" in msg, (
+        f"error message must point at the extra; got: {msg!r}"
+    )
+    print("OK")
+else:
+    raise AssertionError("expected ImportError when mcp is shadowed, got none")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed\nstdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    assert "OK" in result.stdout, f"unexpected stdout: {result.stdout!r}"
+
+
+def test_package_main_without_mcp_raises_helpful_error() -> None:
+    """The top-level ``pptx_mcp_server.main`` entry point must surface the
+    same helpful error when ``mcp`` is not importable."""
+    script = r"""
+import sys
+import importlib.abc
+import importlib.machinery
+
+
+class _BlockMcp(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "mcp" or fullname.startswith("mcp."):
+            raise ModuleNotFoundError(f"No module named {fullname!r}")
+        return None
+
+
+for name in list(sys.modules):
+    if name == "mcp" or name.startswith("mcp."):
+        del sys.modules[name]
+sys.meta_path.insert(0, _BlockMcp())
+
+import pptx_mcp_server
+
+try:
+    pptx_mcp_server.main()
+except ImportError as e:
+    msg = str(e)
+    assert "mcp" in msg.lower(), f"error missing 'mcp' hint: {msg!r}"
+    assert "pptx-mcp-server[mcp]" in msg, (
+        f"error must point at the extra; got: {msg!r}"
+    )
+    print("OK")
+else:
+    raise AssertionError("expected ImportError from main() when mcp is shadowed")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed\nstdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    assert "OK" in result.stdout, f"unexpected stdout: {result.stdout!r}"


### PR DESCRIPTION
## Summary

Closes #36.

- Move `mcp>=1.0.0` from required `[project] dependencies` to a new `[project.optional-dependencies] mcp` extra, so `pip install pptx-mcp-server` no longer pulls the MCP SDK + anyio for pure-library consumers.
- Guard `mcp.server.fastmcp` import at the top of `src/pptx_mcp_server/server.py` and in `pptx_mcp_server.main()`; both raise a clear `ImportError` pointing at `pip install 'pptx-mcp-server[mcp]'` when the extra is missing.
- Update `README.md` to document the two install paths and note the CLI/server require the `[mcp]` extra.
- Add `tests/test_packaging_extras.py` (8 tests) covering pyproject shape, core-dep retention, library-module resolution, and subprocess-based simulation that shadows the `mcp` import to verify the helpful error path from both `pptx_mcp_server.server` and `pptx_mcp_server.main()`.

The existing AST guardrail in `tests/test_library_usage.py::test_engine_has_no_mcp_imports` continues to prove source-level decoupling; this change closes the packaging side of the same split.

## What did NOT change

- `python-pptx` and `lxml` stay required.
- `[project.scripts] pptx-mcp-server = "pptx_mcp_server:main"` entry point stays; invoking it without `[mcp]` raises the helpful error (same UX as scipy CLIs that depend on optional extras).
- No package rename, no PyPI publish.

## Test plan

- [x] `python -m pytest` — **427 passed** (baseline 419 + 8 new packaging tests).
- [x] Fresh venv manual verification (see below).

## Fresh-venv manual verification

```bash
python3 -m venv /tmp/fresh-venv-36
/tmp/fresh-venv-36/bin/pip install .
```

**Installed packages (no `mcp`, no `anyio`):**
```
Successfully installed Pillow-12.2.0 XlsxWriter-3.2.9 lxml-6.1.0
pptx-mcp-server-0.1.0 python-pptx-1.0.2 typing-extensions-4.15.0
```

**Step 2 — library import succeeds:**
```
$ /tmp/fresh-venv-36/bin/python -c "from pptx_mcp_server.engine.shapes import add_textbox; print('ok')"
ok
```

**Step 3 — server import fails with helpful message:**
```
$ /tmp/fresh-venv-36/bin/python -c "import pptx_mcp_server.server"
...
ModuleNotFoundError: No module named 'mcp'
The above exception was the direct cause of the following exception:
...
ImportError: pptx_mcp_server.server requires the 'mcp' package.
Install with: pip install 'pptx-mcp-server[mcp]'
```

**Step 3b — `pptx_mcp_server.main()` also raises the helpful error:**
```
$ /tmp/fresh-venv-36/bin/python -c "import pptx_mcp_server; pptx_mcp_server.main()"
...
ImportError: pptx-mcp-server CLI requires the 'mcp' extra.
Install with: pip install 'pptx-mcp-server[mcp]'
```

**Step 4 — install the extra and re-import:**
```
$ /tmp/fresh-venv-36/bin/pip install '.[mcp]'
Successfully installed annotated-types-0.7.0 anyio-4.13.0 ... mcp-1.27.0 ...

$ /tmp/fresh-venv-36/bin/python -c "import pptx_mcp_server.server; print('server import ok')"
server import ok
```

All four steps pass.