### PR TITLE
fix(validation): heuristic unreadable whitelist + anchor-aware divider collision

### DIFF
--- a/src/pptx_mcp_server/engine/validation.py
+++ b/src/pptx_mcp_server/engine/validation.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field, asdict
 from typing import Any, Dict, List, Optional, Tuple
 
 from pptx import Presentation
+from pptx.enum.text import MSO_ANCHOR
 from pptx.util import Emu
 
 from .text_metrics import estimate_text_height, estimate_text_width
@@ -440,17 +441,100 @@ def check_text_overflow(
     return findings
 
 
+def _matches_whitelist_names(name: str, whitelist_names: Optional[List[str]]) -> bool:
+    """``whitelist_names`` の任意要素が ``name`` に部分一致するかを返す.
+
+    大文字小文字を区別しない。``whitelist_names`` が None/空の場合は False。
+    """
+    if not whitelist_names:
+        return False
+    lowered = (name or "").lower()
+    for needle in whitelist_names:
+        if not needle:
+            continue
+        if needle.lower() in lowered:
+            return True
+    return False
+
+
+def _is_footer_zone_shape(
+    shape,
+    text_frame,
+    slide_height: float,
+    min_readable_pt: float,
+) -> bool:
+    """フッタゾーン (スライド下端 0.6" 以内) にある小型テキストかをヒューリスティックで判定する.
+
+    条件 (すべて満たす場合に True):
+        1. shape の bounding box 上端が ``slide_height - 0.6`` 以上
+           (すなわち底辺から 0.6" 以内に完全に収まる)
+        2. 推定折返し後の行数 ≤ 3
+        3. 代表フォントサイズが ``min_readable_pt - 1`` 以上
+           (極小フォントはフッタ扱いせず別途 unreadable で検出する)
+
+    名前ベースのホワイトリストを補完するために用いる。
+    """
+    try:
+        s_top = _emu_to_in(shape.top)
+        s_height = _emu_to_in(shape.height)
+        s_width = _emu_to_in(shape.width)
+    except Exception:
+        return False
+    # bbox が完全に底辺 0.6" 以内に収まるか
+    if s_top < slide_height - 0.6:
+        return False
+
+    # 代表フォント pt
+    max_pt: Optional[float] = None
+    for para in text_frame.paragraphs:
+        pt = _effective_paragraph_size(para, default_pt=min_readable_pt)
+        if max_pt is None or pt > max_pt:
+            max_pt = pt
+    if max_pt is None:
+        max_pt = min_readable_pt
+    if max_pt < min_readable_pt - 1:
+        return False
+
+    # 行数 (段落ごとに折返し推定)
+    usable_width = max(0.1, s_width - 0.10)
+    total_lines = 0
+    for para in text_frame.paragraphs:
+        text = _paragraph_text(para)
+        if not text:
+            total_lines += 1
+            continue
+        pt = _effective_paragraph_size(para, default_pt=max_pt)
+        # estimate_text_height は pt × 0.0139 × 1.2 × n_lines 相当
+        line_h = max(pt * 0.0139 * 1.2, 0.01)
+        h = estimate_text_height(text, usable_width, pt)
+        n_lines = max(1, int(round(h / line_h)))
+        total_lines += n_lines
+        if total_lines > 3:
+            return False
+    if total_lines > 3:
+        return False
+    return True
+
+
 def check_unreadable_text(
     presentation: Presentation,
     *,
     min_readable_pt: float = 8.0,
+    whitelist_names: Optional[List[str]] = None,
 ) -> List[ValidationFinding]:
     """``min_readable_pt`` 未満の font サイズを警告する.
 
-    shape 名に ``footer`` / ``page_number`` / ``source`` / ``footnote`` を
-    含む shape は (大文字小文字を区別せず) 除外する。
+    以下のいずれかに該当する shape は検査対象から除外する:
+
+    1. ``whitelist_names`` (呼び出し側が明示した部分一致リスト) に shape 名が
+       部分一致する (大文字小文字を区別しない)。日本語名のフッタ等にも対応する。
+    2. フッタゾーン ヒューリスティック (``_is_footer_zone_shape``) に合致する
+       (底辺 0.6" 以内に収まり、行数 ≤ 3、フォントが ``min_readable_pt - 1`` 以上)。
+    3. shape 名に ``footer`` / ``page_number`` / ``source`` / ``footnote`` を
+       含む (英語既定の正規表現フォールバック、後方互換)。
     """
     findings: List[ValidationFinding] = []
+    slide_height_in = _emu_to_in(presentation.slide_height)
 
     for slide_index, slide in enumerate(presentation.slides):
         for shape_i, shape in enumerate(slide.shapes):
@@ -459,10 +543,18 @@ def check_unreadable_text(
             if not shape.has_text_frame:
                 continue
             name = _shape_name(shape, f"Shape {shape_i}")
+            # 1. 明示 whitelist (substring, case-insensitive)
+            if _matches_whitelist_names(name, whitelist_names):
+                continue
+            # 3. 既存英語正規表現フォールバック
             if _UNREADABLE_WHITELIST_RE.search(name or ""):
                 continue
 
             tf = shape.text_frame
+
+            # 2. フッタゾーン ヒューリスティック
+            if _is_footer_zone_shape(shape, tf, slide_height_in, min_readable_pt):
+                continue
             smallest: Optional[float] = None
             # run に明示された size を優先、無い場合は段落の実効サイズを見る
             for para in tf.paragraphs:
@@ -505,14 +597,56 @@ def check_unreadable_text(
     return findings
 
 
+def _get_vertical_anchor(text_frame) -> Any:
+    """text_frame の ``vertical_anchor`` を安全に取得する.
+
+    未設定または例外時は ``None`` を返す (呼び出し側で TOP 相当に扱う)。
+    """
+    try:
+        return text_frame.vertical_anchor
+    except Exception:
+        return None
+
+
+def _projected_text_range(
+    shape, text_frame, needed_height: float
+) -> Tuple[float, float]:
+    """text_frame の vertical_anchor に基づいた実描画垂直範囲 (top, bottom) を返す.
+
+    - ``TOP`` (または未設定/None): ``[s_top, s_top + needed_height]``
+    - ``BOTTOM``: ``[s_bottom - needed_height, s_bottom]``
+    - ``MIDDLE``: ``[s_center - needed_height/2, s_center + needed_height/2]``
+
+    戻り値は inches の (top, bottom) タプル。
+    """
+    s_top = _emu_to_in(shape.top)
+    s_height = _emu_to_in(shape.height)
+    s_bottom = s_top + s_height
+    s_center = s_top + s_height / 2.0
+
+    anchor = _get_vertical_anchor(text_frame)
+    if anchor == MSO_ANCHOR.BOTTOM:
+        return (s_bottom - needed_height, s_bottom)
+    if anchor == MSO_ANCHOR.MIDDLE:
+        half = needed_height / 2.0
+        return (s_center - half, s_center + half)
+    # TOP / None / unset → TOP 相当
+    return (s_top, s_top + needed_height)
+
+
 def check_divider_collision(
     presentation: Presentation,
 ) -> List[ValidationFinding]:
     """タイトル直下の divider line にタイトルテキストが食い込まないかを検証する.
 
     divider 条件: 高さ < 0.05" かつ 幅 > 2"。
-    その上 0.5" 以内に存在する text frame について、推定高さが
-    ``divider.top - 0.02"`` を越えたら ``error`` finding。
+    その上 0.5" 以内に存在する text frame について、vertical_anchor を考慮した
+    投影範囲 (``_projected_text_range``) が divider 帯と交差したら
+    ``error`` finding を返す。
+
+    bottom-anchor の場合 (McKinsey 風タイトル: y=0.45..0.95 を anchor=bottom で
+    テキストが上方向に伸びる) は、``s_bottom <= divider_top`` の限り
+    collision とみなさない。
     """
     findings: List[ValidationFinding] = []
 
@@ -555,10 +689,33 @@ def check_divider_collision(
                 needed_height, font_size = _estimate_frame_needed_height(
                     tf, frame_width
                 )
-                projected_bottom = s_top + needed_height
+                proj_top, proj_bottom = _projected_text_range(
+                    shape, tf, needed_height
+                )
                 limit = d_top - 0.02
 
-                if projected_bottom > limit:
+                # divider 帯との交差判定 (projected range が divider 上端を
+                # 越えて食い込むか)。divider 自体の厚みは 0.05" 未満なので
+                # ``limit`` (= d_top - 0.02) を越えたら error とする。
+                anchor = _get_vertical_anchor(tf)
+                collides = False
+                if anchor == MSO_ANCHOR.BOTTOM:
+                    # bottom-anchor: テキストは上方向に伸びる。
+                    # s_bottom (= proj_bottom) が divider top を越えて、
+                    # かつ proj_top が divider top より上にあるときのみ衝突。
+                    # s_bottom <= d_top の場合は絶対に衝突しない。
+                    if proj_bottom > d_top and proj_top < d_top:
+                        collides = True
+                elif anchor == MSO_ANCHOR.MIDDLE:
+                    # center 基準の投影範囲が divider 上端を跨ぐ場合に衝突
+                    if proj_bottom > limit:
+                        collides = True
+                else:
+                    # TOP (既定): 従来どおり bottom が limit を越えたら衝突
+                    if proj_bottom > limit:
+                        collides = True
+
+                if collides:
                     name = _shape_name(shape, f"Shape {shape_i}")
                     div_name = _shape_name(div_shape, "Divider")
                     findings.append(
@@ -568,7 +725,7 @@ def check_divider_collision(
                             shape_name=name,
                             category="divider_collision",
                             message=(
-                                f"text extends to {projected_bottom:.2f}\" "
+                                f"text extends to {proj_bottom:.2f}\" "
                                 f"overlapping divider '{div_name}' at "
                                 f"{d_top:.2f}\" (limit {limit:.2f}\")"
                             ),
@@ -726,6 +883,7 @@ def check_deck_extended(
     overflow_tolerance_pct: float = 5.0,
     axis_tolerance: float = 0.1,
     gap_tolerance: float = 0.05,
+    whitelist_names: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """deck 全体を走査し、既存 + 拡張チェックをまとめて返す.
 
@@ -777,6 +935,7 @@ def check_deck_extended(
     unreadable = check_unreadable_text(
         presentation,
         min_readable_pt=min_readable_pt,
+        whitelist_names=whitelist_names,
     )
     divider = check_divider_collision(presentation)
     gaps = check_inconsistent_gaps(

--- a/tests/test_validation_extended.py
+++ b/tests/test_validation_extended.py
@@ -10,10 +10,13 @@ import pytest
 from pptx import Presentation
 from pptx.util import Inches, Pt
 
+from pptx.enum.text import MSO_ANCHOR
+
 from pptx_mcp_server.engine.validation import (
     ValidationFinding,
     _axis_groups,
     _effective_paragraph_size,
+    _projected_text_range,
     check_deck_extended,
     check_divider_collision,
     check_inconsistent_gaps,
@@ -445,3 +448,229 @@ class TestParagraphSizeResolution:
         _add_textbox(slide, 1.0, 1.0, 2.0, 0.5, long_jp, font_pt=18, name="OverflowBox")
         findings = check_text_overflow(one_slide_prs)
         assert any(f.shape_name == "OverflowBox" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# Issue #44: unreadable whitelist by heuristic and explicit names
+# ---------------------------------------------------------------------------
+
+
+class TestUnreadableWhitelistExtended:
+    """``check_unreadable_text`` の whitelist_names / heuristic 除外の検証."""
+
+    def test_japanese_footer_heuristic_excluded(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # 脚注: スライド底辺から 0.6" 以内 (y=7.1, slide_h=7.5 → top は 7.1, bbox 完全に下 0.4")
+        # 6pt (= min_readable_pt - 2) は閾値 min_readable_pt - 1 を下回るため
+        # ヒューリスティックで除外されない。フォント 7pt (= 8 - 1) に調整して
+        # フッタ ヒューリスティック該当にする。
+        slide = one_slide_prs.slides[0]
+        _add_textbox(
+            slide, 0.9, 7.1, 3.0, 0.3, "出典: 社内資料",
+            font_pt=7, name="脚注",
+        )
+        findings = check_unreadable_text(one_slide_prs)
+        assert findings == []
+
+    def test_japanese_footer_6pt_still_flagged_by_heuristic(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # 6pt は min_readable_pt - 1 を下回るので heuristic は救わない。
+        # ただし明示 whitelist_names=["脚注"] を渡せば除外できることを次のテストで担保。
+        slide = one_slide_prs.slides[0]
+        _add_textbox(
+            slide, 0.9, 7.1, 3.0, 0.3, "出典: 社内資料",
+            font_pt=6, name="脚注",
+        )
+        findings = check_unreadable_text(one_slide_prs)
+        # 6pt の「脚注」は heuristic の font しきい値を外れるため警告が出る
+        assert len(findings) == 1
+        assert findings[0].shape_name == "脚注"
+
+    def test_japanese_footer_6pt_whitelist_excluded(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # whitelist_names に "脚注" を指定すれば 6pt でも skip される
+        slide = one_slide_prs.slides[0]
+        _add_textbox(
+            slide, 0.9, 7.1, 3.0, 0.3, "出典: 社内資料",
+            font_pt=6, name="脚注",
+        )
+        findings = check_unreadable_text(
+            one_slide_prs, whitelist_names=["脚注", "フッター"]
+        )
+        assert findings == []
+
+    def test_midslide_small_text_still_flagged(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # mid-slide (y=3.0) にある 6pt text は heuristic で救われない
+        slide = one_slide_prs.slides[0]
+        _add_textbox(slide, 1.0, 3.0, 3.0, 0.5, "fact", font_pt=6, name="fact")
+        findings = check_unreadable_text(one_slide_prs)
+        assert len(findings) == 1
+        assert findings[0].shape_name == "fact"
+
+    def test_whitelist_matching_vs_non_matching(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # whitelist_names に合致するものは skip、合致しないものは flag される
+        slide = one_slide_prs.slides[0]
+        _add_textbox(slide, 1.0, 3.0, 3.0, 0.3, "tiny", font_pt=6, name="脚注_1")
+        _add_textbox(slide, 1.0, 4.0, 3.0, 0.3, "tiny", font_pt=6, name="Body_Small")
+        findings = check_unreadable_text(
+            one_slide_prs, whitelist_names=["脚注"]
+        )
+        names = [f.shape_name for f in findings]
+        assert "脚注_1" not in names
+        assert "Body_Small" in names
+
+    def test_english_regex_whitelist_regression(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # 既存英語正規表現 (footer / page_number / source / footnote) が引き続き有効
+        slide = one_slide_prs.slides[0]
+        _add_textbox(
+            slide, 1.0, 3.0, 3.0, 0.3, "1",
+            font_pt=6, name="page_number_1",
+        )
+        findings = check_unreadable_text(one_slide_prs)
+        assert findings == []
+
+    def test_whitelist_names_case_insensitive(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # 部分一致・大文字小文字を区別しないことを確認
+        slide = one_slide_prs.slides[0]
+        _add_textbox(
+            slide, 1.0, 3.0, 3.0, 0.3, "note",
+            font_pt=6, name="My_FOOTNOTE_Box",
+        )
+        findings = check_unreadable_text(
+            one_slide_prs, whitelist_names=["footnote"]
+        )
+        assert findings == []
+
+    def test_deck_extended_propagates_whitelist_names(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # check_deck_extended も whitelist_names を受け取り unreadable に伝搬する
+        slide = one_slide_prs.slides[0]
+        _add_textbox(slide, 1.0, 3.0, 3.0, 0.3, "tiny", font_pt=6, name="脚注")
+        result = check_deck_extended(one_slide_prs, whitelist_names=["脚注"])
+        assert result["slides"][0]["unreadable_text"] == []
+        assert result["summary"]["warnings"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #45: divider_collision anchor-aware projection
+# ---------------------------------------------------------------------------
+
+
+def _set_vertical_anchor(textbox, anchor) -> None:
+    """textbox の vertical_anchor を設定するヘルパ."""
+    textbox.text_frame.vertical_anchor = anchor
+
+
+class TestDividerCollisionAnchor:
+    """vertical_anchor に応じた collision 判定の検証 (Issue #45)."""
+
+    def test_bottom_anchored_no_collision(self, one_slide_prs: Presentation) -> None:
+        # McKinsey 風: title at y=0.45 h=0.5 (bottom at 0.95), anchor=bottom
+        # 長いタイトルが 2 行に折り返されるが bottom が divider top (0.95") に揃うため
+        # 実テキストは上方向に伸びて divider を超えない → no collision
+        slide = one_slide_prs.slides[0]
+        long_title = (
+            "これはスライドのアクションタイトルで必ず折り返される日本語テキスト"
+        )
+        tb = _add_textbox(
+            slide, 0.9, 0.45, 3.0, 0.5, long_title,
+            font_pt=14, name="Title",
+        )
+        _set_vertical_anchor(tb, MSO_ANCHOR.BOTTOM)
+        _add_rect(slide, 0.9, 0.95, 11.5, 0.02, name="Divider")
+
+        findings = check_divider_collision(one_slide_prs)
+        assert findings == [], f"unexpected findings: {[f.message for f in findings]}"
+
+    def test_top_anchored_collision_detected(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # 同じ寸法で top-anchor は collision として検出される (回帰)
+        slide = one_slide_prs.slides[0]
+        long_title = (
+            "これはスライドのアクションタイトルで必ず折り返される日本語テキスト"
+        )
+        tb = _add_textbox(
+            slide, 0.9, 0.45, 3.0, 0.5, long_title,
+            font_pt=14, name="Title",
+        )
+        _set_vertical_anchor(tb, MSO_ANCHOR.TOP)
+        _add_rect(slide, 0.9, 0.95, 11.5, 0.02, name="Divider")
+
+        findings = check_divider_collision(one_slide_prs)
+        assert len(findings) >= 1
+        assert findings[0].shape_name == "Title"
+
+    def test_middle_anchored_collision_edge_case(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # middle-anchor で center=0.70", needed_height≈0.6 → range [0.40, 1.00]
+        # 1.00 が divider top 0.95 を越えるため collision
+        slide = one_slide_prs.slides[0]
+        long_title = (
+            "これはスライドのアクションタイトルで必ず折り返される日本語テキスト"
+        )
+        tb = _add_textbox(
+            slide, 0.9, 0.45, 3.0, 0.5, long_title,
+            font_pt=14, name="Title",
+        )
+        _set_vertical_anchor(tb, MSO_ANCHOR.MIDDLE)
+        _add_rect(slide, 0.9, 0.95, 11.5, 0.02, name="Divider")
+
+        findings = check_divider_collision(one_slide_prs)
+        assert len(findings) >= 1
+        assert findings[0].shape_name == "Title"
+
+    def test_bottom_anchored_short_text_no_collision(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # bottom-anchor + 短文は当然 collision なし
+        slide = one_slide_prs.slides[0]
+        tb = _add_textbox(
+            slide, 0.9, 0.45, 11.5, 0.5, "短題",
+            font_pt=14, name="Title",
+        )
+        _set_vertical_anchor(tb, MSO_ANCHOR.BOTTOM)
+        _add_rect(slide, 0.9, 0.95, 11.5, 0.02, name="Divider")
+
+        findings = check_divider_collision(one_slide_prs)
+        assert findings == []
+
+    def test_projected_text_range_helper(self, one_slide_prs: Presentation) -> None:
+        # _projected_text_range ヘルパの単体挙動を検証
+        slide = one_slide_prs.slides[0]
+        tb = _add_textbox(
+            slide, 0.9, 0.45, 3.0, 0.5, "x",
+            font_pt=14, name="Title",
+        )
+        tf = tb.text_frame
+
+        # TOP
+        tf.vertical_anchor = MSO_ANCHOR.TOP
+        top, bot = _projected_text_range(tb, tf, needed_height=0.6)
+        assert top == pytest.approx(0.45, abs=1e-3)
+        assert bot == pytest.approx(1.05, abs=1e-3)
+
+        # BOTTOM (s_bottom = 0.45 + 0.5 = 0.95)
+        tf.vertical_anchor = MSO_ANCHOR.BOTTOM
+        top, bot = _projected_text_range(tb, tf, needed_height=0.6)
+        assert top == pytest.approx(0.35, abs=1e-3)
+        assert bot == pytest.approx(0.95, abs=1e-3)
+
+        # MIDDLE (center = 0.70)
+        tf.vertical_anchor = MSO_ANCHOR.MIDDLE
+        top, bot = _projected_text_range(tb, tf, needed_height=0.6)
+        assert top == pytest.approx(0.40, abs=1e-3)
+        assert bot == pytest.approx(1.00, abs=1e-3)


### PR DESCRIPTION
## Summary

Addresses two validation false-positives flagged by Google review.

**#44 — Whitelist by heuristic, not only name regex**
- `check_unreadable_text` now accepts an optional `whitelist_names: list[str]` kwarg (case-insensitive substring match), so Japanese-named shapes like `"脚注"` can be excluded explicitly.
- Adds `_is_footer_zone_shape` heuristic: shapes whose bbox sits entirely within the bottom 0.6" of the slide, with ≤3 wrapped lines, and font ≥ `min_readable_pt - 1` are silently skipped.
- Existing English regex (`footer|page_number|source|footnote`) remains as a fallback.
- `check_deck_extended` propagates `whitelist_names`.

**#45 — divider_collision assumes vertical_anchor=top**
- Adds `_projected_text_range(shape, text_frame, needed_height)` helper branching on `text_frame.vertical_anchor`:
  - `TOP`/None → `[s_top, s_top + needed_height]`
  - `BOTTOM` → `[s_bottom - needed_height, s_bottom]`; no collision when `s_bottom <= divider_top` (McKinsey pattern)
  - `MIDDLE` → `[s_center ± needed_height/2]`
- `check_divider_collision` now consults the anchor before flagging collisions.

Public signatures preserved (only optional kwargs added); no changes outside `validation.py` + tests.

## Test plan

- [x] 13 new tests in `tests/test_validation_extended.py` covering Japanese footer heuristic, explicit whitelist, regex regression, bottom/top/middle anchor cases, and `_projected_text_range` helper
- [x] All 21 pre-existing validation tests still pass
- [x] Full test suite: 452 passed

Closes #44
Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)