### PR TITLE
fix(flex): raise on non-stretch align + strict unknown-key validation (closes #24, closes #43)

### DIFF
--- a/src/pptx_mcp_server/engine/flex.py
+++ b/src/pptx_mcp_server/engine/flex.py
@@ -155,13 +155,27 @@ def add_flex_container(
         direction: 主軸方向。``"row"`` または ``"column"``。
         gap: 子要素間のスペース (inches)。
         padding: コンテナ内側の余白 (inches、全 4 辺に適用)。
-        align: cross 軸方向の整列。``"stretch"`` 以外は現状、cross サイズ
-            自体は stretch と同等に扱う (intrinsic cross 未測定のため MVP)。
+        align: cross 軸方向の整列。現状 MVP では ``"stretch"`` のみサポート
+            する。``"start"``・``"center"``・``"end"`` は intrinsic cross
+            サイズの測定が未実装であるため、指定された場合は
+            ``EngineError(INVALID_PARAMETER)`` を送出する (#24)。サイレント
+            に stretch 扱いに降格させない。
 
-    Returns:
-        各 item に割り当てられた ``(left, top, width, height)`` のタプル
-        のリスト。``items`` と同順。
+    Raises:
+        EngineError: ``align`` が ``"stretch"`` 以外のとき
+            (``INVALID_PARAMETER``)、もしくは fixed+content の合計が
+            usable_main を超過しているとき。
     """
+    # #24: MVP 実装は cross 軸の intrinsic サイズを測定しないため、``center``・
+    # ``start``・``end`` を本来の意味で実装できない。従来はサイレントに
+    # stretch として扱っていたが、LLM エージェントには失敗シグナルが届かず
+    # 修正機会を奪っていた。明示的に拒否する。
+    if align != "stretch":
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            f"align={align!r} is not yet implemented; use 'stretch' for MVP.",
+        )
+
     if not items:
         return []
 
@@ -259,6 +273,35 @@ def add_flex_container(
 
 _SUPPORTED_ITEM_TYPES = ("text", "rectangle")
 
+# #43: item spec に許可するキーを ``type`` ごとに明示する。未知キーは
+# サイレントに無視せず ``INVALID_PARAMETER`` を送出し、LLM エージェントの
+# typo (例: ``font_size`` ではなく ``font_size_pt`` が正) を再試行時に
+# 明確にフィードバックする。
+_ALLOWED_COMMON: frozenset[str] = frozenset(
+    {"type", "sizing", "size", "grow", "content_size", "min_size", "max_size"}
+)
+_ALLOWED_TEXT: frozenset[str] = _ALLOWED_COMMON | frozenset(
+    {
+        "text",
+        "font_name",
+        "font_size_pt",
+        "min_size_pt",
+        "bold",
+        "color_hex",
+        "align",
+        "vertical_anchor",
+        "truncate_with_ellipsis",
+    }
+)
+_ALLOWED_RECT: frozenset[str] = _ALLOWED_COMMON | frozenset(
+    {"fill_color", "line_color", "line_width", "no_line"}
+)
+
+_ALLOWED_BY_TYPE: dict[str, frozenset[str]] = {
+    "text": _ALLOWED_TEXT,
+    "rectangle": _ALLOWED_RECT,
+}
+
 
 def _build_declarative_item(
     slide,
@@ -273,6 +316,10 @@ def _build_declarative_item(
     - ``"rectangle"``: ``_add_shape`` で塗りつぶし矩形を描画する。
 
     描画結果 (shape_index) は ``created_shape_indices`` に追記される。
+
+    spec に未知のキーが含まれる場合は ``EngineError(INVALID_PARAMETER)``
+    を送出する (#43)。``type`` ごとに許可キー集合を定義し、typo を
+    サイレントに握りつぶさない。
     """
     sizing: SizingMode = spec.get("sizing", "grow")
     if sizing not in ("fixed", "grow", "content"):
@@ -287,6 +334,18 @@ def _build_declarative_item(
             ErrorCode.INVALID_PARAMETER,
             f"Unknown flex item type '{item_type}'. "
             f"Supported: {', '.join(_SUPPORTED_ITEM_TYPES)}.",
+        )
+
+    # #43: 未知キーの検証。``type`` が既知なので type-specific な allowed を参照。
+    allowed = _ALLOWED_BY_TYPE[item_type]
+    unknown = set(spec.keys()) - allowed
+    if unknown:
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            (
+                f"Unknown keys {sorted(unknown)} for flex item type "
+                f"{item_type!r}; allowed keys: {sorted(allowed)}."
+            ),
         )
 
     size = float(spec.get("size", 0.0))

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -12,6 +12,7 @@ Parameter conventions (new tools):
 """
 
 import json
+from dataclasses import fields
 from typing import Any, Dict
 
 try:
@@ -24,6 +25,7 @@ except ImportError as e:
 
 from .engine import (
     EngineError,
+    ErrorCode,
     create_presentation,
     get_presentation_info,
     read_slide,
@@ -796,6 +798,21 @@ def pptx_add_responsive_card_row(
     """
     try:
         card_dicts = json.loads(cards_json) if isinstance(cards_json, str) else cards_json
+        # #43: CardSpec dataclass は未知キーを TypeError として弾くが、
+        # MCP ツール層で明示的に ``INVALID_PARAMETER`` として報告し、
+        # どのカード・どのキーが原因かを LLM エージェントが再試行時に
+        # 解釈できる形式で返す。
+        _card_known_keys = {f.name for f in fields(CardSpec)}
+        for i, spec in enumerate(card_dicts):
+            unknown = set(spec.keys()) - _card_known_keys
+            if unknown:
+                raise EngineError(
+                    ErrorCode.INVALID_PARAMETER,
+                    (
+                        f"card[{i}]: unknown keys {sorted(unknown)}; "
+                        f"known keys: {sorted(_card_known_keys)}."
+                    ),
+                )
         cards = [CardSpec(**d) for d in card_dicts]
         prs = open_pptx(file_path)
         slide = _get_slide(prs, slide_index)

--- a/tests/test_flex.py
+++ b/tests/test_flex.py
@@ -165,22 +165,51 @@ def test_column_direction_stack_vertically():
         assert _approx(w, 5.0)
 
 
-def test_align_center_cross_axis_size():
-    """align='center' の cross サイズは usable_cross と一致する (MVP 仕様)."""
-    renders = [_recorder() for _ in range(1)]
-    items = [
-        FlexItem(sizing="fixed", size=3.0, render=renders[0][0]),
-    ]
+def test_align_non_stretch_raises():
+    """#24: align='center' はサイレントに stretch 扱いせず INVALID_PARAMETER."""
+    render, _ = _recorder()
+    items = [FlexItem(sizing="fixed", size=3.0, render=render)]
+    with pytest.raises(EngineError) as excinfo:
+        add_flex_container(
+            slide=None,
+            items=items,
+            left=0.0, top=0.0, width=10.0, height=2.0,
+            direction="row", gap=0.0, padding=0.0, align="center",
+        )
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMETER
+    msg = str(excinfo.value)
+    assert "center" in msg
+    assert "stretch" in msg
+
+
+@pytest.mark.parametrize("bad_align", ["start", "center", "end"])
+def test_align_non_stretch_all_values_raise(bad_align):
+    """start/center/end すべてが同様に拒否される (MVP)."""
+    render, _ = _recorder()
+    items = [FlexItem(sizing="fixed", size=3.0, render=render)]
+    with pytest.raises(EngineError) as excinfo:
+        add_flex_container(
+            slide=None,
+            items=items,
+            left=0.0, top=0.0, width=10.0, height=2.0,
+            direction="row", gap=0.0, padding=0.0, align=bad_align,  # type: ignore[arg-type]
+        )
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMETER
+
+
+def test_align_stretch_ok_regression():
+    """align='stretch' は従来どおり成功する (回帰防止)."""
+    render, calls = _recorder()
+    items = [FlexItem(sizing="fixed", size=3.0, render=render)]
     allocs = add_flex_container(
         slide=None,
         items=items,
         left=0.0, top=0.0, width=10.0, height=2.0,
-        direction="row", gap=0.0, padding=0.0, align="center",
+        direction="row", gap=0.0, padding=0.0, align="stretch",
     )
-    # cross サイズは usable_cross = height - 2*padding = 2.0
     assert _approx(allocs[0][3], 2.0)
-    # cross 位置は padding から
     assert _approx(allocs[0][1], 0.0)
+    assert len(calls) == 1
 
 
 def test_padding_insets_all_items():
@@ -408,3 +437,77 @@ def test_render_receives_correct_args():
     )
     assert len(calls) == 1
     assert calls[0] == allocs[0]
+
+
+# ── #43: _build_declarative_item strict unknown-key validation ──────
+
+class TestDeclarativeItemStrictKeys:
+    """``_build_declarative_item`` が未知キーを明示的に拒否する (#43)."""
+
+    def test_text_unknown_font_size_raises_with_hint(self):
+        """``font_size`` (``_pt`` 欠落) は弾かれ、hint として
+        ``font_size_pt`` が allowed に含まれる。"""
+        from pptx_mcp_server.engine.flex import _build_declarative_item
+
+        created: list = []
+        with pytest.raises(EngineError) as excinfo:
+            _build_declarative_item(
+                slide=None,
+                spec={"type": "text", "text": "hi", "font_size": 12},
+                created_shape_indices=created,
+            )
+        assert excinfo.value.code == ErrorCode.INVALID_PARAMETER
+        msg = str(excinfo.value)
+        assert "font_size" in msg
+        # allowed 集合に font_size_pt が含まれることで、LLM が正しいキーを発見できる
+        assert "font_size_pt" in msg
+        # 描画は走っていない
+        assert created == []
+
+    def test_text_valid_font_size_pt_ok_regression(self):
+        """``font_size_pt`` は既知キーなので成功する (回帰防止)。"""
+        from pptx_mcp_server.engine.flex import _build_declarative_item
+
+        created: list = []
+        item = _build_declarative_item(
+            slide=None,
+            spec={"type": "text", "text": "hi", "font_size_pt": 12},
+            created_shape_indices=created,
+        )
+        assert item.sizing == "grow"
+        # render callback は未呼び出し (slide=None での実 render は呼び元責務)
+        assert created == []
+
+    def test_rectangle_unknown_key_raises(self):
+        """rectangle の未知キーは allowed 集合と共にエラーに出現する。"""
+        from pptx_mcp_server.engine.flex import _build_declarative_item
+
+        created: list = []
+        with pytest.raises(EngineError) as excinfo:
+            _build_declarative_item(
+                slide=None,
+                spec={
+                    "type": "rectangle",
+                    "fill_color": "FF0000",
+                    "badkey": 1,
+                },
+                created_shape_indices=created,
+            )
+        assert excinfo.value.code == ErrorCode.INVALID_PARAMETER
+        msg = str(excinfo.value)
+        assert "badkey" in msg
+        assert "rectangle" in msg
+
+    def test_unknown_type_still_raises_regression(self):
+        """``type`` が未知の場合は従来どおり弾く (既存挙動の回帰)。"""
+        from pptx_mcp_server.engine.flex import _build_declarative_item
+
+        created: list = []
+        with pytest.raises(EngineError) as excinfo:
+            _build_declarative_item(
+                slide=None,
+                spec={"type": "ellipse"},
+                created_shape_indices=created,
+            )
+        assert excinfo.value.code == ErrorCode.INVALID_PARAMETER
+        assert "ellipse" in str(excinfo.value)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -378,3 +378,62 @@ class TestFlexContainerItemsJson:
             left=0.5, top=0.5, width=10.0, height=1.0,
         )
         assert "INVALID_PARAMETER" in result
+
+
+# ── #43: CardSpec JSON strict unknown-key validation ───────────────
+
+class TestResponsiveCardRowStrictKeys:
+    """``pptx_add_responsive_card_row`` が未知キーを弾く (#43)."""
+
+    def test_unknown_key_rejected_with_index_and_name(self, deck):
+        """``typo`` など CardSpec に無いキーは INVALID_PARAMETER。
+        エラーメッセージにインデックスとキー名が含まれる。"""
+        cards_json = json.dumps([{"title": "t", "body": "b", "typo": "x"}])
+        result = pptx_add_responsive_card_row(
+            file_path=deck,
+            slide_index=0,
+            cards_json=cards_json,
+            left=0.5, top=0.5, width=10.0, max_height=3.0,
+        )
+        assert "INVALID_PARAMETER" in result
+        assert "typo" in result
+        # どのカードが原因かを示すため、index プレフィックスも含む
+        assert "card[0]" in result
+
+    def test_unknown_key_index_points_to_bad_card(self, deck):
+        """不良カードが配列の途中にある場合、index が正しく反映される。"""
+        cards_json = json.dumps(
+            [
+                {"title": "ok", "body": "ok"},
+                {"title": "bad", "body": "b", "oops": 1},
+            ]
+        )
+        result = pptx_add_responsive_card_row(
+            file_path=deck,
+            slide_index=0,
+            cards_json=cards_json,
+            left=0.5, top=0.5, width=10.0, max_height=3.0,
+        )
+        assert "INVALID_PARAMETER" in result
+        assert "card[1]" in result
+        assert "oops" in result
+
+    def test_valid_cards_ok_regression(self, deck):
+        """既知キーのみのカードは従来どおり成功する (回帰防止)。"""
+        cards_json = json.dumps(
+            [
+                {"title": "A", "body": "aa", "accent_color": "2251FF"},
+                {"title": "B", "body": "bb", "padding": 0.25},
+            ]
+        )
+        result = pptx_add_responsive_card_row(
+            file_path=deck,
+            slide_index=0,
+            cards_json=cards_json,
+            left=0.5, top=0.5, width=10.0, max_height=3.0,
+        )
+        # 先頭行は成功時の JSON
+        first_line = result.split("\n")[0]
+        parsed = json.loads(first_line)
+        assert "cards" in parsed
+        assert len(parsed["cards"]) == 2


### PR DESCRIPTION
## Summary

Two validation-hardening fixes at the MCP / declarative boundary. Both previously silently swallowed agent mistakes.

### #24 — flex `align` silently ignored

`add_flex_container` accepted `align in {"start","center","end","stretch"}` but MVP had no cross-axis intrinsic measurement, so non-stretch was silently downgraded to stretch. An LLM passing `align="center"` got stretch with no signal.

Fix: raise `EngineError(INVALID_PARAMETER)` with message `align='{align}' is not yet implemented; use 'stretch' for MVP.`. Docstring updated.

### #43 — strict unknown-key validation

- `_build_declarative_item` accepted any spec dict and dropped unknown keys. Typos like `font_size` (missing `_pt`) vanished with no error.
- `pptx_add_responsive_card_row` built `CardSpec(**spec)` directly; the stdlib dataclass does raise `TypeError` on unknown, but the MCP layer returned it as a generic `INTERNAL_ERROR` with no index hint.

Fix:
- `_build_declarative_item`: per-type allowed key sets (`_ALLOWED_TEXT`, `_ALLOWED_RECT`); unknown keys raise `EngineError(INVALID_PARAMETER, f"Unknown keys {sorted(unknown)} for flex item type {type!r}; allowed keys: {sorted(allowed)}.")`.
- `pptx_add_responsive_card_row`: use `dataclasses.fields(CardSpec)` to pre-validate each card; raise `EngineError(INVALID_PARAMETER, f"card[{i}]: unknown keys {sorted(unknown)}; known keys: {sorted(known)}.")` with the offending index and full known set.

All error messages include the bad key and the allowed set so an LLM can self-correct on retry.

## Test plan

- [x] `tests/test_flex.py`: align rejection (start/center/end parametrized) + stretch regression
- [x] `tests/test_flex.py::TestDeclarativeItemStrictKeys`: font_size hint, rectangle unknown key, valid regression, unknown type regression
- [x] `tests/test_server.py::TestResponsiveCardRowStrictKeys`: bad index reporting, mid-array bad card, valid regression
- [x] `python -m pytest` — 450 passed, 0 failed

Closes #24
Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)