### PR TITLE
refactor(engine): centralize textbox inner-padding constant (closes #42)

### DIFF
--- a/src/pptx_mcp_server/engine/__init__.py
+++ b/src/pptx_mcp_server/engine/__init__.py
@@ -1,3 +1,7 @@
+from .layout_constants import (
+    TEXTBOX_INNER_PADDING_PER_SIDE,
+    TEXTBOX_INNER_PADDING_TOTAL,
+)
 from .pptx_io import open_pptx, save_pptx, create_presentation, EngineError, ErrorCode
 from .slides import (
     get_presentation_info,
@@ -104,6 +108,8 @@ from .cards import (
 )
 
 __all__ = [
+    # Layout constants
+    "TEXTBOX_INNER_PADDING_PER_SIDE", "TEXTBOX_INNER_PADDING_TOTAL",
     # I/O
     "open_pptx", "save_pptx", "create_presentation",
     "EngineError", "ErrorCode",

--- a/src/pptx_mcp_server/engine/cards.py
+++ b/src/pptx_mcp_server/engine/cards.py
@@ -25,8 +25,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
+from .layout_constants import (
+    TEXTBOX_INNER_PADDING_PER_SIDE as _AUTO_FIT_PADDING_PER_SIDE,
+)
 from .pptx_io import EngineError, ErrorCode
-from .shapes import _AUTO_FIT_PADDING_PER_SIDE, _add_shape, add_auto_fit_textbox
+from .shapes import _add_shape, add_auto_fit_textbox
 from .text_metrics import estimate_text_height
 
 CardHeightMode = Literal["content", "max", "fill"]

--- a/src/pptx_mcp_server/engine/layout_constants.py
+++ b/src/pptx_mcp_server/engine/layout_constants.py
@@ -1,0 +1,16 @@
+"""Shared layout constants for sizing and padding.
+
+Centralized so that text-height estimation, auto-fit shrinking, card rendering,
+and overflow validation all use the same numeric assumptions. Drift between
+these call sites has historically caused false-positive overflow findings and
+clipped text in generated decks.
+"""
+
+from __future__ import annotations
+
+# 2026-04: 各 textbox の内側左右の padding (inches)。python-pptx / PowerPoint が
+# 標準の textbox に適用する既定マージンに合わせて calibrate した値である。
+TEXTBOX_INNER_PADDING_PER_SIDE: float = 0.05
+
+# Convenience: 左右合計 (width calculations で頻繁に使うため事前計算してある)。
+TEXTBOX_INNER_PADDING_TOTAL: float = 2 * TEXTBOX_INNER_PADDING_PER_SIDE

--- a/src/pptx_mcp_server/engine/shapes.py
+++ b/src/pptx_mcp_server/engine/shapes.py
@@ -536,8 +536,11 @@ def list_shapes(file_path, slide_index):
 
 # 内側 padding (inches、左右各側)。左右に同量の padding を見込むため、
 # usable width は width - 2 * _AUTO_FIT_PADDING_PER_SIDE となる。
-# cards.py など他モジュールからも参照できるよう module-level の定数として公開する。
-_AUTO_FIT_PADDING_PER_SIDE: float = 0.05
+# cards.py / validation.py と単一定義を共有するため ``layout_constants`` から
+# import する。alias 名は既存 import 互換のため維持する。
+from .layout_constants import (
+    TEXTBOX_INNER_PADDING_PER_SIDE as _AUTO_FIT_PADDING_PER_SIDE,
+)
 
 # 後方互換のための別名 (旧名)。新規コードは _AUTO_FIT_PADDING_PER_SIDE を使うこと。
 _AUTO_FIT_PADDING: float = _AUTO_FIT_PADDING_PER_SIDE

--- a/src/pptx_mcp_server/engine/validation.py
+++ b/src/pptx_mcp_server/engine/validation.py
@@ -16,6 +16,10 @@ from pptx import Presentation
 from pptx.enum.text import MSO_ANCHOR
 from pptx.util import Emu
 
+from .layout_constants import (
+    TEXTBOX_INNER_PADDING_PER_SIDE,
+    TEXTBOX_INNER_PADDING_TOTAL,
+)
 from .text_metrics import estimate_text_height, estimate_text_width
 
 # ---------------------------------------------------------------------------
@@ -372,10 +376,10 @@ def check_text_overflow(
 ) -> List[ValidationFinding]:
     """テキストフレームの高さ溢れを検出する.
 
-    各 text frame の幅 (左右 0.05" マージン合計) に基づき、段落単位で
-    有効フォントサイズを解決し、段落ごとの推定高さを合算する。合計が
-    frame_height × (1 + tolerance/100) を超える場合に ``error`` finding
-    を返す。
+    各 text frame の幅から左右の ``TEXTBOX_INNER_PADDING_TOTAL`` (= 0.10") を
+    差し引いた usable width に基づき、段落単位で有効フォントサイズを解決し、
+    段落ごとの推定高さを合算する。合計が frame_height × (1 + tolerance/100)
+    を超える場合に ``error`` finding を返す。
     """
     findings: List[ValidationFinding] = []
     tolerance_factor = 1 + overflow_tolerance_pct / 100.0
@@ -396,7 +400,7 @@ def check_text_overflow(
             if not text.strip():
                 continue
 
-            usable_width = max(0.1, frame_width - 0.10)
+            usable_width = max(0.1, frame_width - TEXTBOX_INNER_PADDING_TOTAL)
             needed_height, font_size = _estimate_frame_needed_height(
                 tf, usable_width
             )
@@ -496,7 +500,7 @@ def _is_footer_zone_shape(
         return False
 
     # 行数 (段落ごとに折返し推定)
-    usable_width = max(0.1, s_width - 0.10)
+    usable_width = max(0.1, s_width - TEXTBOX_INNER_PADDING_TOTAL)
     total_lines = 0
     for para in text_frame.paragraphs:
         text = _paragraph_text(para)
@@ -685,7 +689,9 @@ def check_divider_collision(
                 text = _full_text(tf)
                 if not text.strip():
                     continue
-                frame_width = max(0.1, (s_right - s_left) - 0.10)
+                frame_width = max(
+                    0.1, (s_right - s_left) - TEXTBOX_INNER_PADDING_TOTAL
+                )
                 needed_height, font_size = _estimate_frame_needed_height(
                     tf, frame_width
                 )

--- a/tests/test_layout_constants.py
+++ b/tests/test_layout_constants.py
@@ -1,0 +1,57 @@
+"""layout_constants 単一ソース定数を pin するテスト.
+
+issue #42 — textbox の内側 padding は shapes.py / cards.py / validation.py の
+3 箇所に magic number として散らばっていた。centralization 後もドリフトさせ
+ないよう、値自体と alias の一致を明示的にアサートする。
+"""
+
+from __future__ import annotations
+
+from pptx_mcp_server.engine import layout_constants
+from pptx_mcp_server.engine import shapes as shapes_mod
+from pptx_mcp_server.engine import cards as cards_mod
+from pptx_mcp_server.engine.layout_constants import (
+    TEXTBOX_INNER_PADDING_PER_SIDE,
+    TEXTBOX_INNER_PADDING_TOTAL,
+)
+
+
+def test_per_side_value_pinned() -> None:
+    """per-side padding は 0.05" で固定。変更は意図的に行う."""
+    assert TEXTBOX_INNER_PADDING_PER_SIDE == 0.05
+
+
+def test_total_value_pinned() -> None:
+    """total は per-side の 2 倍 (= 0.10")."""
+    assert TEXTBOX_INNER_PADDING_TOTAL == 0.10
+    assert TEXTBOX_INNER_PADDING_TOTAL == 2 * TEXTBOX_INNER_PADDING_PER_SIDE
+
+
+def test_shapes_alias_matches_constant() -> None:
+    """shapes._AUTO_FIT_PADDING_PER_SIDE は layout_constants と同一値を指す."""
+    assert shapes_mod._AUTO_FIT_PADDING_PER_SIDE == TEXTBOX_INNER_PADDING_PER_SIDE
+    # 旧名 alias も同一値
+    assert shapes_mod._AUTO_FIT_PADDING == TEXTBOX_INNER_PADDING_PER_SIDE
+
+
+def test_cards_alias_matches_constant() -> None:
+    """cards.py が layout_constants と同一の per-side 定数を使う."""
+    assert cards_mod._AUTO_FIT_PADDING_PER_SIDE == TEXTBOX_INNER_PADDING_PER_SIDE
+
+
+def test_exported_from_engine_package() -> None:
+    """engine パッケージ経由でも同じ値を import できる."""
+    from pptx_mcp_server import engine
+
+    assert engine.TEXTBOX_INNER_PADDING_PER_SIDE == 0.05
+    assert engine.TEXTBOX_INNER_PADDING_TOTAL == 0.10
+    assert "TEXTBOX_INNER_PADDING_PER_SIDE" in engine.__all__
+    assert "TEXTBOX_INNER_PADDING_TOTAL" in engine.__all__
+
+
+def test_module_has_future_annotations() -> None:
+    """layout_constants は ``from __future__ import annotations`` を使う."""
+    import inspect
+
+    src = inspect.getsource(layout_constants)
+    assert "from __future__ import annotations" in src


### PR DESCRIPTION
## Summary

- New `engine/layout_constants.py` holds `TEXTBOX_INNER_PADDING_PER_SIDE` (= 0.05") and `TEXTBOX_INNER_PADDING_TOTAL` (= 0.10") as the single source of truth for the textbox inner-padding model.
- `shapes.py`, `cards.py`, and `validation.py` all migrate to the centralized constants. Previously these three files duplicated the 0.05/0.10 magic number and drift had historically caused false-positive overflow findings and clipped text.
- Both constants are re-exported from `pptx_mcp_server.engine` for downstream consumers (e.g. the agentrank pipeline) that need to match this padding model in their own layout math.

Closes #42.

## Migration details

- `shapes.py`: `_AUTO_FIT_PADDING_PER_SIDE` is now `from .layout_constants import TEXTBOX_INNER_PADDING_PER_SIDE as _AUTO_FIT_PADDING_PER_SIDE`. The old `_AUTO_FIT_PADDING` alias is preserved. Any internal or external code importing either name keeps working.
- `cards.py`: switched from `from .shapes import _AUTO_FIT_PADDING_PER_SIDE` to importing directly from `layout_constants` under the same local name (minimal churn).
- `validation.py`: three lateral-padding sites converted to `TEXTBOX_INNER_PADDING_TOTAL`:
  - `check_text_overflow` — `usable_width = frame_width - 0.10` → `frame_width - TEXTBOX_INNER_PADDING_TOTAL`
  - `_is_footer_zone_shape` — `s_width - 0.10` → `s_width - TEXTBOX_INNER_PADDING_TOTAL`
  - `check_divider_collision` — `(s_right - s_left) - 0.10` → `- TEXTBOX_INNER_PADDING_TOTAL`
  - Docstring on `check_text_overflow` updated to reference the named constant.

## Magic-number audit (0.05 / 0.10 in engine/*.py)

Converted to `TEXTBOX_INNER_PADDING_*`:
- `shapes.py:540` (`_AUTO_FIT_PADDING_PER_SIDE = 0.05`) — now a re-export alias
- `cards.py:119` (`2 * _AUTO_FIT_PADDING_PER_SIDE`) — via direct import
- `validation.py:399, 499, 688` — three lateral-padding subtractions

Left alone (intentionally unrelated to textbox padding):
- `cards.py:43` `_INTRA_GAP = 0.05` — inter-block gap inside a card, not padding
- `validation.py:63` `if w * h < 0.05` — a minimum-area threshold for micro shapes
- `validation.py:173, 951` `margin=-0.05` — overlap-tolerance for adjacency checks
- `validation.py:422` `max(0.05, needed_height - frame_height)` — floor for the suggested delta in a finding message (unit is "inches of extra height to suggest")
- `validation.py:642, 659, 698` — divider-thickness heuristic (`h < 0.05`)
- `validation.py:754, 777, 885` `gap_tolerance = 0.05` — axis-group clustering tolerance
- `validation.py:391` `frame_height <= 0.05` — degenerate-frame guard (not a padding value)

## Tolerance-factor drift assessment (from issue #42)

The issue asks whether `check_text_overflow`'s `tolerance_factor` applies consistently to both the shape height *and* the auto-fit search. I read the two side-by-side:

- `check_text_overflow` (validation.py) compares `needed_height > frame_height * (1 + overflow_tolerance_pct/100)`. Default tolerance = 5%.
- `add_auto_fit_textbox` → `_fit_font_size` (shapes.py) compares `height_est <= height` **strictly** — no tolerance. It shrinks until the estimate fits exactly, or truncates at `min_size_pt`.

So there *is* a drift: validation tolerates 5% overflow, but auto-fit does not. This means a deck that auto-fit accepted (because the estimator said it fits at 0.01" under limit) is clearly fine for the validator, but the converse is also true — validation may green-light a slide that `add_auto_fit_textbox` would have shrunk further. 

Per instructions ("note in the PR body and skip" if drift exists, to stay narrow), **not fixing in this PR**. Fix would be a tiny `_fits_with_tolerance(needed, available, tolerance_pct)` helper consumed by both sites, but it's a behavioral change and out of the narrow centralization scope. Worth tracking as a follow-up issue if false positives or clipping surface in practice. The current 5% tolerance on the validator side is conservative (errs toward fewer false positives), which is the less-harmful direction to drift.

## Test plan
- [x] `pytest tests/test_shapes_auto_fit.py tests/test_cards.py tests/test_validation_extended.py tests/test_layout_constants.py -v` — 64 passed
- [x] `pytest` (full suite) — 471 passed, no regressions
- [x] New `test_layout_constants.py` pins: per-side = 0.05, total = 0.10, shapes/cards aliases equal the canonical constant, both names exported from `engine` package, module uses `from __future__ import annotations`

No behavioral change expected. Constant value is unchanged (0.05 per side / 0.10 total).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>