### PR TITLE
fix(pptx_io): atomic save via temp-file-then-rename (closes #62)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,13 @@ part of the default test run and also run in the library-only CI job
 If you need MCP-specific behavior, put it in `src/pptx_mcp_server/server.py`
 or a sibling module that is only imported when the CLI starts.
 
+## File safety
+
+`save_pptx` is atomic (temp-file-then-rename) but does NOT guard against
+concurrent writes from multiple processes. The single-writer contract is:
+at most one process mutates a given `.pptx` path at a time. Consumers that
+need multi-writer coordination should layer their own locking on top.
+
 ## Pull request flow
 
 1. Branch off `main` with a short, topic-style name

--- a/src/pptx_mcp_server/engine/pptx_io.py
+++ b/src/pptx_mcp_server/engine/pptx_io.py
@@ -5,6 +5,7 @@ PPTX file I/O — open, save, create, error types.
 from __future__ import annotations
 
 import os
+import tempfile
 from enum import Enum
 from pptx import Presentation
 from pptx.util import Inches, Pt, Emu
@@ -38,8 +39,38 @@ def open_pptx(file_path: str) -> Presentation:
 
 
 def save_pptx(prs: Presentation, file_path: str) -> None:
-    """Save a presentation to disk."""
-    prs.save(file_path)
+    """PPTX を原子的に保存する。
+
+    同一ディレクトリに一時ファイルを書き出したあと ``os.replace`` で rename する。
+    ``os.replace`` は POSIX でも Windows でも atomic であり、
+    途中で失敗しても元のファイルは損なわれない。
+
+    注意: 原子性は同一ファイルシステム内でのみ保証されるため、一時ファイルは
+    必ず target と同じディレクトリに作る。クロスマウントでの temp+rename は
+    静かに degrade するため避ける。
+
+    なお本関数はクラッシュ耐性のみを目的としており、マルチプロセス間の
+    書き込み排他は行わない (単一ライター契約。詳細は CONTRIBUTING.md 参照)。
+    """
+    abs_path = os.path.abspath(file_path)
+    dir_ = os.path.dirname(abs_path) or "."
+    # mkstemp で同一ディレクトリ内にユニークな一時パスを確保する。
+    # NamedTemporaryFile は open 済み fd を保持するが、python-pptx は
+    # パスから自前で open するため fd は不要。ここでは名前だけ欲しい。
+    fd, tmp_path = tempfile.mkstemp(
+        dir=dir_,
+        prefix="." + os.path.basename(abs_path) + ".tmp.",
+    )
+    os.close(fd)
+    try:
+        prs.save(tmp_path)
+        os.replace(tmp_path, abs_path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def create_presentation(

--- a/tests/test_pptx_io.py
+++ b/tests/test_pptx_io.py
@@ -88,7 +88,7 @@ class TestParseColor:
 
 
 class TestSavePptx:
-    """save_pptx must write a valid file."""
+    """save_pptx must write a valid file atomically."""
 
     def test_saves_to_disk(self, tmp_path):
         prs = Presentation()
@@ -98,3 +98,104 @@ class TestSavePptx:
         # Verify it's loadable
         loaded = Presentation(path)
         assert loaded is not None
+
+    def test_happy_path_round_trips(self, tmp_path):
+        """Happy path: save round-trips through Presentation."""
+        prs = Presentation()
+        prs.slide_width = Inches(13.333)
+        prs.slide_height = Inches(7.5)
+        # Add a blank slide so we can inspect structure after reload.
+        layout = prs.slide_layouts[6]
+        prs.slides.add_slide(layout)
+
+        path = str(tmp_path / "rt.pptx")
+        save_pptx(prs, path)
+
+        assert os.path.exists(path)
+        loaded = Presentation(path)
+        assert len(loaded.slides) == 1
+        assert abs(loaded.slide_width / 914400 - 13.333) < 0.01
+
+        # No lingering temp files.
+        leftovers = [p.name for p in tmp_path.iterdir() if ".tmp." in p.name]
+        assert leftovers == []
+
+    def test_crash_during_save_preserves_original(self, tmp_path, monkeypatch):
+        """If Presentation.save raises, the pre-existing target file is untouched."""
+        path = tmp_path / "existing.pptx"
+        original_bytes = b"ORIGINAL CONTENT -- not a real pptx"
+        path.write_bytes(original_bytes)
+
+        prs = Presentation()
+
+        def boom(*_args, **_kwargs):
+            raise IOError("simulated mid-write failure")
+
+        # Presentation() is a factory; patch save on the instance's class.
+        monkeypatch.setattr(type(prs), "save", boom, raising=True)
+
+        with pytest.raises(IOError, match="simulated"):
+            save_pptx(prs, str(path))
+
+        # Original content preserved verbatim.
+        assert path.read_bytes() == original_bytes
+        # No lingering .tmp.* sibling.
+        leftovers = [p.name for p in tmp_path.iterdir() if ".tmp." in p.name]
+        assert leftovers == []
+
+    def test_crash_with_no_existing_target_leaves_no_file(self, tmp_path, monkeypatch):
+        """If target did not exist, a failing save must not create it."""
+        path = tmp_path / "fresh.pptx"
+        assert not path.exists()
+
+        prs = Presentation()
+
+        def boom(*_args, **_kwargs):
+            raise IOError("simulated mid-write failure")
+
+        # Presentation() is a factory; patch save on the instance's class.
+        monkeypatch.setattr(type(prs), "save", boom, raising=True)
+
+        with pytest.raises(IOError, match="simulated"):
+            save_pptx(prs, str(path))
+
+        assert not path.exists()
+        leftovers = [p.name for p in tmp_path.iterdir() if ".tmp." in p.name]
+        assert leftovers == []
+
+    def test_two_sequential_saves_same_path(self, tmp_path):
+        """Back-to-back saves to the same path must both succeed."""
+        path = str(tmp_path / "twice.pptx")
+
+        prs1 = Presentation()
+        save_pptx(prs1, path)
+        assert os.path.exists(path)
+        first_mtime = os.path.getmtime(path)
+
+        prs2 = Presentation()
+        save_pptx(prs2, path)
+        assert os.path.exists(path)
+
+        # File still loadable after the second save.
+        loaded = Presentation(path)
+        assert loaded is not None
+
+        # No lingering temp files.
+        leftovers = [p.name for p in tmp_path.iterdir() if ".tmp." in p.name]
+        assert leftovers == []
+        # Final file is the second save (or at least not removed).
+        assert os.path.getmtime(path) >= first_mtime
+
+    def test_relative_path(self, tmp_path, monkeypatch):
+        """Relative paths work identically (resolved via os.path.abspath)."""
+        monkeypatch.chdir(tmp_path)
+        prs = Presentation()
+        save_pptx(prs, "relative.pptx")
+
+        target = tmp_path / "relative.pptx"
+        assert target.exists()
+        loaded = Presentation(str(target))
+        assert loaded is not None
+
+        leftovers = [p.name for p in tmp_path.iterdir() if ".tmp." in p.name]
+        assert leftovers == []


### PR DESCRIPTION
## Summary

- `save_pptx` now writes to a sibling temp file and `os.replace`s onto the target, preserving the original file on any mid-write failure (disk full, OOM, kill -9).
- Same-directory temp ensures cross-filesystem silent degradation is avoided; `os.replace` is atomic on POSIX and Windows.
- Public signature unchanged; all existing callers (`create_presentation`, per-file engine wrappers, MCP tools) work unchanged.

## Scope

Atomic save only. Cross-process file locking is explicitly out of scope (issue #62 defers it). CONTRIBUTING.md gains a **File safety** section documenting the single-writer contract.

## Tests

`tests/test_pptx_io.py::TestSavePptx` now pins:

1. Happy path round-trip (slide count + dimensions preserved; no `.tmp.*` residue).
2. Crash during save preserves pre-existing target bytes exactly, no temp leaked, `IOError` propagates.
3. Crash with no pre-existing target leaves a clean directory.
4. Two sequential saves to the same path both succeed.
5. Relative paths resolve via `os.path.abspath` and work identically.

Crash simulation uses `monkeypatch.setattr(type(prs), "save", boom)` — `Presentation` is a factory, so the class has to be resolved from the instance rather than patched on the `pptx.Presentation` name directly.

Full suite: 480 passed locally.

## Test plan

- [x] `python -m pytest tests/test_pptx_io.py -v` — 16 passed
- [x] `python -m pytest` — 480 passed, no regressions
- [ ] CI green on this PR

Closes #62

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>