### PR TITLE
fix(flex): raise when grow min_size total exceeds remaining budget (closes #59)

### DIFF
--- a/src/pptx_mcp_server/engine/flex.py
+++ b/src/pptx_mcp_server/engine/flex.py
@@ -163,8 +163,10 @@ def add_flex_container(
 
     Raises:
         EngineError: ``align`` が ``"stretch"`` 以外のとき
-            (``INVALID_PARAMETER``)、もしくは fixed+content の合計が
-            usable_main を超過しているとき。
+            (``INVALID_PARAMETER``)、fixed+content の合計が usable_main を
+            超過しているとき、または grow 項目の ``min_size`` 合計が残余
+            予算 (usable_main - fixed_total - content_total) を超過して
+            いるとき (#59)。
     """
     # #24: MVP 実装は cross 軸の intrinsic サイズを測定しないため、``center``・
     # ``start``・``end`` を本来の意味で実装できない。従来はサイレントに
@@ -226,6 +228,33 @@ def add_flex_container(
     remain = max(0.0, usable_main - declared_total)
 
     grow_indices = [i for i, it in enumerate(items) if it.sizing == "grow"]
+
+    # #59: grow 項目の min_size 合計が残余予算を超える場合、``_distribute_grow``
+    # は各項目に宣言された min_size をクランプとして配り続け、結果として
+    # 合計が usable_main を超えてもサイレントに配置してしまう (items が
+    # コンテナ外にはみ出す)。#25 と同じ失敗モードだが、``fixed`` / ``content``
+    # の over-budget チェックでは検出できない経路である。ここで先回りして
+    # ``INVALID_PARAMETER`` で失敗させ、エージェントに修正の糸口を与える。
+    grow_min_total = sum(max(items[i].min_size, 0.0) for i in grow_indices)
+    if grow_min_total > remain + _OVER_BUDGET_EPS:
+        gap_total = gap * max(n - 1, 0)
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            (
+                "Flex container over-budget: "
+                f"grow items' min_size total={grow_min_total:.2f} "
+                f"exceeds remaining budget={remain:.2f} "
+                f"(= usable_main={usable_main:.2f} "
+                f"- fixed_total={fixed_total:.2f} "
+                f"- content_total={content_total:.2f}; "
+                f"{'width' if direction == 'row' else 'height'}="
+                f"{(width if direction == 'row' else height):.2f} "
+                f"- 2*padding={2 * padding:.2f} "
+                f"- gap*(n-1)={gap_total:.2f}). "
+                "Reduce min_size or increase container width."
+            ),
+        )
+
     grow_sizes = _distribute_grow(items, grow_indices, remain)
 
     # 各 item の main 軸サイズを決定

--- a/tests/test_flex.py
+++ b/tests/test_flex.py
@@ -423,6 +423,116 @@ def test_padding_tight_fit_ok_then_over_budget():
     assert "9.00" in msg
 
 
+# ── #59: grow items' min_size over-budget ────────────────────────────
+
+def test_grow_min_over_budget_three_items_raises():
+    """3 × grow(grow=1, min_size=4) in 10" (padding=0, gap=0) は INVALID_PARAMETER で失敗する (#59).
+
+    remain=10、min_size 合計 12 > 10 なので ``_distribute_grow`` のクランプ
+    によってコンテナ外配置が発生する経路。先回りして弾く。
+    """
+    renders = [_recorder() for _ in range(3)]
+    items = [
+        FlexItem(sizing="grow", grow=1.0, min_size=4.0, render=renders[0][0]),
+        FlexItem(sizing="grow", grow=1.0, min_size=4.0, render=renders[1][0]),
+        FlexItem(sizing="grow", grow=1.0, min_size=4.0, render=renders[2][0]),
+    ]
+    with pytest.raises(EngineError) as excinfo:
+        add_flex_container(
+            slide=None,
+            items=items,
+            left=0.0, top=0.0, width=10.0, height=1.0,
+            direction="row", gap=0.0, padding=0.0,
+        )
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMETER
+    msg = str(excinfo.value)
+    # エラーメッセージは fixed/content over-budget と区別できる語彙を含む
+    assert "grow" in msg
+    assert "min_size" in msg
+    # 数値根拠 (合計 12、remain 10) を含む
+    assert "12.00" in msg
+    assert "10.00" in msg
+    # render は一度も呼ばれていない (早期 raise)
+    for _, calls in renders:
+        assert calls == []
+
+
+def test_grow_min_within_budget_allocates_evenly():
+    """2 × grow(grow=1, min_size=3) in 10" (padding=0, gap=0) は 5+5 で成功する.
+
+    min_size 合計 6 ≤ remain 10 なので、クランプ発動せず通常按分する。
+    """
+    renders = [_recorder() for _ in range(2)]
+    items = [
+        FlexItem(sizing="grow", grow=1.0, min_size=3.0, render=renders[0][0]),
+        FlexItem(sizing="grow", grow=1.0, min_size=3.0, render=renders[1][0]),
+    ]
+    allocs = add_flex_container(
+        slide=None,
+        items=items,
+        left=0.0, top=0.0, width=10.0, height=1.0,
+        direction="row", gap=0.0, padding=0.0,
+    )
+    assert _approx(allocs[0][2], 5.0)
+    assert _approx(allocs[1][2], 5.0)
+
+
+def test_grow_min_over_budget_with_fixed_raises():
+    """1 × fixed(2) + 2 × grow(grow=1, min_size=5) in 10" (gap=0) は raises.
+
+    fixed_total=2、remain=8、grow min 合計 10 > 8。
+    """
+    renders = [_recorder() for _ in range(3)]
+    items = [
+        FlexItem(sizing="fixed", size=2.0, render=renders[0][0]),
+        FlexItem(sizing="grow", grow=1.0, min_size=5.0, render=renders[1][0]),
+        FlexItem(sizing="grow", grow=1.0, min_size=5.0, render=renders[2][0]),
+    ]
+    with pytest.raises(EngineError) as excinfo:
+        add_flex_container(
+            slide=None,
+            items=items,
+            left=0.0, top=0.0, width=10.0, height=1.0,
+            direction="row", gap=0.0, padding=0.0,
+        )
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMETER
+    msg = str(excinfo.value)
+    assert "grow" in msg
+    assert "min_size" in msg
+    # remain=8、min 合計=10
+    assert "10.00" in msg
+    assert "8.00" in msg
+    for _, calls in renders:
+        assert calls == []
+
+
+def test_grow_min_over_budget_column_direction_raises():
+    """direction='column' でも同じチェックが有効である (縦軸).
+
+    3 × grow(min_size=4) in height=10" → 合計 12 > 10 で raises。
+    """
+    renders = [_recorder() for _ in range(3)]
+    items = [
+        FlexItem(sizing="grow", grow=1.0, min_size=4.0, render=renders[0][0]),
+        FlexItem(sizing="grow", grow=1.0, min_size=4.0, render=renders[1][0]),
+        FlexItem(sizing="grow", grow=1.0, min_size=4.0, render=renders[2][0]),
+    ]
+    with pytest.raises(EngineError) as excinfo:
+        add_flex_container(
+            slide=None,
+            items=items,
+            left=0.0, top=0.0, width=1.0, height=10.0,
+            direction="column", gap=0.0, padding=0.0,
+        )
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMETER
+    msg = str(excinfo.value)
+    assert "grow" in msg
+    assert "min_size" in msg
+    assert "height" in msg
+    for _, calls in renders:
+        assert calls == []
+
+
 def test_render_receives_correct_args():
     """render コールバックが allocations と一致する引数で呼ばれる."""
     render, calls = _recorder()


### PR DESCRIPTION
## Summary

- Fixes #59: `add_flex_container` silently over-allocated when grow items' `min_size` sum exceeded the remaining budget. `_distribute_grow` happily clamped every grow item to its declared `min_size`, pushing later items outside the container — same failure mode PR #47 prevented, but via the grow/min path rather than fixed/content.
- Add a pre-distribution check in `add_flex_container` (after `remain` is computed, before calling `_distribute_grow`): if `sum(max(it.min_size, 0) for grow items) > remain + eps`, raise `EngineError(INVALID_PARAMETER)` with a message that (a) clearly identifies the grow/min path so agents can distinguish it from the fixed/content over-budget message, and (b) spells out the budget breakdown (`usable_main`, `fixed_total`, `content_total`, container width/height, padding, gap).
- The check lives in the shared code path after direction branching, so both `row` and `column` directions are covered by a single branch.
- `_distribute_grow` itself is untouched — it remains correct for the in-budget case.

## Test plan

- [x] New: `test_grow_min_over_budget_three_items_raises` — 3 × grow(grow=1, min_size=4) in 10" raises with "grow" + "min_size" in the message; render never called.
- [x] New: `test_grow_min_within_budget_allocates_evenly` — 2 × grow(grow=1, min_size=3) in 10" succeeds with 5+5 allocation (regression guard that the check does not over-fire).
- [x] New: `test_grow_min_over_budget_with_fixed_raises` — 1 × fixed(2) + 2 × grow(grow=1, min_size=5) in 10" raises (remain=8, grow-min total=10).
- [x] New: `test_grow_min_over_budget_column_direction_raises` — same check applies on the vertical axis.
- [x] Existing 26 flex tests still pass (fixed/content over-budget path unchanged).
- [x] Full suite: 475 passed (471 baseline + 4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)