### PR TITLE
fix(validation): per-run effective-size resolution in check_unreadable_text

### DIFF
--- a/src/pptx_mcp_server/engine/validation.py
+++ b/src/pptx_mcp_server/engine/validation.py
@@ -311,6 +311,42 @@ def _effective_paragraph_size(paragraph, default_pt: float = 18.0) -> float:
     return default_pt
 
 
+def _effective_run_size(run, paragraph, default_pt: float = 18.0) -> float:
+    """run の実効フォントサイズ (pt) を解決する.
+
+    優先順:
+        1. ``run.font.size`` (run に明示された値)
+        2. ``paragraph.font.size`` (paragraph の ``rPr`` 由来)
+        3. ``pPr/defRPr/@sz`` (段落既定値)
+        4. ``default_pt`` (フォールバック)
+
+    ``_effective_paragraph_size`` が段落全体の代表サイズ (run の最大値) を
+    返すのに対し、こちらは個別 run の継承サイズを解決する。同一段落内で
+    明示 size を持つ sibling run がいても、``size=None`` の run が defRPr
+    を継承する場合にその pt を正しく得る目的で使う (Issue #60)。
+    """
+    # (1) run レベル
+    size = run.font.size
+    if size is not None:
+        return size.pt
+
+    # (2) paragraph.font.size
+    try:
+        pf_size = paragraph.font.size
+    except Exception:
+        pf_size = None
+    if pf_size is not None:
+        return pf_size.pt
+
+    # (3) pPr/defRPr/@sz
+    defrpr_pt = _pptx_defrpr_size(paragraph)
+    if defrpr_pt is not None:
+        return defrpr_pt
+
+    # (4) デフォルト
+    return default_pt
+
+
 def _dominant_font_size(text_frame, default_pt: float = 18.0) -> float:
     """text_frame 内の段落で最大の実効フォントサイズ (pt) を返す.
 
@@ -560,23 +596,27 @@ def check_unreadable_text(
             if _is_footer_zone_shape(shape, tf, slide_height_in, min_readable_pt):
                 continue
             smallest: Optional[float] = None
-            # run に明示された size を優先、無い場合は段落の実効サイズを見る
+            # run 単位で実効サイズを解決する。明示 size のある sibling run が
+            # いても、``size=None`` の run が defRPr を継承するケースを取り
+            # こぼさない (Issue #60)。
             for para in tf.paragraphs:
-                seen_run_size = False
-                for run in para.runs:
-                    size = run.font.size
-                    if size is None:
-                        continue
-                    seen_run_size = True
-                    pt = size.pt
-                    if pt < min_readable_pt:
-                        if smallest is None or pt < smallest:
-                            smallest = pt
-                if not seen_run_size:
-                    # 段落レベル (paragraph.font.size / defRPr) を評価する
-                    # defRPr 経路で書かれた小フォントも確実に検出する
-                    eff_pt = _effective_paragraph_size(para, default_pt=min_readable_pt)
-                    # default_pt に閾値を入れているので defRPr 等で明示されない限り検出しない
+                runs = list(para.runs)
+                if runs:
+                    for run in runs:
+                        # 明示されない場合は min_readable_pt をフォールバックに
+                        # することで、defRPr 等で明示されない限り警告しない
+                        # ("size 不明 = 読みにくい" と誤警告しない) 挙動を保つ。
+                        eff_pt = _effective_run_size(
+                            run, para, default_pt=min_readable_pt
+                        )
+                        if eff_pt < min_readable_pt:
+                            if smallest is None or eff_pt < smallest:
+                                smallest = eff_pt
+                else:
+                    # run を持たない段落 (空段落) は paragraph / defRPr のみを見る
+                    eff_pt = _effective_paragraph_size(
+                        para, default_pt=min_readable_pt
+                    )
                     if eff_pt < min_readable_pt:
                         if smallest is None or eff_pt < smallest:
                             smallest = eff_pt

--- a/tests/test_validation_extended.py
+++ b/tests/test_validation_extended.py
@@ -16,6 +16,7 @@ from pptx_mcp_server.engine.validation import (
     ValidationFinding,
     _axis_groups,
     _effective_paragraph_size,
+    _effective_run_size,
     _projected_text_range,
     check_deck_extended,
     check_divider_collision,
@@ -561,6 +562,139 @@ class TestUnreadableWhitelistExtended:
         result = check_deck_extended(one_slide_prs, whitelist_names=["脚注"])
         assert result["slides"][0]["unreadable_text"] == []
         assert result["summary"]["warnings"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #60: check_unreadable_text per-run inherited-size resolution
+# ---------------------------------------------------------------------------
+
+
+def _install_defrpr(paragraph, sz_hundredths: int) -> None:
+    """段落に ``<a:pPr><a:defRPr sz="NN"/></a:pPr>`` を手動で付与する."""
+    from lxml import etree
+
+    a_ns = "http://schemas.openxmlformats.org/drawingml/2006/main"
+    p_elem = paragraph._p
+    for existing in p_elem.findall(f"{{{a_ns}}}pPr"):
+        p_elem.remove(existing)
+    p_pr = etree.SubElement(p_elem, f"{{{a_ns}}}pPr")
+    # pPr は段落の先頭子要素にある必要がある
+    p_elem.insert(0, p_pr)
+    etree.SubElement(p_pr, f"{{{a_ns}}}defRPr", {"sz": str(sz_hundredths)})
+
+
+class TestUnreadableRunInheritance:
+    """check_unreadable_text が run ごとに継承サイズを解決することを検証する (Issue #60)."""
+
+    def test_mixed_run_with_inherited_small_run_flagged(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # 段落に 11pt (明示) run と size=None の run (defRPr sz=600 → 6pt) を同居させる。
+        # 旧実装は「explicit run がある段落は run レベルのみ」で早期確定するため
+        # 継承 6pt を取りこぼす。新実装は run ごとに実効サイズを解決し警告する。
+        slide = one_slide_prs.slides[0]
+        tb = slide.shapes.add_textbox(
+            Inches(1.0), Inches(1.0), Inches(6.0), Inches(1.0)
+        )
+        tb.name = "MixedInheritBox"
+        tf = tb.text_frame
+        tf.text = "A"
+        para = tf.paragraphs[0]
+        # run A: 11pt 明示
+        run_a = para.runs[0]
+        run_a.font.size = Pt(11)
+        # run B: size=None (継承)
+        run_b = para.add_run()
+        run_b.text = "B"
+        assert run_b.font.size is None
+        # 段落 defRPr = 600 (= 6pt)
+        _install_defrpr(para, 600)
+
+        findings = check_unreadable_text(one_slide_prs)
+        matched = [f for f in findings if f.shape_name == "MixedInheritBox"]
+        assert len(matched) == 1
+        assert "6.0pt" in matched[0].message
+
+    def test_mixed_run_all_explicit_readable_no_finding(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # 同じ段落内に 11pt と 14pt の明示 run → どちらも閾値以上なので警告なし。
+        slide = one_slide_prs.slides[0]
+        tb = slide.shapes.add_textbox(
+            Inches(1.0), Inches(1.0), Inches(6.0), Inches(1.0)
+        )
+        tb.name = "TwoExplicitBox"
+        tf = tb.text_frame
+        tf.text = "A"
+        para = tf.paragraphs[0]
+        para.runs[0].font.size = Pt(11)
+        run_b = para.add_run()
+        run_b.text = "B"
+        run_b.font.size = Pt(14)
+
+        findings = check_unreadable_text(one_slide_prs)
+        matched = [f for f in findings if f.shape_name == "TwoExplicitBox"]
+        assert matched == []
+
+    def test_all_runs_inherit_readable_defrpr_no_finding(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # 全 run が size=None、defRPr sz=900 (9pt) → 閾値 8pt を上回るため警告なし。
+        slide = one_slide_prs.slides[0]
+        tb = slide.shapes.add_textbox(
+            Inches(1.0), Inches(1.0), Inches(6.0), Inches(1.0)
+        )
+        tb.name = "InheritReadableBox"
+        tf = tb.text_frame
+        tf.text = "X"
+        para = tf.paragraphs[0]
+        for run in para.runs:
+            run.font.size = None
+        _install_defrpr(para, 900)
+
+        findings = check_unreadable_text(one_slide_prs)
+        matched = [f for f in findings if f.shape_name == "InheritReadableBox"]
+        assert matched == []
+
+    def test_all_runs_inherit_small_defrpr_flagged_regression(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # Issue #23 の回帰: 全 run が size=None、defRPr sz=600 (6pt) → 警告 1 件。
+        slide = one_slide_prs.slides[0]
+        tb = slide.shapes.add_textbox(
+            Inches(1.0), Inches(1.0), Inches(6.0), Inches(1.0)
+        )
+        tb.name = "InheritSmallBox"
+        tf = tb.text_frame
+        tf.text = "X"
+        para = tf.paragraphs[0]
+        for run in para.runs:
+            run.font.size = None
+        _install_defrpr(para, 600)
+
+        findings = check_unreadable_text(one_slide_prs)
+        matched = [f for f in findings if f.shape_name == "InheritSmallBox"]
+        assert len(matched) == 1
+        assert "6.0pt" in matched[0].message
+
+    def test_effective_run_size_helper_resolves_defrpr(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # helper 単体: size=None の run が defRPr 経由で 6pt を解決できること。
+        slide = one_slide_prs.slides[0]
+        tb = slide.shapes.add_textbox(
+            Inches(1.0), Inches(1.0), Inches(6.0), Inches(1.0)
+        )
+        tf = tb.text_frame
+        tf.text = "A"
+        para = tf.paragraphs[0]
+        para.runs[0].font.size = Pt(11)
+        run_b = para.add_run()
+        run_b.text = "B"
+        _install_defrpr(para, 600)
+
+        assert _effective_run_size(para.runs[0], para, default_pt=18.0) == pytest.approx(11.0)
+        assert _effective_run_size(run_b, para, default_pt=18.0) == pytest.approx(6.0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `check_unreadable_text` が同一段落内に明示 `run.font.size` を持つ run がいると、``size=None`` で ``pPr/defRPr`` を継承する sibling run を取りこぼしていた問題を修正する (例: 11pt 明示 run と defRPr sz=600 継承 run が同居すると 6pt 継承 run が警告対象から外れる)。
- Issue #23 で追加された ``_effective_paragraph_size`` と同じ構造のバグを、run レベルの継承解決ヘルパ ``_effective_run_size(run, paragraph, default_pt)`` として切り出し、``check_unreadable_text`` を全 run 走査に書き換えた。公開シグネチャは保持している。
- whitelist_names / フッタ ヒューリスティック / defRPr-only 継承 (Issue #23) の既存挙動は回帰しない。

## Test plan
- [x] `python -m pytest tests/test_validation_extended.py -v` — 39 passed (5 new `TestUnreadableRunInheritance` ケース含む)
- [x] `python -m pytest` — 476 passed (全スイート)
- [x] 新規ケース: 混在 run (11pt 明示 + defRPr 継承 6pt) で run B に対する警告が出ること
- [x] 新規ケース: 混在 run (11pt + 14pt 両方明示) で警告なし
- [x] 新規ケース: 全 run 継承 9pt (defRPr) で警告なし
- [x] 回帰ケース: 全 run 継承 6pt (defRPr) で警告 1 件 (Issue #23 保持)
- [x] 既存 whitelist / 英語正規表現 / ヒューリスティック / deck_extended 伝搬テスト全通過

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)