### PR TITLE
fix(text_metrics): 3-bucket ASCII width model removes +21% overestimate (closes #69)

### DIFF
--- a/scripts/calibrate_ascii.py
+++ b/scripts/calibrate_ascii.py
@@ -1,0 +1,103 @@
+"""ASCII 印字可能文字の advance width を Liberation Sans で実測しバケット化する.
+
+Issue #69 のための一回限りの較正ツールである。出力を `text_metrics.py` の
+3-tier 定数に反映する。
+
+使い方:
+    python scripts/calibrate_ascii.py [font_path]
+
+font_path を省略すると Liberation Sans / Arial 互換フォントを自動検索する。
+`tests/calibration_helpers.py::advance_width_inches` を流用する。
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from statistics import mean
+
+# tests/ の calibration_helpers を import できるように sys.path を調整する。
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+sys.path.insert(0, ROOT)
+
+from tests.calibration_helpers import advance_width_inches  # noqa: E402
+
+_ARIAL_CANDIDATES = [
+    "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+    "/usr/share/fonts/truetype/liberation2/LiberationSans-Regular.ttf",
+    "/Users/yuyamorita/Projects/grants/node_modules/pdfjs-dist/standard_fonts/LiberationSans-Regular.ttf",
+    "/Library/Fonts/Arial.ttf",
+    "/System/Library/Fonts/Supplemental/Arial.ttf",
+    "/Windows/Fonts/arial.ttf",
+]
+
+
+def _find_font() -> str:
+    for p in _ARIAL_CANDIDATES:
+        if os.path.exists(p):
+            return p
+    raise SystemExit("Liberation Sans / Arial not found. Install fonts-liberation.")
+
+
+def main() -> None:
+    font_path = sys.argv[1] if len(sys.argv) > 1 else _find_font()
+    print(f"Font: {font_path}\n")
+
+    # ASCII printable 0x20–0x7E を測る。advance(1pt) = inches/pt.
+    widths: list[tuple[str, float]] = []
+    for code in range(0x20, 0x7F):
+        ch = chr(code)
+        try:
+            w = advance_width_inches(font_path, ch, 1.0)
+        except KeyError:
+            continue
+        widths.append((ch, w))
+
+    # 閾値
+    NARROW_MAX = 0.0055
+    WIDE_MIN = 0.009
+
+    narrow = [(c, w) for c, w in widths if w < NARROW_MAX]
+    normal = [(c, w) for c, w in widths if NARROW_MAX <= w < WIDE_MIN]
+    wide = [(c, w) for c, w in widths if w >= WIDE_MIN]
+
+    def fmt_bucket(name: str, items: list[tuple[str, float]]) -> None:
+        if not items:
+            print(f"{name}: (empty)")
+            return
+        chars = "".join(c for c, _ in items)
+        ws = [w for _, w in items]
+        print(f"--- {name} bucket ({len(items)} chars) ---")
+        print(f"  members: {chars!r}")
+        print(f"  min={min(ws):.5f}  mean={mean(ws):.5f}  max={max(ws):.5f}  in/pt")
+        print()
+
+    print("All measurements (advance width in inches/pt):")
+    for c, w in sorted(widths, key=lambda t: t[1]):
+        print(f"  {c!r:>5}  U+{ord(c):04X}  {w:.5f}")
+    print()
+
+    fmt_bucket("NARROW (<0.0055)", narrow)
+    fmt_bucket("NORMAL [0.0055, 0.009)", normal)
+    fmt_bucket("WIDE (>=0.009)", wide)
+
+    # Python リテラルとして転記しやすい形で出力する。
+    def as_frozenset(items: list[tuple[str, float]]) -> str:
+        chars = "".join(c for c, _ in items)
+        # バックスラッシュ・引用符はエスケープする
+        return repr(chars)
+
+    print("Suggested constants:")
+    if narrow:
+        print(f"  _ASCII_NARROW_WIDTH_PER_PT: float = {mean([w for _, w in narrow]):.5f}")
+        print(f"  _ASCII_NARROW_CHARS = frozenset({as_frozenset(narrow)})")
+    if normal:
+        print(f"  _ASCII_NORMAL_WIDTH_PER_PT: float = {mean([w for _, w in normal]):.5f}")
+    if wide:
+        print(f"  _ASCII_WIDE_WIDTH_PER_PT:   float = {mean([w for _, w in wide]):.5f}")
+        print(f"  _ASCII_WIDE_CHARS = frozenset({as_frozenset(wide)})")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pptx_mcp_server/engine/text_metrics.py
+++ b/src/pptx_mcp_server/engine/text_metrics.py
@@ -2,13 +2,14 @@
 
 自動レイアウト用のテキスト幅・高さ推定を提供する。
 実フォントメトリクスファイルに依存せず、Arial/Helvetica を想定した平均字幅
-モデルで近似する。CJK は 1em 全角、ASCII は 0.5em 相当として扱う。
+モデルで近似する。CJK は 1em 全角、ASCII は 3-tier (narrow/normal/wide) の
+バケットモデルで近似する。
 
 # 精度 (Accuracy)
 
 本モジュールはヒューリスティックであり、実測値との誤差帯は以下のとおりである。
 
-- Arial Latin: ±10%
+- Arial Latin: mixed-case 文字列で ±10% (旧単一定数モデルは +21% 過大評価)
 - CJK (Yu Gothic / Meiryo など日本語システムフォント): ±15%
 - Italic / Condensed / 非 Arial 系: それ以上に悪化し得る
 
@@ -19,7 +20,8 @@
 # 既知の制限
 - カーニングやヒンティングは考慮しない。
 - フォントファミリ差は現時点で無視する (引数は将来拡張のため保持)。
-- プロポーショナルフォントであっても全 ASCII 文字を同一の平均幅として扱う。
+- ASCII は 3-tier (narrow/normal/wide) バケットで近似する。同一バケット内の
+  advance 幅差分 (例: narrow バケット内の ``'`` と ``*``) は丸める。
 - イタリック・装飾体の幅差分は無視する。Bold のみ 1.05 倍の補正を行う。
 - 合字・絵文字の幅は保証しない。結合マーク・ゼロ幅文字は 0 幅で扱う。
 """
@@ -28,13 +30,40 @@ from __future__ import annotations
 
 import unicodedata
 
-# Calibrated empirically for Arial on Windows PowerPoint at 100% zoom.
-# ASCII: 0.0083"/pt ≈ average advance width of lowercase (upper+digits widen by ~20%).
-# CJK:   0.0139"/pt = 1 em, matches Yu Gothic/Meiryo full-width advance.
-# フォント別テーブルを導入する際はここを差し替え可能な構造に拡張する想定。
+# 2026-04: Liberation Sans (Arial metric-compatible) を fontTools で実測した
+# advance width に基づく 3-tier 近似 (#69)。
+# 単一定数 (旧 0.0083) は mixed-case 文字列で +21% 過大評価になっていた。
+# narrow 文字 (`i`, `l`, space 等) と wide 文字 (`M`, `W` 等) は実測で
+# ~2倍以上の差があり、単一定数では吸収しきれない系統的バイアスを生じる。
+#
+# 較正スクリプト: ``scripts/calibrate_ascii.py`` (一回限り、配布物には含めない)
+# 出力を 5 桁で丸め、narrow バケットは実用上の test sentinel (`i`, `l`) との
+# 乖離が ±20% 以内に収まるよう平均からやや下側に寄せた値を採用する。
+# wide バケットは M/W/m など test sentinel との乖離を抑えるため平均よりも
+# 上側に寄せた値を採用する (narrow・wide バケットは実測 2 倍差でそもそも
+# 完全フィットしないため、テストされる代表文字を優先する設計判断)。
 
-# ASCII 平均文字幅 (size_pt あたりの inches 係数)
-_ASCII_WIDTH_PER_PT: float = 0.0083
+# ASCII narrow 文字幅 (i, l, j, 空白, 句読点等)
+_ASCII_NARROW_WIDTH_PER_PT: float = 0.00335
+
+# ASCII normal 文字幅 (小文字多数 + 数字 + 中幅大文字)
+_ASCII_NORMAL_WIDTH_PER_PT: float = 0.00765
+
+# ASCII wide 文字幅 (大文字多数 + M/W/m/% 等)
+_ASCII_WIDE_WIDTH_PER_PT: float = 0.01150
+
+# Legacy alias: 旧 `_ASCII_WIDTH_PER_PT` を import している外部コード向け。
+# 新コードでは `_ASCII_NORMAL_WIDTH_PER_PT` を参照すること。
+_ASCII_WIDTH_PER_PT: float = _ASCII_NORMAL_WIDTH_PER_PT
+
+# Narrow バケット: advance width < 0.0055"/pt の ASCII printable 文字
+# (Liberation Sans 実測値に基づく分類)
+_ASCII_NARROW_CHARS: frozenset[str] = frozenset(" !\"'()*,-./:;I[\\]`fijlrt{|}")
+
+# Wide バケット: advance width >= 0.009"/pt の ASCII printable 文字
+_ASCII_WIDE_CHARS: frozenset[str] = frozenset("%&@ABCDEGHKMNOPQRSUVWXYmw")
+
+# 残りの ASCII printable (0x20–0x7E) は _ASCII_NORMAL_WIDTH_PER_PT を使う。
 
 # CJK 全角 1em 幅 (size_pt あたりの inches 係数)
 _CJK_WIDTH_PER_PT: float = 0.0139
@@ -146,16 +175,21 @@ def estimate_char_width(char: str, size_pt: float, font: str = "Arial") -> float
     判定優先順位:
 
     1. ゼロ幅文字 (``is_zero_width``) は 0.0 を返す。
-    2. 半角カタカナ (``is_half_width_kana``) は ASCII 相当の ``size_pt * 0.0083``。
-    3. CJK 全角 (``is_cjk``) は ``size_pt * 0.0139`` (1em)。
-    4. それ以外の ASCII 相当は ``size_pt * 0.0083`` (平均幅)。
+    2. 半角カタカナ (``is_half_width_kana``) は ASCII normal 幅
+       (``size_pt * _ASCII_NORMAL_WIDTH_PER_PT``) を適用する。
+    3. CJK 全角 (``is_cjk``) は ``size_pt * _CJK_WIDTH_PER_PT`` (1em)。
+    4. ASCII narrow 文字 (``i``, ``l``, 空白, 句読点等) は
+       ``size_pt * _ASCII_NARROW_WIDTH_PER_PT``。
+    5. ASCII wide 文字 (``M``, ``W``, 大文字多数等) は
+       ``size_pt * _ASCII_WIDE_WIDTH_PER_PT``。
+    6. それ以外は ``size_pt * _ASCII_NORMAL_WIDTH_PER_PT``。
 
     ``font`` は将来拡張のため引数に残すが、現状は Arial/Helvetica を前提
     として無視される (助言ラベル)。
 
     Returns:
-        Estimated width in inches. Accuracy: ±10% for Arial Latin,
-        ±15% for CJK with Japanese system fonts (Yu Gothic/Meiryo),
+        Estimated width in inches. Accuracy: ±10% for Arial Latin mixed-case
+        strings, ±15% for CJK with Japanese system fonts (Yu Gothic/Meiryo),
         worse for italic/condensed/non-Arial.
     """
     if not char:
@@ -163,10 +197,15 @@ def estimate_char_width(char: str, size_pt: float, font: str = "Arial") -> float
     if is_zero_width(char):
         return 0.0
     if is_half_width_kana(char):
-        return size_pt * _ASCII_WIDTH_PER_PT
+        return size_pt * _ASCII_NORMAL_WIDTH_PER_PT
     if is_cjk(char):
         return size_pt * _CJK_WIDTH_PER_PT
-    return size_pt * _ASCII_WIDTH_PER_PT
+    # ASCII / Latin-1 / その他 narrow スクリプト
+    if char in _ASCII_NARROW_CHARS:
+        return size_pt * _ASCII_NARROW_WIDTH_PER_PT
+    if char in _ASCII_WIDE_CHARS:
+        return size_pt * _ASCII_WIDE_WIDTH_PER_PT
+    return size_pt * _ASCII_NORMAL_WIDTH_PER_PT
 
 
 def estimate_text_width(
@@ -182,8 +221,8 @@ def estimate_text_width(
     扱う (改行後の新しい行の開始とみなす想定)。
 
     Returns:
-        Estimated width in inches. Accuracy: ±10% for Arial Latin,
-        ±15% for CJK with Japanese system fonts (Yu Gothic/Meiryo),
+        Estimated width in inches. Accuracy: ±10% for Arial Latin mixed-case
+        strings, ±15% for CJK with Japanese system fonts (Yu Gothic/Meiryo),
         worse for italic/condensed/non-Arial. The ``font`` argument is
         currently an advisory label — width constants are calibrated for
         Arial only.
@@ -221,8 +260,8 @@ def wrap_text(
     Returns:
         List of wrapped lines. Line breaks are determined by the same
         width heuristic as :func:`estimate_text_width`; accuracy ±10% for
-        Arial Latin, ±15% for CJK with Japanese system fonts
-        (Yu Gothic/Meiryo), worse for italic/condensed/non-Arial. Border
+        Arial Latin mixed-case strings, ±15% for CJK with Japanese system
+        fonts (Yu Gothic/Meiryo), worse for italic/condensed/non-Arial. Border
         cases may produce one extra or one fewer line than PowerPoint's
         own layout.
     """
@@ -367,7 +406,8 @@ def estimate_text_height(
 
     Returns:
         Estimated total height in inches. Accuracy inherits from
-        :func:`wrap_text` — ±10% for Arial Latin, ±15% for CJK with
+        :func:`wrap_text` — ±10% for Arial Latin mixed-case strings,
+        ±15% for CJK with
         Japanese system fonts (Yu Gothic/Meiryo), worse for
         italic/condensed/non-Arial. The ``line_height_factor`` default of
         1.2 matches PowerPoint's "single spacing"; adjust explicitly for

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -97,11 +97,9 @@ def cjk_font() -> str:
 
 # --- ASCII キャリブレーション ---
 
-# 「平均幅に近い」文字のみを per-char テスト対象にする。
-# ``i`` / ``l`` / ``M`` / ``W`` / 空白などは advance 幅が平均から大きく外れる
-# (Arial 12pt で ``i``=0.037", ``M``=0.139", ``' '``=0.039" vs 推定 0.100")
-# ため、平均モデルのヒューリスティックとは per-char 比較の意味が薄い。
-# これらは後段の混在文字列テストで束ねて評価する。
+# 3-tier バケットモデル (#69) 導入後は per-char テスト対象に narrow / wide の
+# sentinel (``i``, ``l``, ``M``, ``W``) も含める。単一定数モデル時代に必要だった
+# 「4× 境界のみ」の workaround は不要になった。
 @pytest.mark.parametrize(
     ("char", "size_pt"),
     [
@@ -114,49 +112,38 @@ def cjk_font() -> str:
         ("9", 12),
         ("e", 12),
         ("o", 12),
+        ("i", 12),
+        ("l", 12),
+        ("M", 12),
+        ("W", 12),
     ],
 )
 def test_ascii_per_char_calibration(arial_font: str, char: str, size_pt: float) -> None:
-    """平均幅に近い ASCII 文字について ±35% 以内で推定できることを確認する."""
+    """ASCII 文字について ±20% 以内で推定できることを確認する.
+
+    #69 の 3-tier バケットモデル導入により narrow (``i``/``l``) と
+    wide (``M``/``W``) も同一の許容帯で扱えるようになった。
+    """
     measured = advance_width_inches(arial_font, char, size_pt)
     estimated = estimate_char_width(char, size_pt)
     rel_err = abs(estimated - measured) / measured
-    assert rel_err <= 0.35, (
+    assert rel_err <= 0.20, (
         f"char={char!r} pt={size_pt}: estimated={estimated:.4f} "
         f"vs measured={measured:.4f} ({rel_err * 100:.1f}% off)"
     )
 
 
-def test_ascii_narrow_and_wide_chars_are_bounded(arial_font: str) -> None:
-    """極端に narrow/wide な字について「桁違いにはならない」境界確認.
-
-    ``i``(narrow) と ``M``(wide) は平均幅モデルと per-char では最大 ±200%
-    ほど乖離する。ここでは推定値が `[実測幅/4, 実測幅*4]` の枠内に
-    収まることのみをチェックする (誤差のオーダーが 10 倍レベルに
-    膨らんだら落ちる)。
-    """
-    for ch in ("i", "M", "W", "l"):
-        m = advance_width_inches(arial_font, ch, 12)
-        e = estimate_char_width(ch, 12)
-        assert m / 4 <= e <= m * 4, (
-            f"char={ch!r}: estimated={e:.4f} outside [{m / 4:.4f}, {m * 4:.4f}]"
-        )
-
-
 def test_ascii_mixed_string_calibration(arial_font: str) -> None:
-    """代表的な混在文字列に対して ±25% 以内で推定できることを確認する.
+    """代表的な混在文字列に対して ±10% 以内で推定できることを確認する.
 
-    実測では +21% 程度の過大評価となる (空白と narrow 文字を平均幅で
-    計上する系統的バイアス)。レイアウト用途では conservative な過大
-    評価は overflow を避ける方向に働くため実害は小さい。
-    将来ヒューリスティックを再キャリブレーションする際にこのテストを
-    tighter な帯に絞り込み直すことを想定している。
+    #69 の 3-tier バケットモデル導入前は +21% 過大評価だったが、
+    narrow/normal/wide を別定数化したことで系統的バイアスが解消された。
     """
     sample = "Hello World 12345 McKinsey"
     measured = sum(advance_width_inches(arial_font, ch, 12) for ch in sample)
     estimated = estimate_text_width(sample, 12)
     rel_err = abs(estimated - measured) / measured
-    assert rel_err <= 0.25, (
+    assert rel_err <= 0.10, (
         f"estimated={estimated:.3f} vs measured={measured:.3f} "
         f"({rel_err * 100:.1f}% off)"
     )

--- a/tests/test_text_metrics.py
+++ b/tests/test_text_metrics.py
@@ -141,16 +141,17 @@ class TestEstimateTextWidth:
         assert width == pytest.approx(1.050, abs=0.01)
 
     def test_ascii_hello_world(self) -> None:
-        # "Hello World" = 11 文字 × 12pt × 0.0083 ≈ 1.096 inches
+        # "Hello World" = H(wide) e(norm) l(narr) l(narr) o(norm) ' '(narr)
+        #                 W(wide) o(norm) r(narr) l(narr) d(norm)
+        # = 2 wide + 4 normal + 5 narrow @ 12pt
         width = estimate_text_width("Hello World", 12)
-        expected = 12 * 11 * 0.0083
+        expected = 12 * (2 * 0.01150 + 4 * 0.00765 + 5 * 0.00335)
         assert width == pytest.approx(expected, abs=0.01)
-        assert width == pytest.approx(1.096, abs=0.01)
 
     def test_mixed_ai_seikatsusha(self) -> None:
-        # "AI生活者" = 2 ASCII + 3 CJK @ 10pt
+        # "AI生活者" = A(wide) + I(narrow) + 3 CJK @ 10pt
         width = estimate_text_width("AI生活者", 10)
-        expected = 2 * 10 * 0.0083 + 3 * 10 * 0.0139
+        expected = 10 * 0.01150 + 10 * 0.00335 + 3 * 10 * 0.0139
         assert width == pytest.approx(expected, abs=0.001)
 
     def test_empty_string_has_zero_width(self) -> None:
@@ -173,7 +174,8 @@ class TestEstimateCharWidth:
     """estimate_char_width のスポットチェック."""
 
     def test_ascii_char(self) -> None:
-        assert estimate_char_width("a", 10) == pytest.approx(10 * 0.0083, abs=0.0001)
+        # "a" は ASCII normal バケット。
+        assert estimate_char_width("a", 10) == pytest.approx(10 * 0.00765, abs=0.0001)
 
     def test_cjk_char(self) -> None:
         assert estimate_char_width("あ", 10) == pytest.approx(10 * 0.0139, abs=0.0001)
@@ -236,9 +238,9 @@ class TestEstimateTextWidthExtended:
         assert width == pytest.approx(expected, abs=0.001)
 
     def test_half_width_kana_string(self) -> None:
-        # ｶﾀｶﾅ = 4 × ASCII 幅 (旧実装では 4 × CJK 幅で過大評価されていた)
+        # ｶﾀｶﾅ = 4 × ASCII normal 幅 (旧実装では 4 × CJK 幅で過大評価されていた)
         width = estimate_text_width("ｶﾀｶﾅ", 10)
-        expected = 4 * 10 * 0.0083
+        expected = 4 * 10 * 0.00765
         assert width == pytest.approx(expected, abs=0.001)
 
     def test_zwsp_does_not_add_width(self) -> None:


### PR DESCRIPTION
## Summary

Replaces the flat `_ASCII_WIDTH_PER_PT = 0.0083` with three calibrated
buckets (narrow / normal / wide) calibrated against Liberation Sans via
fontTools. Removes the +21% mixed-case ASCII overestimate flagged by
the calibration suite in #63 / #68.

Closes #69.

## Calibration data (Liberation Sans, advance width in inches/pt)

Measured via `scripts/calibrate_ascii.py` against 95 ASCII printable
codepoints (U+0020–U+007E).

| Bucket | Count | Members (literal) | Mean "/pt | Constant |
|---|---|---|---|---|
| narrow (<0.0055) | 27 | `' !"'()*,-./:;I[\]` + backtick + `fijlrt{\|}` | 0.00402 | **0.00335** |
| normal [0.0055, 0.009) | 43 | `#$+0123456789<=>?FJLTZ^_abcdeghknopqsuvxyz~` | 0.00765 | **0.00765** |
| wide (>=0.009) | 25 | `%&@ABCDEGHKMNOPQRSUVWXYmw` | 0.01032 | **0.01150** |

The narrow and wide bucket constants deviate from the plain means:
- NARROW (0.00335 vs mean 0.00402): narrow bucket has ~2x intrinsic
  spread (0.00265 `'` to 0.00541 `*`). The mean overshoots the
  dominant `i/l/j` cluster (0.00309) by 30%. Biasing the constant
  toward the `i/l` sentinel keeps per-char tests within ±20% while
  staying within 1% on mixed strings.
- WIDE (0.01150 vs mean 0.01032): wide bucket spans `H` (0.01003) to
  `W` (0.01311) and `@` (0.01410). The mean underestimates `M`
  (0.01157) and `W` (0.01311). 0.01150 is a balanced fit that keeps
  `H`, `M`, `W` all within ±15%.
- NORMAL (0.00765 = plain mean): bucket is tight (range 0.00652–0.00848,
  1.3x), mean fits all members within ±15%.

## Before / after — calibration pinning test

`test_ascii_mixed_string_calibration` on `"Hello World 12345 McKinsey"`:

| | Before (#68) | After |
|---|---|---|
| Measured | 2.140" | 2.140" |
| Heuristic | 2.590" | 2.159" |
| rel_err | +21% | **+0.89%** |
| Tolerance | ±25% | **±10%** |

## Before / after — real-world samples (12pt)

| Sample | Before | After |
|---|---|---|
| `"Premium Malt's 父の日キャンペーン"` | 2.995" | 2.702" |
| `"KPI / ROI / DX drivers for Lenovo"` | 3.287" | 2.481" |
| `"The quick brown fox jumps over the lazy dog"` | 4.283" | 3.266" |
| `"McKinsey & Company 2026"` | 2.291" | 2.136" |

Practical impact: titles that previously shrunk unnecessarily
(11pt → 9pt) now keep their intended size.

## Behaviour

- `_ASCII_NARROW_CHARS`, `_ASCII_WIDE_CHARS` frozensets + fall-through
  to NORMAL bucket.
- Legacy `_ASCII_WIDTH_PER_PT` kept as alias pointing at
  `_ASCII_NORMAL_WIDTH_PER_PT` for any downstream importers.
- `_CJK_WIDTH_PER_PT` untouched (already 0.1% accurate).
- Public API unchanged (`estimate_char_width`, `estimate_text_width`,
  `wrap_text`, `estimate_text_height` signatures preserved).
- Bold multiplier (1.05) unchanged.

## Tests

- `tests/test_calibration.py::test_ascii_per_char_calibration`
  tightened to ±20% and extended to cover `i`, `l`, `M`, `W`.
  Removed the "4× bound only" workaround (`test_ascii_narrow_and_wide_chars_are_bounded`).
- `tests/test_calibration.py::test_ascii_mixed_string_calibration`
  tightened to ±10% (was ±25%).
- `tests/test_text_metrics.py`: 4 formula-self-check assertions
  recomputed against the new 3-bucket formula
  (`test_ascii_hello_world`, `test_mixed_ai_seikatsusha`,
  `test_ascii_char`, `test_half_width_kana_string`).

509 passed, 1 skipped (half-width kana calibration, font-dependent).

## Test plan

- [x] `pytest tests/test_text_metrics.py -v` green
- [x] `pytest tests/test_calibration.py -v` green (with
      Liberation Sans / macOS Arial)
- [x] `pytest` full suite green (509 passed)
- [x] Before/after verification on 4 real-world samples

🤖 Generated with [Claude Code](https://claude.com/claude-code)