### PR TITLE
fix(pptx_io): add opt-in fsync for crash durability (closes #73)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,10 +86,20 @@ or a sibling module that is only imported when the CLI starts.
 
 ## File safety
 
-`save_pptx` is atomic (temp-file-then-rename) but does NOT guard against
-concurrent writes from multiple processes. The single-writer contract is:
-at most one process mutates a given `.pptx` path at a time. Consumers that
-need multi-writer coordination should layer their own locking on top.
+`save_pptx` performs an atomic temp-file-then-rename (via `os.replace`), so
+a crash during save preserves the original file. This is atomicity, not
+durability: the new file's contents may still be in page cache when the call
+returns. For crash-durable saves, pass `fsync=True` — this adds an I/O
+barrier on the temp file and the containing directory before returning.
+
+The default is `fsync=False` because most deck-generation workflows don't
+need power-loss durability (the process can re-run). Enable fsync when:
+- Saving a long-running batch result that would be expensive to regenerate
+- Writing to a mount that buffers aggressively
+- Required by a compliance/archival policy
+
+Concurrency contract: at most one process mutates a given .pptx path at a
+time. Cross-process locking is not provided.
 
 ## Pull request flow
 

--- a/src/pptx_mcp_server/engine/pptx_io.py
+++ b/src/pptx_mcp_server/engine/pptx_io.py
@@ -5,6 +5,7 @@ PPTX file I/O — open, save, create, error types.
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
 from enum import Enum
 from pptx import Presentation
@@ -38,19 +39,24 @@ def open_pptx(file_path: str) -> Presentation:
         raise EngineError(ErrorCode.INVALID_PPTX, f"Not a valid PPTX file: {file_path} ({e})")
 
 
-def save_pptx(prs: Presentation, file_path: str) -> None:
+def save_pptx(prs: Presentation, file_path: str, fsync: bool = False) -> None:
     """PPTX を原子的に保存する。
 
-    同一ディレクトリに一時ファイルを書き出したあと ``os.replace`` で rename する。
-    ``os.replace`` は POSIX でも Windows でも atomic であり、
-    途中で失敗しても元のファイルは損なわれない。
+    Atomicity (default): os.replace is syscall-atomic on POSIX and Windows
+    within a single filesystem — the old file is preserved if the save raises
+    mid-write.
 
-    注意: 原子性は同一ファイルシステム内でのみ保証されるため、一時ファイルは
-    必ず target と同じディレクトリに作る。クロスマウントでの temp+rename は
-    静かに degrade するため避ける。
+    Durability (fsync=True, opt-in): fsyncs the temp file AND the containing
+    directory entry before returning, so the new file survives power loss on
+    local ext4/xfs/NTFS. Adds one-to-two disk barriers per call — avoid on
+    hot paths. Skipped on Windows for directory fsync (unsupported).
 
-    なお本関数はクラッシュ耐性のみを目的としており、マルチプロセス間の
-    書き込み排他は行わない (単一ライター契約。詳細は CONTRIBUTING.md 参照)。
+    Caveats:
+    - NFS: os.replace atomicity depends on server + client config. Do not
+      rely on fsync for cross-mount durability.
+    - Windows: os.replace raises PermissionError if the target is held open
+      (e.g., the .pptx is open in PowerPoint). Caller should retry or
+      surface a clear error.
     """
     abs_path = os.path.abspath(file_path)
     dir_ = os.path.dirname(abs_path) or "."
@@ -64,7 +70,22 @@ def save_pptx(prs: Presentation, file_path: str) -> None:
     os.close(fd)
     try:
         prs.save(tmp_path)
+        if fsync:
+            # Flush the temp file's contents to disk before swapping it in.
+            tmp_fd = os.open(tmp_path, os.O_RDONLY)
+            try:
+                os.fsync(tmp_fd)
+            finally:
+                os.close(tmp_fd)
         os.replace(tmp_path, abs_path)
+        if fsync and sys.platform != "win32":
+            # fsync the containing directory so the rename itself survives
+            # power loss. Windows does not support directory fsync.
+            dir_fd = os.open(dir_, os.O_DIRECTORY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
     except Exception:
         try:
             os.unlink(tmp_path)

--- a/tests/test_pptx_io.py
+++ b/tests/test_pptx_io.py
@@ -5,12 +5,14 @@ Unit tests for pptx_io -- file operations and color parsing.
 from __future__ import annotations
 
 import os
+import sys
 
 import pytest
 from pptx import Presentation
 from pptx.util import Inches
 from pptx.dml.color import RGBColor
 
+from pptx_mcp_server.engine import pptx_io
 from pptx_mcp_server.engine.pptx_io import (
     EngineError,
     ErrorCode,
@@ -199,3 +201,126 @@ class TestSavePptx:
 
         leftovers = [p.name for p in tmp_path.iterdir() if ".tmp." in p.name]
         assert leftovers == []
+
+
+class TestSavePptxFsync:
+    """fsync=True opt-in path must call os.fsync; default must not."""
+
+    @staticmethod
+    def _install_fsync_counter(monkeypatch):
+        """Patch os.fsync via the pptx_io module's reference so the call site
+        picks up the mock (the module does `import os` then calls `os.fsync`,
+        so patching `os.fsync` on the shared `os` module is what the call
+        site sees)."""
+        calls = {"count": 0, "fds": []}
+        real_fsync = os.fsync
+
+        def mock_fsync(fd):
+            calls["count"] += 1
+            calls["fds"].append(fd)
+            return real_fsync(fd)
+
+        # Patch on the shared os module — pptx_io does `import os` so the
+        # attribute lookup goes through this module.
+        monkeypatch.setattr(os, "fsync", mock_fsync)
+        # Also patch via the engine module's `os` binding explicitly for
+        # robustness against any future `from os import fsync`-style import.
+        monkeypatch.setattr(pptx_io.os, "fsync", mock_fsync, raising=True)
+        return calls
+
+    def test_fsync_true_calls_fsync(self, tmp_path, monkeypatch):
+        """fsync=True must call os.fsync at least once (temp file). On
+        non-Windows, also calls it for the containing directory (>=2)."""
+        calls = self._install_fsync_counter(monkeypatch)
+
+        prs = Presentation()
+        path = str(tmp_path / "durable.pptx")
+        save_pptx(prs, path, fsync=True)
+
+        assert os.path.exists(path)
+        assert calls["count"] >= 1, "fsync=True must fsync the temp file"
+        if sys.platform != "win32":
+            assert calls["count"] >= 2, (
+                "fsync=True on POSIX must fsync both temp file and directory"
+            )
+
+    def test_fsync_false_does_not_call_fsync(self, tmp_path, monkeypatch):
+        """Default (fsync=False) must not invoke os.fsync."""
+        calls = self._install_fsync_counter(monkeypatch)
+
+        prs = Presentation()
+        path = str(tmp_path / "fast.pptx")
+        save_pptx(prs, path, fsync=False)
+
+        assert os.path.exists(path)
+        assert calls["count"] == 0, (
+            "default save must not impose an fsync barrier"
+        )
+
+    def test_fsync_default_is_false(self, tmp_path, monkeypatch):
+        """Omitting the fsync kwarg must behave like fsync=False."""
+        calls = self._install_fsync_counter(monkeypatch)
+
+        prs = Presentation()
+        path = str(tmp_path / "default.pptx")
+        save_pptx(prs, path)  # no kwarg
+
+        assert os.path.exists(path)
+        assert calls["count"] == 0
+
+    def test_fsync_true_still_atomic_on_crash(self, tmp_path, monkeypatch):
+        """fsync=True must preserve the same atomicity guarantee: if
+        Presentation.save raises, the original file is untouched and no
+        temp leaks."""
+        path = tmp_path / "existing.pptx"
+        original_bytes = b"ORIGINAL CONTENT -- not a real pptx"
+        path.write_bytes(original_bytes)
+
+        prs = Presentation()
+
+        def boom(*_args, **_kwargs):
+            raise IOError("simulated mid-write failure")
+
+        monkeypatch.setattr(type(prs), "save", boom, raising=True)
+
+        with pytest.raises(IOError, match="simulated"):
+            save_pptx(prs, str(path), fsync=True)
+
+        # Original bytes preserved, no temp leak.
+        assert path.read_bytes() == original_bytes
+        leftovers = [p.name for p in tmp_path.iterdir() if ".tmp." in p.name]
+        assert leftovers == []
+
+    def test_fsync_true_round_trips(self, tmp_path):
+        """fsync=True produces a valid, loadable PPTX (no regression)."""
+        prs = Presentation()
+        prs.slide_width = Inches(13.333)
+        prs.slide_height = Inches(7.5)
+        layout = prs.slide_layouts[6]
+        prs.slides.add_slide(layout)
+
+        path = str(tmp_path / "durable_rt.pptx")
+        save_pptx(prs, path, fsync=True)
+
+        loaded = Presentation(path)
+        assert len(loaded.slides) == 1
+        leftovers = [p.name for p in tmp_path.iterdir() if ".tmp." in p.name]
+        assert leftovers == []
+
+    def test_fsync_true_skips_dir_fsync_on_windows(self, tmp_path, monkeypatch):
+        """On Windows, directory fsync is unsupported and must be skipped:
+        only the temp-file fsync runs (1 call total)."""
+        calls = self._install_fsync_counter(monkeypatch)
+        monkeypatch.setattr(sys, "platform", "win32")
+        # pptx_io binds `import sys`; patch that reference too so the
+        # module's `sys.platform` check sees "win32".
+        monkeypatch.setattr(pptx_io.sys, "platform", "win32", raising=True)
+
+        prs = Presentation()
+        path = str(tmp_path / "win.pptx")
+        save_pptx(prs, path, fsync=True)
+
+        assert os.path.exists(path)
+        assert calls["count"] == 1, (
+            "on Windows, only the temp file is fsynced; directory fsync skipped"
+        )


### PR DESCRIPTION
## Summary

- Add `fsync: bool = False` kwarg to `save_pptx`. When `True`, fsync the temp file after `prs.save` and fsync the containing directory after `os.replace` so the new file and the rename itself survive power loss on local ext4/xfs/NTFS.
- Default remains `False`: existing callers are unchanged, no I/O barrier imposed on hot paths.
- Revise docstring to separate atomicity (always) from durability (opt-in), with NFS and Windows caveats.
- Expand CONTRIBUTING.md "File safety" section with when to enable fsync.

## Test plan

- [x] `python -m pytest tests/test_pptx_io.py -v` → 22 passed (6 new fsync tests)
- [x] `python -m pytest` → 515 passed, 1 skipped, no regressions
- [x] fsync=True asserts at least 1 fsync on all platforms, >=2 on POSIX (temp + dir)
- [x] fsync=False / default asserts 0 fsync calls
- [x] fsync=True on simulated `sys.platform = "win32"` calls fsync exactly once (dir fsync skipped)
- [x] fsync=True preserves atomicity: crash during save leaves original intact, no temp leak

Closes #73