### PR TITLE
fix(text_metrics): re-audit ASCII buckets using full sentinel coverage (closes #71)

### DIFF
--- a/scripts/calibrate_ascii.py
+++ b/scripts/calibrate_ascii.py
@@ -1,19 +1,31 @@
 """ASCII 印字可能文字の advance width を Liberation Sans で実測しバケット化する.
 
-Issue #69 のための一回限りの較正ツールである。出力を `text_metrics.py` の
-3-tier 定数に反映する。
+Issue #71 のための再較正ツールである (#69/#70 の後続)。出力を
+`text_metrics.py` の多段バケット定数に反映する。
 
 使い方:
     python scripts/calibrate_ascii.py [font_path]
 
 font_path を省略すると Liberation Sans / Arial 互換フォントを自動検索する。
 `tests/calibration_helpers.py::advance_width_inches` を流用する。
+
+#71 対応:
+- 全 ASCII printable (0x20–0x7E) の advance を測定した上で、
+  「worst-case per-char 相対誤差を最小化する」バケット分け探索を行う。
+- 3 バケット分割と 4 バケット分割を両方試し、
+  worst-case が ±20% 未満に収まる最小バケット数を採用する。
+- 各バケットの代表値は単純平均ではなく、そのバケットに属する文字の
+  worst-case 相対誤差を最小化する値 (= (min + max) / 2 の調和平均的な補正)
+  を採用する。厳密には worst-case 誤差を最小化する代表値は
+  sqrt(min*max) ではなく (2*min*max) / (min+max) (調和平均) で与えられる
+  ため、それを使う。
 """
 
 from __future__ import annotations
 
 import os
 import sys
+from itertools import combinations
 from statistics import mean
 
 # tests/ の calibration_helpers を import できるように sys.path を調整する。
@@ -40,6 +52,114 @@ def _find_font() -> str:
     raise SystemExit("Liberation Sans / Arial not found. Install fonts-liberation.")
 
 
+def _harmonic_mid(lo: float, hi: float) -> float:
+    """2 値 [lo, hi] に対して worst-case 相対誤差を最小化する代表値を返す.
+
+    err_at(c) = max(|c-lo|/lo, |c-hi|/hi)
+    を最小化する c を閉形式で求めると c = 2*lo*hi/(lo+hi) (調和平均) となる。
+    """
+    if lo <= 0 or hi <= 0:
+        return (lo + hi) / 2.0
+    return 2.0 * lo * hi / (lo + hi)
+
+
+def _worst_rel_err(repr_val: float, ws: list[float]) -> float:
+    return max(abs(repr_val - w) / w for w in ws) if ws else 0.0
+
+
+def _partition(widths: list[tuple[str, float]], cuts: list[float]) -> list[list[tuple[str, float]]]:
+    """``cuts`` (昇順) を境界として ``widths`` を (k+1) バケットに分ける."""
+    buckets: list[list[tuple[str, float]]] = [[] for _ in range(len(cuts) + 1)]
+    for c, w in widths:
+        idx = 0
+        for cut in cuts:
+            if w >= cut:
+                idx += 1
+            else:
+                break
+        buckets[idx].append((c, w))
+    return buckets
+
+
+def _search_best_partition(
+    widths: list[tuple[str, float]], k: int
+) -> tuple[list[list[tuple[str, float]]], list[float], list[float], float]:
+    """k バケットの境界を全探索して worst-case rel_err を最小化する.
+
+    境界候補: 実測 advance のソート済み一意値の隣接中点。
+    (文字数 ~95、k=3 の場合 ~C(94,2) ≈ 4400 通り、k=4 でも ~1.3e5 通りと十分小さい。)
+    """
+    if k < 2:
+        raise ValueError("k must be >= 2")
+    sorted_ws = sorted({w for _, w in widths})
+    # 隣接中点候補
+    candidates = [
+        (sorted_ws[i] + sorted_ws[i + 1]) / 2.0 for i in range(len(sorted_ws) - 1)
+    ]
+    best_worst = float("inf")
+    best_cuts: list[float] = []
+    best_buckets: list[list[tuple[str, float]]] = []
+    best_reprs: list[float] = []
+    for combo in combinations(candidates, k - 1):
+        cuts = list(combo)
+        buckets = _partition(widths, cuts)
+        if any(not b for b in buckets):
+            continue
+        reprs: list[float] = []
+        worst = 0.0
+        for b in buckets:
+            ws = [w for _, w in b]
+            r = _harmonic_mid(min(ws), max(ws))
+            reprs.append(r)
+            worst = max(worst, _worst_rel_err(r, ws))
+        if worst < best_worst:
+            best_worst = worst
+            best_cuts = cuts
+            best_buckets = buckets
+            best_reprs = reprs
+    return best_buckets, best_cuts, best_reprs, best_worst
+
+
+def _print_bucket(name: str, items: list[tuple[str, float]], repr_val: float) -> None:
+    if not items:
+        print(f"  {name}: (empty)")
+        return
+    chars = "".join(c for c, _ in items)
+    ws = [w for _, w in items]
+    worst = _worst_rel_err(repr_val, ws)
+    print(f"  --- {name} ({len(items)} chars) ---")
+    print(f"    members: {chars!r}")
+    print(
+        f"    min={min(ws):.5f}  mean={mean(ws):.5f}  max={max(ws):.5f}  in/pt"
+    )
+    print(f"    repr (harmonic mid) = {repr_val:.5f}  worst rel_err = {worst * 100:.2f}%")
+
+
+def _print_char_table(
+    widths: list[tuple[str, float]],
+    buckets: list[list[tuple[str, float]]],
+    reprs: list[float],
+    size_pt: float = 12.0,
+) -> None:
+    """全文字 → 割当バケット → 相対誤差 の表を印字する."""
+    # 文字 → バケット idx のマップを作る
+    char_to_idx: dict[str, int] = {}
+    for idx, b in enumerate(buckets):
+        for c, _ in b:
+            char_to_idx[c] = idx
+    print(f"\nPer-char assignment table (at {size_pt}pt, measured vs bucket repr):")
+    print(f"  {'char':>5}  {'code':>6}  {'measured':>9}  {'bucket':>6}  {'repr':>8}  {'rel_err':>8}")
+    for c, w in sorted(widths, key=lambda t: t[1]):
+        idx = char_to_idx[c]
+        r = reprs[idx]
+        measured_at_pt = w * size_pt
+        est_at_pt = r * size_pt
+        rel_err = abs(est_at_pt - measured_at_pt) / measured_at_pt
+        print(
+            f"  {c!r:>5}  U+{ord(c):04X}  {measured_at_pt:9.5f}  {idx:>6}  {est_at_pt:8.5f}  {rel_err * 100:7.2f}%"
+        )
+
+
 def main() -> None:
     font_path = sys.argv[1] if len(sys.argv) > 1 else _find_font()
     print(f"Font: {font_path}\n")
@@ -54,49 +174,38 @@ def main() -> None:
             continue
         widths.append((ch, w))
 
-    # 閾値
-    NARROW_MAX = 0.0055
-    WIDE_MIN = 0.009
-
-    narrow = [(c, w) for c, w in widths if w < NARROW_MAX]
-    normal = [(c, w) for c, w in widths if NARROW_MAX <= w < WIDE_MIN]
-    wide = [(c, w) for c, w in widths if w >= WIDE_MIN]
-
-    def fmt_bucket(name: str, items: list[tuple[str, float]]) -> None:
-        if not items:
-            print(f"{name}: (empty)")
-            return
-        chars = "".join(c for c, _ in items)
-        ws = [w for _, w in items]
-        print(f"--- {name} bucket ({len(items)} chars) ---")
-        print(f"  members: {chars!r}")
-        print(f"  min={min(ws):.5f}  mean={mean(ws):.5f}  max={max(ws):.5f}  in/pt")
-        print()
-
-    print("All measurements (advance width in inches/pt):")
+    print(f"Measured {len(widths)} ASCII printable chars.\n")
+    print("Raw sorted advance (in/pt):")
     for c, w in sorted(widths, key=lambda t: t[1]):
         print(f"  {c!r:>5}  U+{ord(c):04X}  {w:.5f}")
     print()
 
-    fmt_bucket("NARROW (<0.0055)", narrow)
-    fmt_bucket("NORMAL [0.0055, 0.009)", normal)
-    fmt_bucket("WIDE (>=0.009)", wide)
+    # 3-bucket と 4-bucket を両方試す。
+    for k in (3, 4):
+        print(f"\n===== Best {k}-bucket partition (minimize worst per-char rel_err) =====")
+        buckets, cuts, reprs, worst = _search_best_partition(widths, k)
+        print(f"  cuts: {[f'{c:.5f}' for c in cuts]}")
+        print(f"  worst-case rel_err across all chars: {worst * 100:.2f}%")
+        bucket_names = ["VERY_NARROW", "NARROW", "NORMAL", "WIDE"]
+        if k == 3:
+            bucket_names = ["NARROW", "NORMAL", "WIDE"]
+        for name, b, r in zip(bucket_names, buckets, reprs, strict=False):
+            _print_bucket(name, b, r)
+        _print_char_table(widths, buckets, reprs)
 
-    # Python リテラルとして転記しやすい形で出力する。
-    def as_frozenset(items: list[tuple[str, float]]) -> str:
-        chars = "".join(c for c, _ in items)
-        # バックスラッシュ・引用符はエスケープする
-        return repr(chars)
+        if worst <= 0.20:
+            print(f"\n  --> {k}-bucket partition satisfies <=20% per-char target.")
+        else:
+            print(f"\n  --> {k}-bucket partition does NOT satisfy <=20% target.")
 
-    print("Suggested constants:")
-    if narrow:
-        print(f"  _ASCII_NARROW_WIDTH_PER_PT: float = {mean([w for _, w in narrow]):.5f}")
-        print(f"  _ASCII_NARROW_CHARS = frozenset({as_frozenset(narrow)})")
-    if normal:
-        print(f"  _ASCII_NORMAL_WIDTH_PER_PT: float = {mean([w for _, w in normal]):.5f}")
-    if wide:
-        print(f"  _ASCII_WIDE_WIDTH_PER_PT:   float = {mean([w for _, w in wide]):.5f}")
-        print(f"  _ASCII_WIDE_CHARS = frozenset({as_frozenset(wide)})")
+        # Python リテラル出力。
+        print("\nSuggested constants:")
+        for name, b, r in zip(bucket_names, buckets, reprs, strict=False):
+            chars = "".join(c for c, _ in b)
+            # sort for readability
+            chars_sorted = "".join(sorted(chars))
+            print(f"  _ASCII_{name}_WIDTH_PER_PT: float = {r:.5f}")
+            print(f"  _ASCII_{name}_CHARS = frozenset({chars_sorted!r})")
 
 
 if __name__ == "__main__":

--- a/src/pptx_mcp_server/engine/text_metrics.py
+++ b/src/pptx_mcp_server/engine/text_metrics.py
@@ -2,14 +2,16 @@
 
 自動レイアウト用のテキスト幅・高さ推定を提供する。
 実フォントメトリクスファイルに依存せず、Arial/Helvetica を想定した平均字幅
-モデルで近似する。CJK は 1em 全角、ASCII は 3-tier (narrow/normal/wide) の
-バケットモデルで近似する。
+モデルで近似する。CJK は 1em 全角、ASCII は 4-tier
+(very_narrow / narrow / normal / wide) のバケットモデルで近似する。
 
 # 精度 (Accuracy)
 
 本モジュールはヒューリスティックであり、実測値との誤差帯は以下のとおりである。
 
-- Arial Latin: mixed-case 文字列で ±10% (旧単一定数モデルは +21% 過大評価)
+- Arial Latin per-char: 全 ASCII printable (0x20–0x7E) で最悪 ±17.4%
+  (Liberation Sans 実測ベース、4-bucket 分割で最適化)
+- Arial Latin mixed string: 代表的な文字列で ±10%
 - CJK (Yu Gothic / Meiryo など日本語システムフォント): ±15%
 - Italic / Condensed / 非 Arial 系: それ以上に悪化し得る
 
@@ -20,8 +22,8 @@
 # 既知の制限
 - カーニングやヒンティングは考慮しない。
 - フォントファミリ差は現時点で無視する (引数は将来拡張のため保持)。
-- ASCII は 3-tier (narrow/normal/wide) バケットで近似する。同一バケット内の
-  advance 幅差分 (例: narrow バケット内の ``'`` と ``*``) は丸める。
+- ASCII は 4-tier (very_narrow / narrow / normal / wide) バケットで近似する。
+  同一バケット内の advance 幅差分は丸める。
 - イタリック・装飾体の幅差分は無視する。Bold のみ 1.05 倍の補正を行う。
 - 合字・絵文字の幅は保証しない。結合マーク・ゼロ幅文字は 0 幅で扱う。
 """
@@ -31,37 +33,47 @@ from __future__ import annotations
 import unicodedata
 
 # 2026-04: Liberation Sans (Arial metric-compatible) を fontTools で実測した
-# advance width に基づく 3-tier 近似 (#69)。
-# 単一定数 (旧 0.0083) は mixed-case 文字列で +21% 過大評価になっていた。
-# narrow 文字 (`i`, `l`, space 等) と wide 文字 (`M`, `W` 等) は実測で
-# ~2倍以上の差があり、単一定数では吸収しきれない系統的バイアスを生じる。
+# advance width に基づく 4-tier 近似 (#71)。
+# #70 の 3-tier では `r`/`t`/`f` など advance ~0.00463 の文字が NARROW バケット
+# (0.00335) へ割り当てられ −27% の誤差を生じていた (Codex gpt-5.4 検出)。
+# 全 ASCII printable に対し「worst-case per-char 相対誤差を最小化」する境界・
+# 代表値を探索した結果、3-bucket では最悪 27% だったものが 4-bucket で
+# 17.4% まで低下する。較正ロジックは ``scripts/calibrate_ascii.py`` を参照。
 #
-# 較正スクリプト: ``scripts/calibrate_ascii.py`` (一回限り、配布物には含めない)
-# 出力を 5 桁で丸め、narrow バケットは実用上の test sentinel (`i`, `l`) との
-# 乖離が ±20% 以内に収まるよう平均からやや下側に寄せた値を採用する。
-# wide バケットは M/W/m など test sentinel との乖離を抑えるため平均よりも
-# 上側に寄せた値を採用する (narrow・wide バケットは実測 2 倍差でそもそも
-# 完全フィットしないため、テストされる代表文字を優先する設計判断)。
+# 代表値は各バケットの [min, max] 閉区間における worst-case 相対誤差を最小化
+# する調和平均 repr = 2*min*max/(min+max) を採用する (単純平均ではない)。
+# このため、定数そのものを「手で最適 sentinel に寄せる」バイアス調整は不要。
 
-# ASCII narrow 文字幅 (i, l, j, 空白, 句読点等)
-_ASCII_NARROW_WIDTH_PER_PT: float = 0.00335
+# ASCII very_narrow 文字幅 (i, l, j, ', |)
+# 範囲: 0.00265 ≤ w ≤ 0.00361, repr=0.00306, worst 15.3%
+_ASCII_VERY_NARROW_WIDTH_PER_PT: float = 0.00306
+
+# ASCII narrow 文字幅 (space, punctuation, I, f, r, t 等)
+# 範囲: 0.00386 ≤ w ≤ 0.00541, repr=0.00450, worst 16.7%
+_ASCII_NARROW_WIDTH_PER_PT: float = 0.00450
 
 # ASCII normal 文字幅 (小文字多数 + 数字 + 中幅大文字)
+# 範囲: 0.00652 ≤ w ≤ 0.00926, repr=0.00765, worst 17.4%
 _ASCII_NORMAL_WIDTH_PER_PT: float = 0.00765
 
-# ASCII wide 文字幅 (大文字多数 + M/W/m/% 等)
-_ASCII_WIDE_WIDTH_PER_PT: float = 0.01150
+# ASCII wide 文字幅 (大文字多数 + M/W/m/@ 等)
+# 範囲: 0.01003 ≤ w ≤ 0.01410, repr=0.01172, worst 16.9%
+_ASCII_WIDE_WIDTH_PER_PT: float = 0.01172
 
 # Legacy alias: 旧 `_ASCII_WIDTH_PER_PT` を import している外部コード向け。
 # 新コードでは `_ASCII_NORMAL_WIDTH_PER_PT` を参照すること。
 _ASCII_WIDTH_PER_PT: float = _ASCII_NORMAL_WIDTH_PER_PT
 
-# Narrow バケット: advance width < 0.0055"/pt の ASCII printable 文字
-# (Liberation Sans 実測値に基づく分類)
-_ASCII_NARROW_CHARS: frozenset[str] = frozenset(" !\"'()*,-./:;I[\\]`fijlrt{|}")
+# Very narrow バケット: advance width ≤ ~0.00361"/pt の ASCII printable 文字
+_ASCII_VERY_NARROW_CHARS: frozenset[str] = frozenset("'ijl|")
 
-# Wide バケット: advance width >= 0.009"/pt の ASCII printable 文字
-_ASCII_WIDE_CHARS: frozenset[str] = frozenset("%&@ABCDEGHKMNOPQRSUVWXYmw")
+# Narrow バケット: 0.00386 ≤ advance < ~0.00596"/pt の ASCII printable 文字
+# `r`/`t`/`f` は #70 までの 3-tier で NARROW (<0.0055) に誤分類されていたが、
+# 実測では 0.00386–0.00463 の範囲でこの NARROW バケットに収まる。
+_ASCII_NARROW_CHARS: frozenset[str] = frozenset(" !\"()*,-./:;I[\\]`frt{}")
+
+# Wide バケット: advance ≥ ~0.00965"/pt の ASCII printable 文字
+_ASCII_WIDE_CHARS: frozenset[str] = frozenset("%@CDGHMNOQRUWmw")
 
 # 残りの ASCII printable (0x20–0x7E) は _ASCII_NORMAL_WIDTH_PER_PT を使う。
 
@@ -178,19 +190,21 @@ def estimate_char_width(char: str, size_pt: float, font: str = "Arial") -> float
     2. 半角カタカナ (``is_half_width_kana``) は ASCII normal 幅
        (``size_pt * _ASCII_NORMAL_WIDTH_PER_PT``) を適用する。
     3. CJK 全角 (``is_cjk``) は ``size_pt * _CJK_WIDTH_PER_PT`` (1em)。
-    4. ASCII narrow 文字 (``i``, ``l``, 空白, 句読点等) は
+    4. ASCII very_narrow 文字 (``i``, ``l``, ``j``, ``'``, ``|``) は
+       ``size_pt * _ASCII_VERY_NARROW_WIDTH_PER_PT``。
+    5. ASCII narrow 文字 (space, 句読点, ``I``, ``f``, ``r``, ``t`` 等) は
        ``size_pt * _ASCII_NARROW_WIDTH_PER_PT``。
-    5. ASCII wide 文字 (``M``, ``W``, 大文字多数等) は
+    6. ASCII wide 文字 (``M``, ``W``, ``m``, ``@`` 等) は
        ``size_pt * _ASCII_WIDE_WIDTH_PER_PT``。
-    6. それ以外は ``size_pt * _ASCII_NORMAL_WIDTH_PER_PT``。
+    7. それ以外は ``size_pt * _ASCII_NORMAL_WIDTH_PER_PT``。
 
     ``font`` は将来拡張のため引数に残すが、現状は Arial/Helvetica を前提
     として無視される (助言ラベル)。
 
     Returns:
-        Estimated width in inches. Accuracy: ±10% for Arial Latin mixed-case
-        strings, ±15% for CJK with Japanese system fonts (Yu Gothic/Meiryo),
-        worse for italic/condensed/non-Arial.
+        Estimated width in inches. Accuracy: ±17% per-char / ±10% for
+        mixed-case strings on Arial Latin, ±15% for CJK with Japanese system
+        fonts (Yu Gothic/Meiryo), worse for italic/condensed/non-Arial.
     """
     if not char:
         return 0.0
@@ -201,6 +215,8 @@ def estimate_char_width(char: str, size_pt: float, font: str = "Arial") -> float
     if is_cjk(char):
         return size_pt * _CJK_WIDTH_PER_PT
     # ASCII / Latin-1 / その他 narrow スクリプト
+    if char in _ASCII_VERY_NARROW_CHARS:
+        return size_pt * _ASCII_VERY_NARROW_WIDTH_PER_PT
     if char in _ASCII_NARROW_CHARS:
         return size_pt * _ASCII_NARROW_WIDTH_PER_PT
     if char in _ASCII_WIDE_CHARS:
@@ -222,10 +238,10 @@ def estimate_text_width(
 
     Returns:
         Estimated width in inches. Accuracy: ±10% for Arial Latin mixed-case
-        strings, ±15% for CJK with Japanese system fonts (Yu Gothic/Meiryo),
-        worse for italic/condensed/non-Arial. The ``font`` argument is
-        currently an advisory label — width constants are calibrated for
-        Arial only.
+        strings (per-char ±17%), ±15% for CJK with Japanese system fonts
+        (Yu Gothic/Meiryo), worse for italic/condensed/non-Arial. The
+        ``font`` argument is currently an advisory label — width constants
+        are calibrated for Arial only.
     """
     if not text:
         return 0.0
@@ -260,10 +276,10 @@ def wrap_text(
     Returns:
         List of wrapped lines. Line breaks are determined by the same
         width heuristic as :func:`estimate_text_width`; accuracy ±10% for
-        Arial Latin mixed-case strings, ±15% for CJK with Japanese system
-        fonts (Yu Gothic/Meiryo), worse for italic/condensed/non-Arial. Border
-        cases may produce one extra or one fewer line than PowerPoint's
-        own layout.
+        Arial Latin mixed-case strings (per-char ±17%), ±15% for CJK with
+        Japanese system fonts (Yu Gothic/Meiryo), worse for italic/condensed/
+        non-Arial. Border cases may produce one extra or one fewer line than
+        PowerPoint's own layout.
     """
     if not text:
         return []
@@ -406,12 +422,11 @@ def estimate_text_height(
 
     Returns:
         Estimated total height in inches. Accuracy inherits from
-        :func:`wrap_text` — ±10% for Arial Latin mixed-case strings,
-        ±15% for CJK with
-        Japanese system fonts (Yu Gothic/Meiryo), worse for
-        italic/condensed/non-Arial. The ``line_height_factor`` default of
-        1.2 matches PowerPoint's "single spacing"; adjust explicitly for
-        tighter/looser leading.
+        :func:`wrap_text` — ±10% for Arial Latin mixed-case strings
+        (per-char ±17%), ±15% for CJK with Japanese system fonts
+        (Yu Gothic/Meiryo), worse for italic/condensed/non-Arial. The
+        ``line_height_factor`` default of 1.2 matches PowerPoint's "single
+        spacing"; adjust explicitly for tighter/looser leading.
     """
     if not text:
         return 0.0

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -97,32 +97,63 @@ def cjk_font() -> str:
 
 # --- ASCII キャリブレーション ---
 
-# 3-tier バケットモデル (#69) 導入後は per-char テスト対象に narrow / wide の
-# sentinel (``i``, ``l``, ``M``, ``W``) も含める。単一定数モデル時代に必要だった
-# 「4× 境界のみ」の workaround は不要になった。
+# 4-tier バケットモデル (#71) 導入後は per-char テスト対象に各バケットの
+# 代表 sentinel を網羅する。#70 の 3-tier では `r`/`t`/`f` が NARROW に誤分類
+# されて −27% を超える誤差を出していたが、4-tier では全 ASCII printable で
+# 最悪 ±17.4% に収まる。よってパラメトリ対象を大幅に増やす。
 @pytest.mark.parametrize(
     ("char", "size_pt"),
     [
+        # very_narrow
+        ("i", 12),
+        ("l", 12),
+        ("j", 12),
+        ("'", 12),
+        ("|", 12),
+        # narrow (含 #71 の欠落 sentinel r/t/f)
+        (" ", 12),
+        (".", 12),
+        (",", 12),
+        (":", 12),
+        ("-", 12),
+        ("!", 12),
+        ("I", 12),
+        ("f", 12),
+        ("r", 12),
+        ("t", 12),
+        # normal — 小文字多数 / 数字 / 中幅大文字
         ("a", 10),
         ("a", 12),
         ("a", 14),
-        ("H", 10),
-        ("H", 18),
-        ("0", 10),
-        ("9", 12),
         ("e", 12),
         ("o", 12),
-        ("i", 12),
-        ("l", 12),
+        ("n", 12),
+        ("u", 12),
+        ("s", 12),
+        ("p", 12),
+        ("0", 10),
+        ("5", 12),
+        ("9", 12),
+        ("N", 12),
+        ("T", 12),
+        ("E", 12),
+        ("R", 12),
+        ("S", 12),
+        # wide
+        ("H", 10),
+        ("H", 18),
         ("M", 12),
         ("W", 12),
+        ("m", 12),
+        ("@", 12),
     ],
 )
 def test_ascii_per_char_calibration(arial_font: str, char: str, size_pt: float) -> None:
     """ASCII 文字について ±20% 以内で推定できることを確認する.
 
-    #69 の 3-tier バケットモデル導入により narrow (``i``/``l``) と
-    wide (``M``/``W``) も同一の許容帯で扱えるようになった。
+    #71 で 4-tier バケットモデルに移行し、worst-case ±17.4% (Liberation Sans
+    実測) を達成した。境界 sentinel (r, t, f) も NARROW バケットに正しく
+    分類される。
     """
     measured = advance_width_inches(arial_font, char, size_pt)
     estimated = estimate_char_width(char, size_pt)

--- a/tests/test_text_metrics.py
+++ b/tests/test_text_metrics.py
@@ -141,17 +141,22 @@ class TestEstimateTextWidth:
         assert width == pytest.approx(1.050, abs=0.01)
 
     def test_ascii_hello_world(self) -> None:
-        # "Hello World" = H(wide) e(norm) l(narr) l(narr) o(norm) ' '(narr)
-        #                 W(wide) o(norm) r(narr) l(narr) d(norm)
-        # = 2 wide + 4 normal + 5 narrow @ 12pt
+        # "Hello World" (#71 4-tier):
+        #   H(wide=0.01172) e(norm=0.00765) l(vn=0.00306) l(vn=0.00306)
+        #   o(norm=0.00765) ' '(narr=0.00450) W(wide=0.01172) o(norm=0.00765)
+        #   r(narr=0.00450) l(vn=0.00306) d(norm=0.00765)
+        # = 2 wide + 4 normal + 3 very_narrow + 2 narrow @ 12pt
         width = estimate_text_width("Hello World", 12)
-        expected = 12 * (2 * 0.01150 + 4 * 0.00765 + 5 * 0.00335)
+        expected = 12 * (
+            2 * 0.01172 + 4 * 0.00765 + 3 * 0.00306 + 2 * 0.00450
+        )
         assert width == pytest.approx(expected, abs=0.01)
 
     def test_mixed_ai_seikatsusha(self) -> None:
-        # "AI生活者" = A(wide) + I(narrow) + 3 CJK @ 10pt
+        # "AI生活者" = A(normal=0.00765) + I(narrow=0.00450) + 3 CJK @ 10pt
+        # (#71: A は WIDE ではなく NORMAL に再分類され、I は NARROW バケット)
         width = estimate_text_width("AI生活者", 10)
-        expected = 10 * 0.01150 + 10 * 0.00335 + 3 * 10 * 0.0139
+        expected = 10 * 0.00765 + 10 * 0.00450 + 3 * 10 * 0.0139
         assert width == pytest.approx(expected, abs=0.001)
 
     def test_empty_string_has_zero_width(self) -> None:
@@ -242,6 +247,8 @@ class TestEstimateTextWidthExtended:
         width = estimate_text_width("ｶﾀｶﾅ", 10)
         expected = 4 * 10 * 0.00765
         assert width == pytest.approx(expected, abs=0.001)
+
+
 
     def test_zwsp_does_not_add_width(self) -> None:
         # ZWSP を含む文字列は含まないものと同じ幅


### PR DESCRIPTION
## Summary

Re-audit of the 3-bucket ASCII width model from #70, flagged by Codex gpt-5.4.

**Problem:** 3-bucket calibration only sampled `i`/`l`/`M`/`W` as sentinels. Boundary chars like `r`, `t`, `f` (all advance ~0.00463 on Liberation Sans) ended up in NARROW (0.00335), producing -27% per-char error on extremely common English letters.

**Fix:** Full measurement of ASCII printable (0x20-0x7E), then search the partition that minimizes worst-case per-char relative error. 3-bucket partition cannot get below 26.96% no matter where the cuts go. 4-bucket drops worst-case to **17.4%**. Went with 4-bucket.

Representative constants use the harmonic midpoint `2*min*max/(min+max)` which minimizes worst-case error on a `[min, max]` closed interval — no hand-biasing.

## Decision: 3-bucket vs 4-bucket

| Partition | Worst per-char rel_err | Meets <=20% target? |
|-----------|-----------------------|---------------------|
| 3-bucket (optimal cuts) | 26.96% | No |
| 4-bucket (optimal cuts) | 17.40% | Yes |

## Final bucket constants + membership

```python
_ASCII_VERY_NARROW_WIDTH_PER_PT = 0.00306  # "'ijl|"
_ASCII_NARROW_WIDTH_PER_PT      = 0.00450  # " !\"()*,-./:;I[\\]`frt{}"
_ASCII_NORMAL_WIDTH_PER_PT      = 0.00765  # "#$&+0123456789<=>?ABEFJKLPSTVXYZ^_abcdeghknopqsuvxyz~"
_ASCII_WIDE_WIDTH_PER_PT        = 0.01172  # "%@CDGHMNOQRUWmw"
```

Boundaries: 0.00373 / 0.00596 / 0.00965 in/pt.

## Per-char error table at 12pt (selected sentinels)

Full sweep measured against Liberation Sans (fontTools, deterministic advance). All <=17.4%.

| char | measured | bucket | repr    | rel_err |
|------|----------|--------|---------|---------|
| `'`  | 0.03182  | vnarrow | 0.03668 | 15.28% |
| `i`  | 0.03703  | vnarrow | 0.03668 |  0.94% |
| `l`  | 0.03703  | vnarrow | 0.03668 |  0.94% |
| `j`  | 0.03703  | vnarrow | 0.03668 |  0.94% |
| `\|` | 0.04329  | vnarrow | 0.03668 | 15.28% |
| ` `  | 0.04631  | narrow  | 0.05403 | 16.69% |
| `.`  | 0.04631  | narrow  | 0.05403 | 16.69% |
| `,`  | 0.04631  | narrow  | 0.05403 | 16.69% |
| `:`  | 0.04631  | narrow  | 0.05403 | 16.69% |
| `!`  | 0.04631  | narrow  | 0.05403 | 16.69% |
| `I`  | 0.04631  | narrow  | 0.05403 | 16.69% |
| `f`  | 0.04631  | narrow  | 0.05403 | 16.69% |
| `t`  | 0.04631  | narrow  | 0.05403 | 16.69% |
| `r`  | 0.05550  | narrow  | 0.05403 |  2.64% |
| `-`  | 0.05550  | narrow  | 0.05403 |  2.64% |
| `s`  | 0.08333  | normal  | 0.09182 | 10.18% |
| `0`  | 0.09269  | normal  | 0.09182 |  0.94% |
| `5`  | 0.09269  | normal  | 0.09182 |  0.94% |
| `9`  | 0.09269  | normal  | 0.09182 |  0.94% |
| `a`  | 0.09269  | normal  | 0.09182 |  0.94% |
| `e`  | 0.09269  | normal  | 0.09182 |  0.94% |
| `o`  | 0.09269  | normal  | 0.09182 |  0.94% |
| `n`  | 0.09269  | normal  | 0.09182 |  0.94% |
| `u`  | 0.09269  | normal  | 0.09182 |  0.94% |
| `p`  | 0.09269  | normal  | 0.09182 |  0.94% |
| `T`  | 0.10181  | normal  | 0.09182 |  9.81% |
| `N`  | 0.12036  | wide    | 0.14066 | 16.86% |
| `R`  | 0.12036  | wide    | 0.14066 | 16.86% |
| `M`  | 0.13883  | wide    | 0.14066 |  1.31% |
| `m`  | 0.13883  | wide    | 0.14066 |  1.31% |
| `W`  | 0.15731  | wide    | 0.14066 | 10.58% |
| `@`  | 0.16919  | wide    | 0.14066 | 16.86% |

Worst-case across all 95 ASCII printable chars: **17.40%** (at `^`, `A`, `B`, `E`, `&` and similar boundary chars).

## Mixed-string rel_err

`"Hello World 12345 McKinsey"` at 12pt:
- measured: 2.1398"
- estimated: 2.1618"
- rel_err: **+1.03%** (well within +-10% target)

## Real-sample verification

Before (3-bucket from #70) vs after (this PR), 12pt, Liberation Sans ground truth:

| sample | measured | old (main) | new (this PR) | old err | new err |
|--------|---------:|-----------:|--------------:|--------:|--------:|
| `Premium Malt's 父の日キャンペーン` | 2.6906 | 2.7018 | 2.7083 | +0.42% | +0.66% |
| `KPI / ROI / DX drivers for Lenovo` | 2.4546 | 2.4810 | 2.5538 | +1.08% | +4.04% |
| `The quick brown fox jumps over the lazy dog` | 3.2979 | 3.2658 | 3.4262 | -0.97% | +3.89% |
| `McKinsey & Company 2026` | 2.0566 | 2.1360 | 2.0894 | +3.86% | +1.60% |

Old model looks competitive on these mixed strings because its handful of errors average out, but its per-char worst case is 27% (on `r`-heavy or `f`-heavy strings like `"referer"`, `"for free"`, which were the cases #71 flagged). The new model keeps per-char worst case <=17.4% so pathological strings no longer silently overflow.

## Test plan

- [x] `pytest tests/test_text_metrics.py tests/test_calibration.py -v` -> 115 passed, 1 skipped
- [x] `pytest` (full suite) -> 534 passed, 1 skipped
- [x] All 37 parametrize cases in `test_ascii_per_char_calibration` within +-20%
- [x] `test_ascii_mixed_string_calibration` within +-10% (actual: 1.03%)
- [x] No char exceeds +-20% (worst is 17.40%)

## Char coverage diff

Previously covered: 13 parametrize cases (`a`/`H`/`0`/`9`/`e`/`o`/`i`/`l`/`M`/`W`).
Now covered: 37 cases including `r`, `t`, `f`, `s`, `p`, `n`, `u`, ` `, `.`, `,`, `:`, `-`, `!`, `j`, `'`, `|`, `5`, `N`, `T`, `E`, `R`, `S`, `m`, `@`.