### PR TITLE
feat(shapes+validation): wrap=False auto-fit + title_wrap check (closes #79, closes #80)

### DIFF
--- a/src/pptx_mcp_server/engine/shapes.py
+++ b/src/pptx_mcp_server/engine/shapes.py
@@ -588,6 +588,61 @@ def _fit_font_size(
     return min_size, height_est <= height
 
 
+def _fit_font_size_single_line(
+    text: str,
+    usable_width: float,
+    font_name: str,
+    font_size_pt: float,
+    min_size_pt: float,
+) -> tuple[float, bool]:
+    """単一行描画を前提に width に収まる最大 font size を 0.5pt 刻みで決定する.
+
+    ``wrap=False`` モードで使う。高さは参照せず、``estimate_text_width`` が
+    ``usable_width`` 以下となる最大 size を返す。min_size に達してもなお
+    幅を超える場合は ``(min_size, False)`` を返す。
+
+    Returns:
+        (size, fits): ``size`` は採用する font size、``fits`` は決定 size で
+        実際に単一行 width に収まるかどうか。
+    """
+    size = float(font_size_pt)
+    min_size = float(min_size_pt)
+    while size > min_size:
+        width_est = estimate_text_width(text, size, font_name)
+        if width_est <= usable_width:
+            return size, True
+        size = round(size - _AUTO_FIT_STEP_PT, 2)
+    # min_size でチェック
+    width_est = estimate_text_width(text, min_size, font_name)
+    return min_size, width_est <= usable_width
+
+
+def _truncate_to_fit_single_line(
+    text: str,
+    usable_width: float,
+    font_name: str,
+    size_pt: float,
+) -> str:
+    """``size_pt`` の size で ``usable_width`` に収まるよう末尾を省略記号で切り
+    詰める (単一行版).
+
+    ``_truncate_to_fit`` は wrap を前提としているため、``wrap=False`` モード用に
+    行頭から grapheme cluster を 1 つずつ削りながら ``text + 省略記号`` の幅が
+    ``usable_width`` 以下になるまで縮める専用実装を用意する。省略記号単体でも
+    収まらない場合は省略記号のみを返す。
+    """
+    if not text:
+        return text
+    candidate = text
+    while candidate and estimate_text_width(candidate + _ELLIPSIS, size_pt, font_name) > usable_width:
+        new_candidate = _strip_last_grapheme(candidate)
+        if new_candidate == candidate:
+            # 保険: 進まない場合は code unit で 1 文字削る。
+            new_candidate = candidate[:-1]
+        candidate = new_candidate
+    return (candidate + _ELLIPSIS) if candidate else _ELLIPSIS
+
+
 def _strip_last_grapheme(s: str) -> str:
     """``s`` の末尾 grapheme cluster (近似) を 1 つ除去した文字列を返す.
 
@@ -715,10 +770,11 @@ def add_auto_fit_textbox(
     vertical_anchor: str = "top",
     truncate_with_ellipsis: bool = True,
     east_asian_font: str | None = None,
+    wrap: bool = True,
 ) -> tuple[object, float]:
     """指定 box に収まる最大 font size でテキストを描画する.
 
-    動作:
+    動作 (``wrap=True``、既定):
         (a) 内側 padding 0.05" を左右に見込んで usable width を計算する。
         (b) ``font_size_pt`` から開始し、``estimate_text_height(wrapped)`` が
             ``height`` 以下になるまで 0.5pt 刻みで縮小する。
@@ -728,6 +784,16 @@ def add_auto_fit_textbox(
             を許容する。
         (d) 決定した font size で ``_add_textbox`` 経由で textframe を生成し、
             ``vertical_anchor`` に応じて ``MSO_ANCHOR`` を設定する。
+
+    動作 (``wrap=False``):
+        単一行描画モード。アクションタイトル・KPI 値のように折り返しを
+        許容しないユースケース向け。高さではなく幅で font size を縮小する。
+        具体的には (a) で得た usable width に対し、``estimate_text_width``
+        が usable width 以下となる最大 size を 0.5pt 刻みで探す。``min_size_pt``
+        に達しても幅を超える場合の振る舞いは ``truncate_with_ellipsis`` に
+        従う (True なら末尾を省略記号で切り詰め、False なら clip を許容して
+        そのまま描画)。生成 textbox には ``word_wrap=False`` を設定し、
+        PowerPoint 側でも自動折り返しが発生しないようにする。
 
     Args:
         slide: 対象スライドオブジェクト。
@@ -742,21 +808,34 @@ def add_auto_fit_textbox(
         vertical_anchor: 垂直方向の揃え ``"top" | "middle" | "bottom"``。
         truncate_with_ellipsis: min size でも収まらない場合に末尾を
             省略記号で切り詰めるかどうか。
+        east_asian_font: 東アジア用フォント名 (省略時は theme の既定値等)。
+        wrap: True なら高さベースで auto-fit し折り返しを許容する。False なら
+            幅ベースで auto-fit し単一行を維持する (``word_wrap=False`` を
+            textbox に適用)。既定は後方互換のため True。
 
     Returns:
         ``(shape, actual_font_size)`` のタプル。テスト・デバッグ用途。
     """
     usable_width = max(width - 2 * _AUTO_FIT_PADDING, 0.01)
 
-    actual_size, fits = _fit_font_size(
-        text, usable_width, height, font_name, font_size_pt, min_size_pt,
-    )
-
-    rendered_text = text
-    if not fits and truncate_with_ellipsis:
-        rendered_text = _truncate_to_fit(
-            text, usable_width, height, font_name, actual_size,
+    if wrap:
+        actual_size, fits = _fit_font_size(
+            text, usable_width, height, font_name, font_size_pt, min_size_pt,
         )
+        rendered_text = text
+        if not fits and truncate_with_ellipsis:
+            rendered_text = _truncate_to_fit(
+                text, usable_width, height, font_name, actual_size,
+            )
+    else:
+        actual_size, fits = _fit_font_size_single_line(
+            text, usable_width, font_name, font_size_pt, min_size_pt,
+        )
+        rendered_text = text
+        if not fits and truncate_with_ellipsis:
+            rendered_text = _truncate_to_fit_single_line(
+                text, usable_width, font_name, actual_size,
+            )
 
     idx = _add_textbox(
         slide,
@@ -769,7 +848,7 @@ def add_auto_fit_textbox(
         italic=None,
         alignment=align,
         vertical_anchor=vertical_anchor,
-        word_wrap=True,
+        word_wrap=wrap,
         line_spacing=None,
         underline=None,
         east_asian_font=east_asian_font,
@@ -777,7 +856,7 @@ def add_auto_fit_textbox(
 
     shape = slide.shapes[idx]
     tf = shape.text_frame
-    tf.word_wrap = True
+    tf.word_wrap = wrap
     # auto_size は手動でサイズ決定済みなので明示的に None にする。
     tf.auto_size = None
     if vertical_anchor in _ANCHOR_MAP:
@@ -802,6 +881,7 @@ def add_auto_fit_textbox_file(
     align: str = "left",
     vertical_anchor: str = "top",
     truncate_with_ellipsis: bool = True,
+    wrap: bool = True,
 ) -> dict:
     """File-based wrapper: 指定 box に収まるよう自動縮小する textbox を追加する.
 
@@ -821,6 +901,7 @@ def add_auto_fit_textbox_file(
         align=align,
         vertical_anchor=vertical_anchor,
         truncate_with_ellipsis=truncate_with_ellipsis,
+        wrap=wrap,
     )
     # shape_index を決定 (slide 内で shape を線形検索)
     shape_index = -1

--- a/src/pptx_mcp_server/engine/validation.py
+++ b/src/pptx_mcp_server/engine/validation.py
@@ -20,7 +20,7 @@ from .layout_constants import (
     TEXTBOX_INNER_PADDING_PER_SIDE,
     TEXTBOX_INNER_PADDING_TOTAL,
 )
-from .text_metrics import estimate_text_height, estimate_text_width
+from .text_metrics import estimate_text_height, estimate_text_width, wrap_text
 
 # ---------------------------------------------------------------------------
 # 既存互換ヘルパ
@@ -926,6 +926,120 @@ def check_inconsistent_gaps(
     return findings
 
 
+def check_title_wrap(
+    presentation: Presentation,
+    *,
+    title_zone_top_max: float = 1.15,
+    max_lines_title: int = 1,
+    max_lines_subtitle: int = 2,
+    title_font_threshold: float = 14.0,
+) -> List[ValidationFinding]:
+    """タイトルゾーン内の text frame が意図せず wrap していないかを検出する.
+
+    タイトルゾーンは y < ``title_zone_top_max`` (既定 1.15" — McKinsey
+    レイアウトの divider line 位置) に上端を持つ text frame と定義する。
+    タイトル / サブタイトルの区別は以下のヒューリスティックで行う:
+
+    - 段落の実効 font サイズが ``title_font_threshold`` pt 以上 → タイトル
+      扱いで最大 ``max_lines_title`` 行まで許容する。
+    - それ未満 → サブタイトル扱いで最大 ``max_lines_subtitle`` 行まで許容する。
+
+    各段落で ``wrap_text`` を段落の実効 font サイズで実行し、折り返し後の
+    行数合計が許容値を超える場合に ``warning`` / category ``title_wrap`` の
+    finding を返す。suggested_fix には issue #79 の推奨パターン (font 縮小
+    もしくは ``add_auto_fit_textbox(..., wrap=False)`` の利用) を提示する。
+    """
+    findings: List[ValidationFinding] = []
+
+    for slide_index, slide in enumerate(presentation.slides):
+        for shape_i, shape in enumerate(slide.shapes):
+            if not getattr(shape, "has_text_frame", False):
+                continue
+            if not shape.has_text_frame:
+                continue
+
+            s_top = _emu_to_in(shape.top)
+            if s_top >= title_zone_top_max:
+                # タイトルゾーン外 (body content) はスキップ
+                continue
+
+            frame_width = _emu_to_in(shape.width)
+            if frame_width <= 0.1:
+                continue
+
+            tf = shape.text_frame
+            text = _full_text(tf)
+            if not text.strip():
+                continue
+
+            usable_width = max(0.1, frame_width - TEXTBOX_INNER_PADDING_TOTAL)
+
+            # 段落単位で行数を合算する。代表 font size も記録する。
+            total_lines = 0
+            representative_pt: Optional[float] = None
+            for para in tf.paragraphs:
+                para_text = _paragraph_text(para)
+                pt = _effective_paragraph_size(para, default_pt=18.0)
+                if representative_pt is None or pt > representative_pt:
+                    representative_pt = pt
+                if not para_text:
+                    total_lines += 1
+                    continue
+                lines = wrap_text(para_text, usable_width, pt)
+                total_lines += max(1, len(lines))
+
+            if representative_pt is None:
+                representative_pt = 18.0
+
+            # タイトル / サブタイトルの区別
+            is_title = representative_pt >= title_font_threshold
+            max_lines = max_lines_title if is_title else max_lines_subtitle
+            role = "title" if is_title else "subtitle"
+
+            if total_lines > max_lines:
+                name = _shape_name(shape, f"Shape {shape_i}")
+                # suggested font: 単一行に収めたい場合は幅ベースで推定する。
+                # 現 pt を起点に 0.5pt ステップで estimate_text_width が
+                # usable_width 以下になる size を探す (ヒント用途なので軽量)。
+                fit_pt: Optional[float] = None
+                candidate = representative_pt - 0.5
+                while candidate >= 6.0:
+                    if estimate_text_width(text, candidate) <= usable_width:
+                        fit_pt = candidate
+                        break
+                    candidate -= 0.5
+
+                if fit_pt is not None:
+                    suggested = (
+                        f"reduce font {representative_pt:.1f}pt → {fit_pt:.1f}pt "
+                        f"to fit single line, or use "
+                        f"`add_auto_fit_textbox(..., wrap=False)`"
+                    )
+                else:
+                    suggested = (
+                        f"shorten {role} text, or use "
+                        f"`add_auto_fit_textbox(..., wrap=False, "
+                        f"truncate_with_ellipsis=True)`"
+                    )
+
+                findings.append(
+                    ValidationFinding(
+                        severity="warning",
+                        slide_index=slide_index,
+                        shape_name=name,
+                        category="title_wrap",
+                        message=(
+                            f"{role} wraps to {total_lines} lines "
+                            f"(max {max_lines}) at {representative_pt:.1f}pt "
+                            f"in {frame_width:.2f}\" frame"
+                        ),
+                        suggested_fix=suggested,
+                    )
+                )
+
+    return findings
+
+
 def check_deck_extended(
     presentation: Presentation,
     *,
@@ -934,6 +1048,10 @@ def check_deck_extended(
     axis_tolerance: float = 0.1,
     gap_tolerance: float = 0.05,
     whitelist_names: Optional[List[str]] = None,
+    title_zone_top_max: float = 1.15,
+    max_lines_title: int = 1,
+    max_lines_subtitle: int = 2,
+    title_font_threshold: float = 14.0,
 ) -> Dict[str, Any]:
     """deck 全体を走査し、既存 + 拡張チェックをまとめて返す.
 
@@ -949,6 +1067,7 @@ def check_deck_extended(
                     "unreadable_text": [...],
                     "divider_collision": [...],
                     "inconsistent_gaps": [...],
+                    "title_wrap": [...],
                 },
                 ...
             ],
@@ -967,6 +1086,7 @@ def check_deck_extended(
         - ``divider_collision`` (``check_divider_collision``)
     - ``warnings``:
         - ``unreadable_text`` (``check_unreadable_text``)
+        - ``title_wrap`` (``check_title_wrap``)
     - ``infos``:
         - ``inconsistent_gaps`` (``check_inconsistent_gaps``)
 
@@ -993,6 +1113,13 @@ def check_deck_extended(
         axis_tolerance=axis_tolerance,
         gap_tolerance=gap_tolerance,
     )
+    title_wrap = check_title_wrap(
+        presentation,
+        title_zone_top_max=title_zone_top_max,
+        max_lines_title=max_lines_title,
+        max_lines_subtitle=max_lines_subtitle,
+        title_font_threshold=title_font_threshold,
+    )
 
     # slide index ごとに集約
     by_slide: Dict[int, Dict[str, List[Any]]] = {}
@@ -1011,6 +1138,7 @@ def check_deck_extended(
             "unreadable_text": [],
             "divider_collision": [],
             "inconsistent_gaps": [],
+            "title_wrap": [],
         }
 
     def _place(findings: List[ValidationFinding], key: str) -> None:
@@ -1024,6 +1152,7 @@ def check_deck_extended(
     _place(unreadable, "unreadable_text")
     _place(divider, "divider_collision")
     _place(gaps, "inconsistent_gaps")
+    _place(title_wrap, "title_wrap")
 
     slides_out = [by_slide[i] for i in sorted(by_slide.keys())]
 
@@ -1034,6 +1163,7 @@ def check_deck_extended(
         errors += len(slide_data["overlaps"])
         errors += len(slide_data["out_of_bounds"])
     warnings_count = sum(1 for f in unreadable if f.severity == "warning")
+    warnings_count += sum(1 for f in title_wrap if f.severity == "warning")
     infos = sum(1 for f in gaps if f.severity == "info")
 
     return {

--- a/tests/test_shapes_auto_fit.py
+++ b/tests/test_shapes_auto_fit.py
@@ -77,6 +77,115 @@ def test_vertical_anchor_middle(slide):
     assert shape.text_frame.vertical_anchor == MSO_ANCHOR.MIDDLE
 
 
+# ---------------------------------------------------------------------------
+# Issue #79: wrap=False モード
+# ---------------------------------------------------------------------------
+
+
+class TestWrapFalse:
+    """``wrap=False`` で単一行 auto-fit と word_wrap=False が機能することを検証する."""
+
+    def test_short_title_wide_frame_no_shrink(self, slide):
+        """短いタイトル + 余裕のある幅なら font size は縮まない."""
+        shape, actual = add_auto_fit_textbox(
+            slide,
+            "Short title",
+            left=0.9, top=0.45, width=11.533, height=0.55,
+            font_size_pt=22, min_size_pt=12,
+            wrap=False,
+        )
+        assert actual == 22.0
+        assert shape.text_frame.word_wrap is False
+
+    def test_long_japanese_title_shrinks_until_single_line_fits(self, slide):
+        """長い日本語タイトル + 11.533"×0.55" + wrap=False で単一行に収まる size まで縮む.
+
+        Issue #79 の production シナリオ再現。``wrap=False`` では width 基準で
+        縮み、``estimate_text_width`` が usable width 以下になった時点で停止する。
+        20pt で開始 → 幅超過のため縮小 → 収まる size まで下がる。
+        """
+        from pptx_mcp_server.engine.text_metrics import estimate_text_width
+        from pptx_mcp_server.engine.layout_constants import (
+            TEXTBOX_INNER_PADDING_TOTAL,
+        )
+
+        title = (
+            "Mac乗り換え検討者に対してLenovoはほぼ不可視 — "
+            "「Macに匹敵する体験をWindowsで」のナラティブが不在"
+        )
+        shape, actual = add_auto_fit_textbox(
+            slide,
+            title,
+            left=0.9, top=0.45, width=11.533, height=0.55,
+            font_size_pt=20, min_size_pt=12,
+            wrap=False,
+        )
+        # 開始の 20pt では幅超過するため必ず縮む
+        assert actual < 20.0
+        # min_size_pt 以上には留まる
+        assert actual >= 12.0
+        # 決定 size で実際に単一行 width に収まっている
+        usable = 11.533 - TEXTBOX_INNER_PADDING_TOTAL
+        assert estimate_text_width(title, actual) <= usable + 1e-6
+        # PowerPoint 側でも wrap しない
+        assert shape.text_frame.word_wrap is False
+
+    def test_min_size_still_over_truncates(self, slide):
+        """min size でも幅を超える場合、truncate_with_ellipsis=True で末尾省略."""
+        huge = "これは非常に長いタイトルです。" * 10
+        shape, actual = add_auto_fit_textbox(
+            slide,
+            huge,
+            left=0.9, top=0.45, width=3.0, height=0.55,
+            font_size_pt=20, min_size_pt=12,
+            wrap=False,
+            truncate_with_ellipsis=True,
+        )
+        assert actual == 12.0
+        rendered = shape.text_frame.text
+        assert rendered.endswith("\u2026")
+        # 切り詰め後の幅は usable width 以下
+        from pptx_mcp_server.engine.text_metrics import estimate_text_width
+        from pptx_mcp_server.engine.layout_constants import (
+            TEXTBOX_INNER_PADDING_TOTAL,
+        )
+
+        usable = 3.0 - TEXTBOX_INNER_PADDING_TOTAL
+        assert estimate_text_width(rendered, actual) <= usable + 1e-6
+
+    def test_min_size_still_over_no_truncate_preserves_text(self, slide):
+        """truncate=False なら min_size で full text を保持する (clip 許容)."""
+        huge = "これは非常に長いタイトルです。" * 10
+        shape, actual = add_auto_fit_textbox(
+            slide,
+            huge,
+            left=0.9, top=0.45, width=3.0, height=0.55,
+            font_size_pt=20, min_size_pt=12,
+            wrap=False,
+            truncate_with_ellipsis=False,
+        )
+        assert actual == 12.0
+        assert shape.text_frame.text == huge
+        assert "\u2026" not in shape.text_frame.text
+        assert shape.text_frame.word_wrap is False
+
+    def test_default_wrap_true_unchanged(self, slide):
+        """回帰: wrap 指定なし (既定 True) は従来通り高さベースで縮む.
+
+        既存テスト ``test_long_japanese_in_narrow_box_shrinks`` と同等シナリオで
+        word_wrap が True のまま残ることを確認する。
+        """
+        long_jp = "これは日本語のテキストサンプルです。" * 6
+        shape, actual = add_auto_fit_textbox(
+            slide,
+            long_jp,
+            left=1.0, top=1.0, width=3.0, height=0.8,
+            font_size_pt=14, min_size_pt=7,
+        )
+        assert actual < 14.0
+        assert shape.text_frame.word_wrap is True
+
+
 def test_production_subtitle_11_5x0_5(slide):
     """production-like: 約 120 文字の日本語を 11.5" x 0.5" の箱に流し込む.
 

--- a/tests/test_validation_extended.py
+++ b/tests/test_validation_extended.py
@@ -23,6 +23,7 @@ from pptx_mcp_server.engine.validation import (
     check_inconsistent_gaps,
     check_slide_overlaps,
     check_text_overflow,
+    check_title_wrap,
     check_unreadable_text,
 )
 
@@ -871,3 +872,143 @@ class TestOverlapMinAreaFilter:
         # これは regression: container 内は intentional overlap。
         msgs = [w for w in warnings if "OVERLAP" in w]
         assert not msgs, f"Container overlap should be skipped; got: {warnings}"
+
+
+# ---------------------------------------------------------------------------
+# Issue #80: check_title_wrap
+# ---------------------------------------------------------------------------
+
+
+class TestTitleWrap:
+    """``check_title_wrap`` がタイトルゾーンの意図せぬ折り返しを検出することを検証する."""
+
+    def test_title_14pt_wraps_to_two_lines_flagged(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # タイトルゾーン (y=0.45) に 14pt で長いテキスト → 折り返し 2 行以上
+        slide = one_slide_prs.slides[0]
+        long_title = (
+            "Mac乗り換え検討者に対してLenovoはほぼ不可視 — "
+            "「Macに匹敵する体験をWindowsで」のナラティブが不在である"
+            "ため戦略的な再検討が必要"
+        )
+        _add_textbox(
+            slide, 0.9, 0.45, 11.533, 0.55, long_title,
+            font_pt=14, name="Title",
+        )
+        findings = check_title_wrap(one_slide_prs)
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.category == "title_wrap"
+        assert f.severity == "warning"
+        assert f.shape_name == "Title"
+        # message に行数が含まれる
+        assert "lines" in f.message
+        # 修正案が含まれる
+        assert f.suggested_fix != ""
+
+    def test_title_10pt_single_line_no_finding(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # 10pt は threshold (14pt) 未満なのでサブタイトル扱い。短いテキスト
+        # は 1 行なので no finding。
+        slide = one_slide_prs.slides[0]
+        _add_textbox(
+            slide, 0.9, 0.45, 11.533, 0.55, "短いサブタイトル",
+            font_pt=10, name="Subtitle",
+        )
+        findings = check_title_wrap(one_slide_prs)
+        assert findings == []
+
+    def test_text_outside_title_zone_skipped(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # y=3.0 は body 領域。折り返しても title_wrap は報告しない。
+        slide = one_slide_prs.slides[0]
+        long_title = (
+            "Mac乗り換え検討者に対してLenovoはほぼ不可視 — "
+            "「Macに匹敵する体験をWindowsで」のナラティブが不在"
+        )
+        _add_textbox(
+            slide, 0.9, 3.0, 11.533, 0.55, long_title,
+            font_pt=14, name="BodyTitle",
+        )
+        findings = check_title_wrap(one_slide_prs)
+        assert findings == []
+
+    def test_subtitle_10pt_two_lines_within_max_no_finding(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # 10pt サブタイトル扱い。max_lines_subtitle=2 で 2 行までは OK。
+        slide = one_slide_prs.slides[0]
+        # 10pt で 4" 幅の box に CJK 多めを入れると ~2 行になる長さ
+        subtitle_text = "これは二行に折り返されるサブタイトルのテキストである内容"
+        _add_textbox(
+            slide, 0.9, 0.45, 4.0, 0.55, subtitle_text,
+            font_pt=10, name="Subtitle",
+        )
+        findings = check_title_wrap(
+            one_slide_prs,
+            max_lines_title=1,
+            max_lines_subtitle=2,
+        )
+        # 2 行以内なので finding なし
+        subtitle_findings = [f for f in findings if f.shape_name == "Subtitle"]
+        assert subtitle_findings == []
+
+    def test_subtitle_10pt_three_lines_flagged(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # 10pt サブタイトルが 3 行以上に折り返す → max_lines_subtitle=2 を超え finding
+        slide = one_slide_prs.slides[0]
+        long_subtitle = (
+            "これは非常に長いサブタイトルの例であり三行以上に折り返されるほどの"
+            "文字数を含んでいることで max_lines_subtitle を確実に超える設計である。"
+            "さらに追加の説明を加えて行数を押し上げる追加テキスト。"
+        )
+        _add_textbox(
+            slide, 0.9, 0.45, 4.0, 0.55, long_subtitle,
+            font_pt=10, name="Subtitle",
+        )
+        findings = check_title_wrap(
+            one_slide_prs,
+            max_lines_title=1,
+            max_lines_subtitle=2,
+        )
+        subtitle_findings = [f for f in findings if f.shape_name == "Subtitle"]
+        assert len(subtitle_findings) == 1
+        assert subtitle_findings[0].severity == "warning"
+        assert subtitle_findings[0].category == "title_wrap"
+
+
+class TestTitleWrapIntegration:
+    """check_deck_extended への統合挙動."""
+
+    def test_title_wrap_key_present_and_counted_in_warnings(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        slide = one_slide_prs.slides[0]
+        long_title = (
+            "Mac乗り換え検討者に対してLenovoはほぼ不可視 — "
+            "「Macに匹敵する体験をWindowsで」のナラティブが不在である"
+            "ため戦略的な再検討が必要"
+        )
+        _add_textbox(
+            slide, 0.9, 0.45, 11.533, 0.55, long_title,
+            font_pt=14, name="Title",
+        )
+        result = check_deck_extended(one_slide_prs)
+        slide0 = result["slides"][0]
+        assert "title_wrap" in slide0
+        assert len(slide0["title_wrap"]) == 1
+        assert slide0["title_wrap"][0]["category"] == "title_wrap"
+        # summary.warnings に加算されている
+        assert result["summary"]["warnings"] >= 1
+
+    def test_no_title_wrap_no_warnings_from_this_category(
+        self, one_slide_prs: Presentation
+    ) -> None:
+        # 空の deck: title_wrap 0 件、summary.warnings は 0
+        result = check_deck_extended(one_slide_prs)
+        assert result["slides"][0]["title_wrap"] == []
+        assert result["summary"]["warnings"] == 0


### PR DESCRIPTION
## Summary

- **#79** — Add `wrap: bool = True` kwarg to `add_auto_fit_textbox`. When `wrap=False`, the function shrinks font based on single-line `estimate_text_width` instead of wrapped height, and sets `word_wrap=False` on the produced text frame so PowerPoint will not re-wrap. Intended for action titles, KPI values, and other "single-line always" use cases. Truncation-with-ellipsis path adapted for single-line mode. Default `wrap=True` preserves existing behavior.
- **#80** — Add `check_title_wrap(presentation, *, title_zone_top_max=1.15, max_lines_title=1, max_lines_subtitle=2, title_font_threshold=14.0)` validator that flags text in the title zone that wraps beyond its role's max lines. Title/subtitle distinction uses a configurable font-size threshold (default 14pt). Severity `warning`, category `title_wrap`. Integrated into `check_deck_extended`: new `title_wrap` key per slide and findings counted in `summary.warnings`.

## Design decisions

- **Title vs subtitle distinction** uses **font threshold only** (≥ 14pt → title, else subtitle), per the spec's "simplest heuristic". The title zone gate already constrains us to `top < 1.15"`, so adding a second position criterion would be redundant. Exposed as `title_font_threshold: float = 14.0` for callers who need a different cutoff.
- Reused the existing `_effective_paragraph_size` helper (from #23/#60) for font-size resolution, including `defRPr` inheritance.
- Suggested-fix string includes both a concrete font reduction (when a fitting pt exists) and a pointer to `add_auto_fit_textbox(..., wrap=False)` so callers know the library primitive.

## Surprises

The issue body's width numbers for the 62-char Japanese title (`14pt → ~17" width`) predate the current 4-bucket Arial calibration in `text_metrics.py`; the same title at 14pt now estimates ~9.6" width and fits an 11.433" usable frame on a single line. Tests were adjusted to use a longer title that genuinely wraps at 14pt in the target frame and to assert `actual < 20.0` (starting size) + `estimate_text_width(text, actual) <= usable` rather than the stale `< 14pt` number.

## Test plan

- [x] `tests/test_shapes_auto_fit.py`: 5 new tests under `TestWrapFalse` — short title no shrink, long JP title shrinks until width fits, min-size+truncate yields ellipsis with fitting width, min-size+no-truncate preserves text, default `wrap=True` regression.
- [x] `tests/test_validation_extended.py`: 5 new tests under `TestTitleWrap` and 2 under `TestTitleWrapIntegration` — 14pt title that wraps flagged, 10pt short no finding, body-zone text skipped, 2-line subtitle within max OK, 3-line subtitle flagged, deck-extended key + summary aggregation.
- [x] Full suite: 567 passed, 1 skipped (previous baseline 555+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)