### PR TITLE
fix(validation): _is_container tolerates 1e-6 float drift

### DIFF
--- a/src/pptx_mcp_server/engine/validation.py
+++ b/src/pptx_mcp_server/engine/validation.py
@@ -70,13 +70,21 @@ def _is_small_decorative(shape) -> bool:
 
 
 def _is_container(bounds_a: Tuple, bounds_b: Tuple) -> bool:
-    """一方が他方を完全包含するか (背景矩形内のテキスト配置など)."""
+    """一方が他方を完全包含するか (背景矩形内のテキスト配置など).
+
+    EMU ↔ inches 変換で生じる微小な float ズレ (≈ 1e-16 inches) で
+    containment が false になるケースがあったため、1e-6 inches の tolerance
+    (約 1 micron、EMU 単位でも 1 未満) を許容する。
+    """
     a_left, a_top, a_right, a_bottom = bounds_a
     b_left, b_top, b_right, b_bottom = bounds_b
+    tol = 1e-6
 
-    if a_left <= b_left and a_top <= b_top and a_right >= b_right and a_bottom >= b_bottom:
+    if (a_left - tol) <= b_left and (a_top - tol) <= b_top \
+            and (a_right + tol) >= b_right and (a_bottom + tol) >= b_bottom:
         return True
-    if b_left <= a_left and b_top <= a_top and b_right >= a_right and b_bottom >= a_bottom:
+    if (b_left - tol) <= a_left and (b_top - tol) <= a_top \
+            and (b_right + tol) >= a_right and (b_bottom + tol) >= a_bottom:
         return True
     return False
 

--- a/tests/test_validation_extended.py
+++ b/tests/test_validation_extended.py
@@ -873,6 +873,22 @@ class TestOverlapMinAreaFilter:
         msgs = [w for w in warnings if "OVERLAP" in w]
         assert not msgs, f"Container overlap should be skipped; got: {warnings}"
 
+    def test_float_precision_containment_is_tolerated(self) -> None:
+        """EMU→inches 変換の float drift で b_bottom が a_bottom を 3e-16 超える
+        ケースでも _is_container は True を返す。
+
+        本番で slide に Inches(1.35) + Inches(0.95) と Inches(2.1) + Inches(0.2)
+        が両方 2.3" 扱いになるはずが、演算順で片方だけ 2.3000000000000003 に
+        drift し、厳密 `>=` では containment が false になっていた (#77 follow-up)。
+        """
+        from pptx_mcp_server.engine.validation import _is_container
+        # Rectangle contains TextBox but with a 3e-16 drift on bottom edge.
+        rect = (9.45, 1.35, 12.15, 2.3)
+        textbox = (9.6, 2.1, 12.0, 2.3000000000000003)
+        assert _is_container(rect, textbox), (
+            "Float-precision drift of 3e-16 should not break containment check"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Issue #80: check_title_wrap


### PR DESCRIPTION
## Summary
- \`_is_container\` now uses a 1e-6 inch tolerance
- Fixes false-positive OVERLAP warnings when EMU round-trip produces 3e-16 edge drift between a rectangle and a contained textbox
- Production deck (agentrank/brand_analysis/report_pptx.py) slide 2 had 1 such false positive

## Test plan
- [x] 567 existing tests pass
- [x] New regression test \`test_float_precision_containment_is_tolerated\` pins the 3e-16 case

🤖 Generated with [Claude Code](https://claude.com/claude-code)