### PR TITLE
chore(release): fix URL owner + add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+  # Manual trigger for dry runs
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install build
+      - run: python -m build
+      - name: Verify wheel contents include py.typed
+        run: |
+          unzip -l dist/*.whl | grep py.typed
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    # Only publish on tag push, not manual dispatch
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pptx-mcp-server
+    permissions:
+      id-token: write  # OIDC trusted publishing — no API token needed
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,9 @@ mcp = ["mcp>=1.0.0"]
 test = ["pytest>=7", "fontTools>=4.40"]
 
 [project.urls]
-Homepage = "https://github.com/knorq/pptx-mcp-server"
-Repository = "https://github.com/knorq/pptx-mcp-server"
+Homepage = "https://github.com/knorq-ai/pptx-mcp-server"
+Repository = "https://github.com/knorq-ai/pptx-mcp-server"
+Issues = "https://github.com/knorq-ai/pptx-mcp-server/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pptx_mcp_server"]


### PR DESCRIPTION
## Summary
- Correct URL owner (`knorq` → `knorq-ai`) in pyproject.toml
- Add \`.github/workflows/publish.yml\` with PyPI OIDC trusted publishing on tag push
- Add \`workflow_dispatch\` for manual dry-run builds

## Release flow (after merge)
1. Configure pypi.org "Pending publisher" for the project (workflow: publish.yml, environment: pypi, owner: knorq-ai, repo: pptx-mcp-server)
2. Tag + push: \`git tag v0.1.0 && git push --tags\`
3. Workflow builds + publishes automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)