### PR TITLE
chore(api): delete dead back-compat + document script scope (closes #87, closes #89)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,38 @@ miscalibrations, not hide them behind tight bands. If you change a width
 constant, re-run locally and update bands only if they reflect a genuine
 improvement; do NOT loosen bands to paper over a new miscalibration.
 
+### Adding a new script
+
+Only ASCII/Latin-1 + CJK are currently calibrated. Hangul, Arabic, Thai,
+Devanagari, Hebrew, etc. fall back to ASCII-normal width and will
+silently mis-layout (see README "Supported scripts" for the matrix). If
+you need one of these, follow this process so the new script is
+permanently covered by the calibration suite rather than bolted on ad hoc:
+
+1. **Add the Unicode range(s)** — extend `_CJK_RANGES` in
+   `src/pptx_mcp_server/engine/text_metrics.py`, or introduce a new script
+   set alongside it if the script does not share CJK width characteristics.
+   For non-em-width scripts, also add a predicate like `is_half_width_kana`.
+2. **Add or calibrate a width constant** — e.g.
+   `_HANGUL_WIDTH_PER_PT: float = ...`. Derive the value by running
+   `scripts/calibrate_ascii.py` (or a script modelled on it) against a real
+   system font for that script and taking the harmonic-mean representative
+   across the bucket, not a hand-picked value.
+3. **Extend `tests/test_calibration.py`** — add parametrize entries with
+   sentinel characters from the new script and a tolerance band
+   consistent with the rest of the suite.
+4. **Add font path candidates** — `tests/calibration_helpers.py` enumerates
+   system-font probe paths. Add the new script's font (e.g. Noto Sans KR,
+   Noto Naskh Arabic) to both the macOS and Linux probe lists so the
+   test skips cleanly when the font is missing and runs when it is present.
+5. **Document in the README matrix** — move the script row from
+   "Unsupported" to "Supported" and state the accuracy band. Update the
+   module docstring of `text_metrics.py` accordingly.
+
+PRs adding a new script without all five steps will be asked to split:
+the calibration constant is meaningless without the calibration test, and
+the test is incomplete without matching font-probe plumbing.
+
 ## Engine / MCP boundary
 
 `src/pptx_mcp_server/engine/*.py` MUST NOT import `mcp`. Library consumers

--- a/README.md
+++ b/README.md
@@ -100,6 +100,31 @@ and is only required when launching the `pptx-mcp-server` CLI / importing
 `tests/test_library_usage.py` enforces that, and
 `tests/test_packaging_extras.py` enforces the packaging side of the split.
 
+### Supported scripts
+
+The auto-layout engine (`pptx_mcp_server.engine.text_metrics`) uses a
+heuristic width/height estimator. Only the scripts listed below are
+calibrated and covered by `tests/test_calibration.py`; anything else falls
+back to ASCII-normal width and may be silently under-estimated.
+
+| Script | Status | Accuracy / notes |
+|---|---|---|
+| ASCII / Latin-1 (Arial metric-compatible fonts) | Supported | ±10% for mixed-case strings, ±17% per-char |
+| CJK Unified Ideographs + Hiragana + Katakana (Yu Gothic / Meiryo / Hiragino Sans / Noto Sans CJK) | Supported | ±15% |
+| CJK Ext A/B/SIP/Compat Ideographs | Supported | Treated as full-em |
+| Half-width katakana (U+FF61–U+FF9F) | Supported | Mapped to ASCII-normal width |
+| Zero-width joiners, variation selectors, combining marks | Supported | 0-width |
+| Hangul (Korean) U+AC00–U+D7AF | **Unsupported** | Falls back to ASCII → heights ~2× under-estimated |
+| Arabic U+0600–U+06FF | **Unsupported** | ASCII fallback + RTL ignored |
+| Thai U+0E00–U+0E7F | **Unsupported** | No word-break logic + combining marks |
+| Devanagari U+0900–U+097F | **Unsupported** | Combining marks ignored |
+| Hebrew | **Unsupported** | RTL ignored |
+| Cyrillic | Approximate | ASCII-width fallback (practically acceptable) |
+
+Adding a new script involves extending `_CJK_RANGES` (or a new script set),
+calibrating a width constant, and adding sentinel characters to
+`tests/test_calibration.py`. See `CONTRIBUTING.md` → "Adding a new script".
+
 ## Tools
 
 ### Presentation

--- a/src/pptx_mcp_server/engine/cards.py
+++ b/src/pptx_mcp_server/engine/cards.py
@@ -57,6 +57,12 @@ _BLOCK_HEIGHT_SLACK: float = 1.05
 class CardSpec:
     """1 枚のカードの内容・スタイル定義.
 
+    幅 (width) はこの spec に持たせない。レイアウト幅は
+    :func:`add_responsive_card_row` の ``width`` 引数 (= 行幅) から
+    カード数・``gap`` にもとづき一意に算出され、結果は :class:`CardPlacement`
+    の ``width`` として返る。つまり幅は layout の **出力** であって
+    CardSpec の **入力** ではない。
+
     Attributes:
         title: タイトル文字列。空文字列でブロックを省略する。
         body: 本文文字列。空文字列でブロックを省略する。
@@ -71,8 +77,6 @@ class CardSpec:
         label_size_pt: ラベル font size (pt)。
         label_color: ラベル文字色 (6 桁 hex)。
         padding: カード内側 padding (inches、上下左右共通)。
-        width: ``add_responsive_card_row`` では読み書きしない (後方互換のため
-            フィールド自体は残す)。レイアウト幅は行幅から一意に算出される。
     """
 
     title: str = ""
@@ -87,7 +91,6 @@ class CardSpec:
     label_size_pt: float = 9
     label_color: str = "666666"
     padding: float = 0.2
-    width: float = 0.0
 
 
 @dataclass
@@ -141,16 +144,14 @@ def _estimate_block_heights(
     return label_h, title_h, body_h, n_blocks
 
 
-def _content_height(card: CardSpec, width: float | None = None) -> float:
+def _content_height(card: CardSpec, width: float) -> float:
     """カードの content 高 (padding 込み、intra_gap 含む) を返す.
 
     Args:
         card: 対象カード。
-        width: カード幅 (inches)。``None`` の場合は ``card.width`` を使う
-            (後方互換のための挙動だが、呼び出し側で明示するのが推奨)。
+        width: カード幅 (inches)。呼び出し側が layout 計算結果を明示で渡す。
     """
-    w = width if width is not None else card.width
-    label_h, title_h, body_h, n_blocks = _estimate_block_heights(card, w)
+    label_h, title_h, body_h, n_blocks = _estimate_block_heights(card, width)
     if n_blocks == 0:
         return card.padding * 2
     return (

--- a/src/pptx_mcp_server/engine/text_metrics.py
+++ b/src/pptx_mcp_server/engine/text_metrics.py
@@ -19,6 +19,31 @@
 いる点に注意すること。将来のフォント別較正テーブル導入時に意味を持たせる
 余地を残すため引数シグネチャに残してある。
 
+## サポート対象スクリプト (Supported — 較正＋テストあり)
+
+- ASCII / Latin-1 (Arial metric-compatible フォント): 混在文字列 ±10%
+- CJK 統合漢字 + ひらがな + カタカナ (Yu Gothic / Meiryo / Hiragino Sans /
+  Noto Sans CJK): ±15%
+- CJK Ext A/B/SIP/Compat Ideographs (全て全角扱い)
+- 半角カタカナ (U+FF61–U+FF9F): ASCII normal 幅にマップ
+- ゼロ幅ジョイナー・異体字セレクタ・結合マーク: 0 幅扱い
+
+## サポート外スクリプト (Unsupported — ASCII normal fallback)
+
+以下のスクリプトは :data:`_CJK_RANGES` に含まれず、ASCII normal 幅への
+fallback 経路を通る。幅推定は大きく外れ、レイアウトがサイレントに
+clip/wrap する可能性が高い:
+
+- ハングル (韓国語) U+AC00–U+D7AF: 高さが約 2 倍過小評価される
+- アラビア語 U+0600–U+06FF: RTL も無視される
+- タイ語 U+0E00–U+0E7F: 結合マーク・word-break ロジック非対応
+- デーヴァナーガリー U+0900–U+097F: 結合マーク非対応
+- ヘブライ語: RTL 無視で大幅にずれる
+- キリル文字: ASCII 近似 (実用上は概ね許容範囲)
+
+新規スクリプト対応の追加手順は ``CONTRIBUTING.md`` の
+「Adding a new script」節を参照すること。
+
 # 既知の制限
 - カーニングやヒンティングは考慮しない。
 - フォントファミリ差は現時点で無視する (引数は将来拡張のため保持)。
@@ -59,10 +84,6 @@ _ASCII_NORMAL_WIDTH_PER_PT: float = 0.00765
 # ASCII wide 文字幅 (大文字多数 + M/W/m/@ 等)
 # 範囲: 0.01003 ≤ w ≤ 0.01410, repr=0.01172, worst 16.9%
 _ASCII_WIDE_WIDTH_PER_PT: float = 0.01172
-
-# Legacy alias: 旧 `_ASCII_WIDTH_PER_PT` を import している外部コード向け。
-# 新コードでは `_ASCII_NORMAL_WIDTH_PER_PT` を参照すること。
-_ASCII_WIDTH_PER_PT: float = _ASCII_NORMAL_WIDTH_PER_PT
 
 # Very narrow バケット: advance width ≤ ~0.00361"/pt の ASCII printable 文字
 _ASCII_VERY_NARROW_CHARS: frozenset[str] = frozenset("'ijl|")
@@ -205,6 +226,12 @@ def estimate_char_width(char: str, size_pt: float, font: str = "Arial") -> float
         Estimated width in inches. Accuracy: ±17% per-char / ±10% for
         mixed-case strings on Arial Latin, ±15% for CJK with Japanese system
         fonts (Yu Gothic/Meiryo), worse for italic/condensed/non-Arial.
+
+    Fallback:
+        サポート外のスクリプト (ハングル・アラビア語・タイ語・デーヴァナーガリー・
+        ヘブライ語など) は ASCII normal 幅に fallback する。実描画幅とは
+        大きくずれる可能性があり、ハングルは高さが約 2 倍過小評価される。
+        詳細は本モジュール docstring の「Supported/Unsupported」節を参照。
     """
     if not char:
         return 0.0
@@ -242,6 +269,11 @@ def estimate_text_width(
         (Yu Gothic/Meiryo), worse for italic/condensed/non-Arial. The
         ``font`` argument is currently an advisory label — width constants
         are calibrated for Arial only.
+
+    Fallback:
+        サポート外のスクリプト (ハングル・アラビア語・タイ語・デーヴァナーガリー・
+        ヘブライ語など) を含む文字列は、その文字について ASCII normal 幅に
+        fallback する。実描画幅とは大きくずれる可能性がある。
     """
     if not text:
         return 0.0
@@ -280,6 +312,12 @@ def wrap_text(
         Japanese system fonts (Yu Gothic/Meiryo), worse for italic/condensed/
         non-Arial. Border cases may produce one extra or one fewer line than
         PowerPoint's own layout.
+
+    Fallback:
+        サポート外のスクリプト (ハングル・アラビア語・タイ語・デーヴァナーガリー
+        など) は ASCII normal 幅に fallback するため折り返し位置は実描画と
+        ずれる。特にタイ語には word-break ロジックが存在せず、アラビア語・
+        ヘブライ語は RTL 処理を行わないので wrap 結果は不正確になる。
     """
     if not text:
         return []
@@ -427,6 +465,12 @@ def estimate_text_height(
         (Yu Gothic/Meiryo), worse for italic/condensed/non-Arial. The
         ``line_height_factor`` default of 1.2 matches PowerPoint's "single
         spacing"; adjust explicitly for tighter/looser leading.
+
+    Fallback:
+        サポート外のスクリプト (ハングル・アラビア語・タイ語・デーヴァナーガリー
+        など) は ASCII normal 幅に fallback するため行数推定が実描画と
+        ずれ、結果として高さが過小評価されがちである。ハングルは約 2 倍
+        過小評価され、レイアウトがクリップする可能性が高い。
     """
     if not text:
         return 0.0

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -180,7 +180,8 @@ def test_single_card_fills_row_width(slide):
         gap=0.5, height_mode="max",
     )
 
-    # placement の width が 8.0 と一致 (CardSpec.width には書き戻さない仕様)
+    # placement の width が 8.0 と一致 (width は layout の出力であり、
+    # CardSpec には width フィールド自体が存在しない)
     assert placements[0].width == pytest.approx(8.0, abs=1e-4)
 
     # 先頭 shape = 背景矩形。width が 8.0 に一致
@@ -248,13 +249,15 @@ def test_consumed_height_matches_max_for_max_and_fill(slide, one_slide_prs):
 
 def test_cardspec_not_mutated_between_calls(slide, one_slide_prs):
     """同じ ``CardSpec`` リストを 2 つの ``add_responsive_card_row`` に渡しても
-    2 回目の widths が 1 回目と一致し (幅リーク無し)、``CardSpec.width`` は
-    既定値 (0.0) のまま変わらない (#26 Problem A)."""
+    2 回目の widths が 1 回目と一致し (幅リーク無し)、``CardSpec`` 自体が
+    書き換えられない (#26 Problem A)."""
     cards = [
         CardSpec(title="A", body="Short."),
         CardSpec(title="B", body="Short."),
         CardSpec(title="C", body="Short."),
     ]
+    # snapshot: CardSpec の全フィールド値を保存する
+    snapshots = [tuple(c.__dict__.items()) for c in cards]
 
     # 1 回目の呼び出し
     placements1, _ = add_responsive_card_row(
@@ -263,9 +266,9 @@ def test_cardspec_not_mutated_between_calls(slide, one_slide_prs):
         gap=0.2, height_mode="max",
     )
     widths1 = [p.width for p in placements1]
-    # 入力 CardSpec は mutation されない
-    for c in cards:
-        assert c.width == 0.0
+    # 入力 CardSpec は mutation されない (全フィールドが初期値のまま)
+    for c, snap in zip(cards, snapshots):
+        assert tuple(c.__dict__.items()) == snap
 
     # 同じリストで 2 枚目のスライドにもう 1 回レイアウト
     layout = one_slide_prs.slide_layouts[6]
@@ -281,8 +284,8 @@ def test_cardspec_not_mutated_between_calls(slide, one_slide_prs):
     # 幅は一致
     assert widths1 == pytest.approx(widths2, abs=1e-6)
     # 入力 CardSpec はまだ変わっていない
-    for c in cards:
-        assert c.width == 0.0
+    for c, snap in zip(cards, snapshots):
+        assert tuple(c.__dict__.items()) == snap
 
 
 def test_unknown_height_mode_raises(slide):


### PR DESCRIPTION
## Summary

Two cleanup/docs items for v0.2.0 bundled as one PR.

### #87 — delete dead back-compat (BREAKING)

- **`CardSpec.width` removed**. Documented as "read-only, set by row layout" but still exposed on the dataclass, so agents seeing it in error messages/schemas would try to set it. Width is an output of `add_responsive_card_row` (via `CardPlacement`), not an input. The existing #43 JSON unknown-key guard now surfaces `"width"` as invalid — the correct signal to agents.
- **`_ASCII_WIDTH_PER_PT` alias deleted**. Legacy single-value constant kept alongside the 4-bucket ASCII model (#71). No consumer inside the repo uses it, and as a private underscore-prefixed name no external consumer should depend on it.

### #89 — document script scope (doc-only)

- `text_metrics.py` module docstring: explicit **Supported** (ASCII/Latin-1 + CJK Unified/Hiragana/Katakana + CJK Ext A/B/SIP + half-width kana + ZWJ/variation selectors/combining marks) vs **Unsupported** (Hangul / Arabic / Thai / Devanagari / Hebrew — all fall back to ASCII-normal width) enumeration.
- `estimate_char_width`, `estimate_text_width`, `wrap_text`, `estimate_text_height` each gain a `Fallback:` note.
- README: new "Supported scripts" matrix under the library-usage section.
- CONTRIBUTING: new "Adding a new script" section (5-step process: Unicode range → calibration constant → calibration test → font probe → README matrix).

### Optional `warn_if_unsupported_script` kwarg

Not included. Estimated ~35 LOC (helper predicate + warn branch + test), which sits above the 30-LOC scope threshold for this cleanup PR. Worth filing as a follow-up.

## Test plan

- [x] `python -m pytest` — 568 passed, 1 skipped (Noto CJK font missing locally, consistent with pre-PR baseline)
- [x] `test_cards.py::test_cardspec_not_mutated_between_calls` rewritten to snapshot all CardSpec fields via `__dict__` instead of checking the removed `width` field
- [x] `grep "CardSpec.width\|_ASCII_WIDTH_PER_PT"` returns nothing in `src/` or `tests/`
- [x] `#43` unknown-key test still green (agents passing stray `width` now correctly get `INVALID_PARAMETER`)

Closes #87
Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)