### PR TITLE
fix(engine): file-wrapper shape_index + fail-fast geometry validation

### DIFF
--- a/src/pptx_mcp_server/engine/_validate.py
+++ b/src/pptx_mcp_server/engine/_validate.py
@@ -1,0 +1,127 @@
+"""幾何パラメータの fail-fast 検証ヘルパ.
+
+# 背景 (#85)
+
+エンジンのプリミティブ (``add_auto_fit_textbox`` / ``add_flex_container`` /
+``add_responsive_card_row``) はこれまで ``width <= 0``・``padding < 0``・
+``min_size_pt > font_size_pt`` などの不正な幾何指定をサイレントに受け入れ、
+「技術的には成功したが結果が誤っている」出力を返していた。エージェント
+消費者にとっては最悪の失敗モードであり、ツールは成功を返すのに出力は
+壊れている、という状況を生む。
+
+本モジュールは entry point で呼ぶ最小限のバリデータを提供する。
+メッセージにはパラメータ名と不正値を必ず含めることで、LLM エージェントが
+再試行時に修正点を特定できる形式を担保する。
+
+NaN / inf も拒否する (``math.isfinite``)。
+"""
+
+from __future__ import annotations
+
+import math
+
+from .pptx_io import EngineError, ErrorCode
+
+
+def _reject_nonfinite(caller: str, name: str, value: float) -> None:
+    """NaN / inf を ``INVALID_PARAMETER`` として拒否する."""
+    if not math.isfinite(value):
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            f"{caller}: {name}={value!r} must be finite (no NaN/inf).",
+        )
+
+
+def _require_positive(caller: str, name: str, value: float) -> None:
+    """``value > 0`` を要求する. ``0`` ちょうどは拒否する."""
+    _reject_nonfinite(caller, name, value)
+    if value <= 0:
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            f"{caller}: {name}={value:.4f} must be > 0.",
+        )
+
+
+def _require_non_negative(caller: str, name: str, value: float) -> None:
+    """``value >= 0`` を要求する. ``0`` ちょうどは許容する."""
+    _reject_nonfinite(caller, name, value)
+    if value < 0:
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            f"{caller}: {name}={value:.4f} must be >= 0.",
+        )
+
+
+def validate_auto_fit_geometry(
+    *,
+    caller: str = "add_auto_fit_textbox",
+    width: float,
+    height: float,
+    font_size_pt: float,
+    min_size_pt: float,
+) -> None:
+    """``add_auto_fit_textbox`` の幾何/フォント引数を検証する.
+
+    Raises:
+        EngineError: いずれかの引数が不正なとき (``INVALID_PARAMETER``)。
+    """
+    _require_positive(caller, "width", width)
+    _require_positive(caller, "height", height)
+    _require_positive(caller, "font_size_pt", font_size_pt)
+    _require_positive(caller, "min_size_pt", min_size_pt)
+    if min_size_pt > font_size_pt:
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            (
+                f"{caller}: min_size_pt={min_size_pt:.2f} must be <= "
+                f"font_size_pt={font_size_pt:.2f} "
+                "(auto-fit starts at font_size_pt and steps down toward min_size_pt)."
+            ),
+        )
+
+
+def validate_flex_geometry(
+    *,
+    caller: str = "add_flex_container",
+    width: float,
+    height: float,
+    padding: float,
+    gap: float,
+) -> None:
+    """``add_flex_container`` の幾何引数を検証する.
+
+    Raises:
+        EngineError: いずれかの引数が不正なとき (``INVALID_PARAMETER``)。
+    """
+    _require_positive(caller, "width", width)
+    _require_positive(caller, "height", height)
+    _require_non_negative(caller, "padding", padding)
+    _require_non_negative(caller, "gap", gap)
+
+
+def validate_card_row_geometry(
+    *,
+    caller: str = "add_responsive_card_row",
+    width: float,
+    max_height: float,
+    gap: float,
+    min_card_height: float,
+) -> None:
+    """``add_responsive_card_row`` の幾何引数を検証する.
+
+    Raises:
+        EngineError: いずれかの引数が不正なとき (``INVALID_PARAMETER``)。
+    """
+    _require_positive(caller, "width", width)
+    _require_positive(caller, "max_height", max_height)
+    _require_non_negative(caller, "gap", gap)
+    _require_non_negative(caller, "min_card_height", min_card_height)
+    if max_height < min_card_height:
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            (
+                f"{caller}: max_height={max_height:.2f} < "
+                f"min_card_height={min_card_height:.2f}; "
+                "constraints are contradictory."
+            ),
+        )

--- a/src/pptx_mcp_server/engine/cards.py
+++ b/src/pptx_mcp_server/engine/cards.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
+from ._validate import validate_card_row_geometry
 from .layout_constants import (
     TEXTBOX_INNER_PADDING_PER_SIDE as _AUTO_FIT_PADDING_PER_SIDE,
 )
@@ -353,6 +354,16 @@ def add_responsive_card_row(
                 f"got {height_mode!r}"
             ),
         )
+
+    # #85: コンテナ幾何 (width/max_height/gap/min_card_height) の fail-fast
+    # 検証。``max_height < min_card_height`` のような矛盾制約や負値を拒否し、
+    # 既存の "min_card_height がサイレントに max_height を上書き" パスを塞ぐ。
+    validate_card_row_geometry(
+        width=width,
+        max_height=max_height,
+        gap=gap,
+        min_card_height=min_card_height,
+    )
 
     n = len(cards)
     if n == 0:

--- a/src/pptx_mcp_server/engine/flex.py
+++ b/src/pptx_mcp_server/engine/flex.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, Literal
 
+from ._validate import validate_flex_geometry
 from .pptx_io import EngineError, ErrorCode, open_pptx, save_pptx, _get_slide
 from .shapes import _add_shape, add_auto_fit_textbox
 
@@ -244,6 +245,12 @@ def add_flex_container(
             ErrorCode.INVALID_PARAMETER,
             f"align={align!r} is not yet implemented; use 'stretch' for MVP.",
         )
+
+    # #85: コンテナ幾何 (width/height/padding/gap) の fail-fast 検証。
+    # ``_validate_items`` (項目単位) と役割を分ける。
+    validate_flex_geometry(
+        width=width, height=height, padding=padding, gap=gap,
+    )
 
     # #72: 分配ロジックに入る前に各項目の宣言値を検証する。
     # ``_distribute_grow`` は min-clamp を先に適用するため、``min_size >
@@ -469,7 +476,12 @@ def _build_declarative_item(
         truncate = bool(spec.get("truncate_with_ellipsis", True))
 
         def render_text(x: float, y: float, w: float, h: float) -> None:
-            shape, actual = add_auto_fit_textbox(
+            # #84: identity 検索は save_pptx 後には失敗する (``os.replace``
+            # による原子的 rename で ``slide.shapes`` が再構築される)。
+            # ``add_auto_fit_textbox`` はこの瞬間に必ず末尾に shape を追加
+            # するので、追加直前の長さを記録するのが正しい。
+            idx = len(slide.shapes)
+            _shape, actual = add_auto_fit_textbox(
                 slide, text, x, y, w, h,
                 font_name=font_name,
                 font_size_pt=font_size_pt,
@@ -480,11 +492,6 @@ def _build_declarative_item(
                 vertical_anchor=vertical_anchor,
                 truncate_with_ellipsis=truncate,
             )
-            idx = -1
-            for i, s in enumerate(slide.shapes):
-                if s is shape:
-                    idx = i
-                    break
             created_shape_indices.append({
                 "type": "text",
                 "shape_index": idx,

--- a/src/pptx_mcp_server/engine/shapes.py
+++ b/src/pptx_mcp_server/engine/shapes.py
@@ -13,6 +13,7 @@ from pptx.enum.shapes import MSO_SHAPE
 from pptx.dml.color import RGBColor
 from pptx.oxml.ns import qn
 
+from ._validate import validate_auto_fit_geometry
 from .pptx_io import (
     EngineError, ErrorCode,
     open_pptx, save_pptx, _get_slide, _get_shape, _parse_color,
@@ -815,7 +816,20 @@ def add_auto_fit_textbox(
 
     Returns:
         ``(shape, actual_font_size)`` のタプル。テスト・デバッグ用途。
+
+    Raises:
+        EngineError: ``width``・``height``・``font_size_pt``・``min_size_pt``
+            が ``<= 0`` または NaN/inf のとき、または ``min_size_pt >
+            font_size_pt`` のとき (``INVALID_PARAMETER``, #85)。
     """
+    # #85: 不正な幾何/フォント指定は sile に通過させず entry で拒否する。
+    validate_auto_fit_geometry(
+        width=width,
+        height=height,
+        font_size_pt=font_size_pt,
+        min_size_pt=min_size_pt,
+    )
+
     usable_width = max(width - 2 * _AUTO_FIT_PADDING, 0.01)
 
     if wrap:
@@ -891,6 +905,11 @@ def add_auto_fit_textbox_file(
     """
     prs = open_pptx(file_path)
     slide = _get_slide(prs, slide_index)
+    # #84: ``save_pptx`` 後に identity 検索を行うと (``os.replace`` による
+    # 原子的 rename で) ``slide.shapes`` は新たに読み直された要素を返すため、
+    # 従来実装では常に ``shape_index=-1`` が返っていた。追加直前に末尾
+    # index を控える実装に修正する。
+    shape_index = len(slide.shapes)
     shape, actual_size = add_auto_fit_textbox(
         slide, text, left, top, width, height,
         font_name=font_name,
@@ -903,12 +922,6 @@ def add_auto_fit_textbox_file(
         truncate_with_ellipsis=truncate_with_ellipsis,
         wrap=wrap,
     )
-    # shape_index を決定 (slide 内で shape を線形検索)
-    shape_index = -1
-    for i, s in enumerate(slide.shapes):
-        if s is shape:
-            shape_index = i
-            break
     save_pptx(prs, file_path)
     return {
         "slide_index": slide_index,

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -454,3 +454,114 @@ def test_card_placement_dataclass_shape():
     """``CardPlacement`` は left/top/width/height の 4 フィールドを持つ."""
     p = CardPlacement(left=1.0, top=2.0, width=3.0, height=4.0)
     assert (p.left, p.top, p.width, p.height) == (1.0, 2.0, 3.0, 4.0)
+
+
+# -----------------------------------------------------------------------------
+# #85: fail-fast geometry validation
+# -----------------------------------------------------------------------------
+
+
+class TestCardRowGeometryValidation:
+    """``add_responsive_card_row`` が不正な幾何指定を拒否する (#85)."""
+
+    def _one_card(self) -> list[CardSpec]:
+        return [CardSpec(title="T", body="b")]
+
+    def test_zero_width_rejected(self, slide):
+        with pytest.raises(EngineError) as exc:
+            add_responsive_card_row(
+                slide, self._one_card(),
+                left=0.0, top=0.0, width=0.0, max_height=2.0,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "width" in str(exc.value)
+
+    def test_negative_width_rejected(self, slide):
+        with pytest.raises(EngineError) as exc:
+            add_responsive_card_row(
+                slide, self._one_card(),
+                left=0.0, top=0.0, width=-1.0, max_height=2.0,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "width" in str(exc.value)
+
+    def test_zero_max_height_rejected(self, slide):
+        with pytest.raises(EngineError) as exc:
+            add_responsive_card_row(
+                slide, self._one_card(),
+                left=0.0, top=0.0, width=5.0, max_height=0.0,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "max_height" in str(exc.value)
+
+    def test_negative_gap_rejected(self, slide):
+        with pytest.raises(EngineError) as exc:
+            add_responsive_card_row(
+                slide,
+                [CardSpec(title="A"), CardSpec(title="B")],
+                left=0.0, top=0.0, width=5.0, max_height=2.0,
+                gap=-0.2,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "gap" in str(exc.value)
+
+    def test_negative_min_card_height_rejected(self, slide):
+        with pytest.raises(EngineError) as exc:
+            add_responsive_card_row(
+                slide, self._one_card(),
+                left=0.0, top=0.0, width=5.0, max_height=2.0,
+                min_card_height=-0.1,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "min_card_height" in str(exc.value)
+
+    def test_max_height_less_than_min_card_height_rejected(self, slide):
+        """矛盾制約: ``max_height < min_card_height``."""
+        with pytest.raises(EngineError) as exc:
+            add_responsive_card_row(
+                slide, self._one_card(),
+                left=0.0, top=0.0, width=5.0,
+                max_height=0.3, min_card_height=1.0,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        msg = str(exc.value)
+        assert "max_height" in msg
+        assert "min_card_height" in msg
+
+    def test_nan_width_rejected(self, slide):
+        with pytest.raises(EngineError) as exc:
+            add_responsive_card_row(
+                slide, self._one_card(),
+                left=0.0, top=0.0, width=float("nan"), max_height=2.0,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "width" in str(exc.value)
+
+    def test_inf_max_height_rejected(self, slide):
+        with pytest.raises(EngineError) as exc:
+            add_responsive_card_row(
+                slide, self._one_card(),
+                left=0.0, top=0.0, width=5.0, max_height=float("inf"),
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "max_height" in str(exc.value)
+
+    def test_zero_gap_and_min_card_height_boundary_ok(self, slide):
+        """gap=0, min_card_height=0 は合法."""
+        placements, consumed = add_responsive_card_row(
+            slide,
+            [CardSpec(title="A"), CardSpec(title="B")],
+            left=0.0, top=0.0, width=5.0, max_height=2.0,
+            gap=0.0, min_card_height=0.0,
+        )
+        assert len(placements) == 2
+        assert consumed > 0.0
+
+    def test_max_height_equals_min_card_height_ok(self, slide):
+        """``max_height == min_card_height`` は合法 (境界)."""
+        placements, consumed = add_responsive_card_row(
+            slide, self._one_card(),
+            left=0.0, top=0.0, width=5.0,
+            max_height=1.0, min_card_height=1.0,
+        )
+        assert len(placements) == 1

--- a/tests/test_flex.py
+++ b/tests/test_flex.py
@@ -845,3 +845,126 @@ class TestDeclarativeValidationFlow:
         assert "items[0]" in msg
         assert "min_size" in msg
         assert "max_size" in msg
+
+
+# -----------------------------------------------------------------------------
+# #85: fail-fast container geometry validation
+# -----------------------------------------------------------------------------
+
+
+class TestFlexContainerGeometryValidation:
+    """``add_flex_container`` が不正な container 幾何を拒否する (#85)."""
+
+    def _r(self):
+        return _recorder()[0]
+
+    def test_zero_width_rejected(self):
+        items = [FlexItem(sizing="grow", render=self._r())]
+        with pytest.raises(EngineError) as exc:
+            add_flex_container(
+                None, items,
+                left=0.0, top=0.0, width=0.0, height=1.0,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "width" in str(exc.value)
+
+    def test_negative_width_rejected(self):
+        items = [FlexItem(sizing="grow", render=self._r())]
+        with pytest.raises(EngineError) as exc:
+            add_flex_container(
+                None, items,
+                left=0.0, top=0.0, width=-1.0, height=1.0,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "width" in str(exc.value)
+
+    def test_zero_height_rejected(self):
+        items = [FlexItem(sizing="grow", render=self._r())]
+        with pytest.raises(EngineError) as exc:
+            add_flex_container(
+                None, items,
+                left=0.0, top=0.0, width=1.0, height=0.0,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "height" in str(exc.value)
+
+    def test_negative_height_rejected(self):
+        items = [FlexItem(sizing="grow", render=self._r())]
+        with pytest.raises(EngineError) as exc:
+            add_flex_container(
+                None, items,
+                left=0.0, top=0.0, width=1.0, height=-0.1,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "height" in str(exc.value)
+
+    def test_negative_padding_rejected(self):
+        items = [FlexItem(sizing="grow", render=self._r())]
+        with pytest.raises(EngineError) as exc:
+            add_flex_container(
+                None, items,
+                left=0.0, top=0.0, width=10.0, height=1.0,
+                padding=-0.1,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "padding" in str(exc.value)
+
+    def test_negative_gap_rejected(self):
+        items = [
+            FlexItem(sizing="fixed", size=1.0, render=self._r()),
+            FlexItem(sizing="fixed", size=1.0, render=self._r()),
+        ]
+        with pytest.raises(EngineError) as exc:
+            add_flex_container(
+                None, items,
+                left=0.0, top=0.0, width=10.0, height=1.0,
+                gap=-0.5,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "gap" in str(exc.value)
+
+    def test_nan_width_rejected(self):
+        items = [FlexItem(sizing="grow", render=self._r())]
+        with pytest.raises(EngineError) as exc:
+            add_flex_container(
+                None, items,
+                left=0.0, top=0.0, width=float("nan"), height=1.0,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "width" in str(exc.value)
+
+    def test_inf_gap_rejected(self):
+        items = [
+            FlexItem(sizing="fixed", size=1.0, render=self._r()),
+            FlexItem(sizing="fixed", size=1.0, render=self._r()),
+        ]
+        with pytest.raises(EngineError) as exc:
+            add_flex_container(
+                None, items,
+                left=0.0, top=0.0, width=10.0, height=1.0,
+                gap=float("inf"),
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "gap" in str(exc.value)
+
+    def test_zero_padding_and_gap_boundary_valid(self):
+        """padding=0, gap=0 は合法 (境界値)."""
+        render, calls = _recorder()
+        items = [FlexItem(sizing="fixed", size=1.0, render=render)]
+        add_flex_container(
+            None, items,
+            left=0.0, top=0.0, width=2.0, height=1.0,
+            padding=0.0, gap=0.0,
+        )
+        assert len(calls) == 1
+
+    def test_tiny_boundary_width_ok(self):
+        """width=0.01 は通る."""
+        render, calls = _recorder()
+        items = [FlexItem(sizing="grow", render=render)]
+        add_flex_container(
+            None, items,
+            left=0.0, top=0.0, width=0.01, height=0.01,
+            padding=0.0, gap=0.0,
+        )
+        assert len(calls) == 1

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -1,0 +1,244 @@
+"""``*_file`` wrappers / MCP-adjacent tools の round-trip テスト (#84).
+
+各 file wrapper は「書く → 閉じる → 開き直す → shape を index で拾える」
+という契約を満たす必要がある。以前は ``add_auto_fit_textbox_file`` が
+``save_pptx`` 後に identity 検索を行っており、``os.replace`` の原子的
+rename を挟むことで毎回 ``shape_index=-1`` を返していた (#84)。
+
+本モジュールは ``*_file`` wrappers の専用カバレッジ面として、
+- 返却された ``shape_index`` が >= 0 であること
+- 保存したファイルを開き直してその index で目的の shape が取れること
+- ``shape_index != -1`` を明示する回帰テスト
+を提供する。
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pptx import Presentation
+from pptx.util import Inches
+
+from pptx_mcp_server.engine.flex import add_flex_container_file
+from pptx_mcp_server.engine.pptx_io import save_pptx
+from pptx_mcp_server.engine.shapes import add_auto_fit_textbox_file
+
+
+@pytest.fixture
+def blank_pptx(tmp_path):
+    """16:9 blank deck を 1 スライドで作成して path を返す."""
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    layout = prs.slide_layouts[6]
+    prs.slides.add_slide(layout)
+    path = str(tmp_path / "deck.pptx")
+    save_pptx(prs, path)
+    return path
+
+
+# =============================================================================
+# add_auto_fit_textbox_file
+# =============================================================================
+
+
+class TestAddAutoFitTextboxFile:
+    """#84 の直接対象: ``add_auto_fit_textbox_file`` が正しい index を返すこと."""
+
+    def test_returns_non_negative_shape_index(self, blank_pptx):
+        """shape_index >= 0 (回帰: 以前は常に -1)."""
+        result = add_auto_fit_textbox_file(
+            blank_pptx,
+            slide_index=0,
+            text="Hello",
+            left=1.0, top=1.0, width=4.0, height=1.0,
+        )
+        assert result["shape_index"] >= 0
+
+    def test_shape_index_not_minus_one_regression(self, blank_pptx):
+        """明示的な回帰テスト: ``shape_index != -1``."""
+        result = add_auto_fit_textbox_file(
+            blank_pptx,
+            slide_index=0,
+            text="regression",
+            left=1.0, top=1.0, width=4.0, height=1.0,
+        )
+        assert result["shape_index"] != -1
+
+    def test_round_trip_shape_at_returned_index(self, blank_pptx):
+        """保存した deck を開き直し、返却 index で shape が取れる."""
+        expected_text = "round-trip check"
+        result = add_auto_fit_textbox_file(
+            blank_pptx,
+            slide_index=0,
+            text=expected_text,
+            left=1.0, top=1.0, width=4.0, height=1.0,
+        )
+        idx = result["shape_index"]
+
+        prs = Presentation(blank_pptx)
+        slide = prs.slides[0]
+        shape = slide.shapes[idx]
+        assert shape.has_text_frame
+        assert expected_text in shape.text_frame.text
+
+    def test_sequential_calls_return_distinct_indices(self, blank_pptx):
+        """連続呼び出しで index が重複しない."""
+        r1 = add_auto_fit_textbox_file(
+            blank_pptx, slide_index=0, text="first",
+            left=0.5, top=0.5, width=3.0, height=0.8,
+        )
+        r2 = add_auto_fit_textbox_file(
+            blank_pptx, slide_index=0, text="second",
+            left=0.5, top=2.0, width=3.0, height=0.8,
+        )
+        r3 = add_auto_fit_textbox_file(
+            blank_pptx, slide_index=0, text="third",
+            left=0.5, top=3.5, width=3.0, height=0.8,
+        )
+        assert r1["shape_index"] != r2["shape_index"] != r3["shape_index"]
+        assert r2["shape_index"] == r1["shape_index"] + 1
+        assert r3["shape_index"] == r2["shape_index"] + 1
+
+        # 各 index で目的の shape が解決できる
+        prs = Presentation(blank_pptx)
+        slide = prs.slides[0]
+        assert "first" in slide.shapes[r1["shape_index"]].text_frame.text
+        assert "second" in slide.shapes[r2["shape_index"]].text_frame.text
+        assert "third" in slide.shapes[r3["shape_index"]].text_frame.text
+
+    def test_returns_actual_font_size_float(self, blank_pptx):
+        """``actual_font_size`` も返却される (回帰対象外だが契約としてチェック)."""
+        result = add_auto_fit_textbox_file(
+            blank_pptx,
+            slide_index=0,
+            text="x",
+            left=1.0, top=1.0, width=2.0, height=0.5,
+            font_size_pt=11, min_size_pt=7,
+        )
+        assert isinstance(result["actual_font_size"], float)
+        assert 7.0 <= result["actual_font_size"] <= 11.0
+
+
+# =============================================================================
+# add_flex_container_file
+# =============================================================================
+
+
+class TestAddFlexContainerFile:
+    """``add_flex_container_file`` の round-trip (text 子要素は #84 同類バグが
+    隣接パスにあった — 同じく追加直前 index 方式に修正済み)."""
+
+    def test_text_child_shape_index_non_negative(self, blank_pptx):
+        """text 子要素の shape_index が >= 0."""
+        items = [
+            {"type": "text", "text": "A", "sizing": "grow"},
+            {"type": "text", "text": "B", "sizing": "grow"},
+        ]
+        result = add_flex_container_file(
+            blank_pptx, 0, items,
+            left=0.5, top=0.5, width=10.0, height=1.0,
+        )
+        shapes = result["shapes"]
+        assert len(shapes) == 2
+        for s in shapes:
+            assert s["shape_index"] >= 0
+            assert s["shape_index"] != -1
+
+    def test_text_and_rectangle_round_trip_resolves(self, blank_pptx):
+        """mix (text + rectangle) の index が開き直した deck で正しく解決する."""
+        items = [
+            {"type": "text", "text": "hello", "sizing": "grow"},
+            {
+                "type": "rectangle",
+                "sizing": "fixed",
+                "size": 1.0,
+                "fill_color": "2251FF",
+                "no_line": True,
+            },
+        ]
+        result = add_flex_container_file(
+            blank_pptx, 0, items,
+            left=0.5, top=0.5, width=10.0, height=1.0,
+        )
+
+        prs = Presentation(blank_pptx)
+        slide = prs.slides[0]
+
+        shapes = result["shapes"]
+        assert shapes[0]["type"] == "text"
+        assert shapes[1]["type"] == "rectangle"
+
+        text_shape = slide.shapes[shapes[0]["shape_index"]]
+        assert text_shape.has_text_frame
+        assert "hello" in text_shape.text_frame.text
+
+        rect_shape = slide.shapes[shapes[1]["shape_index"]]
+        # rectangle は has_text_frame でも True になる場合があるので存在だけ確認
+        assert rect_shape is not None
+
+    def test_allocations_count_matches_items(self, blank_pptx):
+        """allocations の長さが入力 items と一致する."""
+        items = [
+            {"type": "text", "text": f"item-{i}", "sizing": "grow"}
+            for i in range(3)
+        ]
+        result = add_flex_container_file(
+            blank_pptx, 0, items,
+            left=0.5, top=0.5, width=10.0, height=1.0,
+        )
+        assert len(result["allocations"]) == 3
+        assert len(result["shapes"]) == 3
+
+
+# =============================================================================
+# responsive_card_row (MCP tool path — placements on reopen)
+# =============================================================================
+
+
+class TestResponsiveCardRowFileRoundTrip:
+    """``add_responsive_card_row`` は engine に直接の ``_file`` wrapper を持たず、
+    server.py 側の MCP ツールでファイル保存を行う。ここでは engine を直接
+    呼びつつ ``save_pptx`` で書き出し、開き直した deck の shape 数が
+    placements 数と整合することを確認する。"""
+
+    def test_placements_persist_on_reopen(self, blank_pptx):
+        from pptx_mcp_server.engine.cards import CardSpec, add_responsive_card_row
+        from pptx_mcp_server.engine.pptx_io import open_pptx, save_pptx
+
+        prs = open_pptx(blank_pptx)
+        slide = prs.slides[0]
+        shapes_before = len(slide.shapes)
+
+        cards = [
+            CardSpec(title="First", body="body1"),
+            CardSpec(title="Second", body="body2"),
+            CardSpec(title="Third", body="body3"),
+        ]
+        placements, consumed = add_responsive_card_row(
+            slide, cards,
+            left=0.5, top=0.5, width=10.0, max_height=2.0,
+        )
+        save_pptx(prs, blank_pptx)
+
+        assert len(placements) == 3
+        assert consumed > 0.0
+
+        # 開き直して placements の bounding box が実 shape と重なっていること
+        reopened = Presentation(blank_pptx)
+        reopened_slide = reopened.slides[0]
+        assert len(reopened_slide.shapes) > shapes_before
+
+        # 各 placement の bbox に 1 個以上の shape が存在する
+        for p in placements:
+            inside = 0
+            for s in reopened_slide.shapes:
+                sx = s.left / 914400
+                sy = s.top / 914400
+                if (
+                    p.left - 0.01 <= sx <= p.left + p.width + 0.01
+                    and p.top - 0.01 <= sy <= p.top + p.height + 0.01
+                ):
+                    inside += 1
+            assert inside >= 1, f"placement {p} has no shapes inside"

--- a/tests/test_shapes_auto_fit.py
+++ b/tests/test_shapes_auto_fit.py
@@ -208,3 +208,128 @@ def test_production_subtitle_11_5x0_5(slide):
     # 切り詰めが起きない場合、本文は保持されているはず (またはオーバーフロー
     # で truncate 発動)。いずれにせよ空ではない。
     assert shape.text_frame.text != ""
+
+
+# -----------------------------------------------------------------------------
+# #85: fail-fast geometry validation
+# -----------------------------------------------------------------------------
+
+
+class TestAutoFitGeometryValidation:
+    """``add_auto_fit_textbox`` が不正な幾何/フォント指定を拒否する (#85)."""
+
+    def test_zero_width_rejected(self, slide):
+        from pptx_mcp_server.engine.pptx_io import EngineError, ErrorCode
+        with pytest.raises(EngineError) as exc:
+            add_auto_fit_textbox(
+                slide, "x",
+                left=0.0, top=0.0, width=0.0, height=1.0,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "width" in str(exc.value)
+        assert "0" in str(exc.value)
+
+    def test_negative_width_rejected(self, slide):
+        from pptx_mcp_server.engine.pptx_io import EngineError, ErrorCode
+        with pytest.raises(EngineError) as exc:
+            add_auto_fit_textbox(
+                slide, "x",
+                left=0.0, top=0.0, width=-0.5, height=1.0,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "width" in str(exc.value)
+
+    def test_zero_height_rejected(self, slide):
+        from pptx_mcp_server.engine.pptx_io import EngineError, ErrorCode
+        with pytest.raises(EngineError) as exc:
+            add_auto_fit_textbox(
+                slide, "x",
+                left=0.0, top=0.0, width=1.0, height=0.0,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "height" in str(exc.value)
+
+    def test_negative_height_rejected(self, slide):
+        from pptx_mcp_server.engine.pptx_io import EngineError, ErrorCode
+        with pytest.raises(EngineError) as exc:
+            add_auto_fit_textbox(
+                slide, "x",
+                left=0.0, top=0.0, width=1.0, height=-1.0,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "height" in str(exc.value)
+
+    def test_zero_font_size_rejected(self, slide):
+        from pptx_mcp_server.engine.pptx_io import EngineError, ErrorCode
+        with pytest.raises(EngineError) as exc:
+            add_auto_fit_textbox(
+                slide, "x",
+                left=0.0, top=0.0, width=1.0, height=1.0,
+                font_size_pt=0, min_size_pt=7,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "font_size_pt" in str(exc.value)
+
+    def test_negative_min_size_rejected(self, slide):
+        from pptx_mcp_server.engine.pptx_io import EngineError, ErrorCode
+        with pytest.raises(EngineError) as exc:
+            add_auto_fit_textbox(
+                slide, "x",
+                left=0.0, top=0.0, width=1.0, height=1.0,
+                font_size_pt=11, min_size_pt=-1,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "min_size_pt" in str(exc.value)
+
+    def test_min_size_greater_than_font_size_rejected(self, slide):
+        """``min_size_pt > font_size_pt`` は auto-fit 契約違反."""
+        from pptx_mcp_server.engine.pptx_io import EngineError, ErrorCode
+        with pytest.raises(EngineError) as exc:
+            add_auto_fit_textbox(
+                slide, "x",
+                left=0.0, top=0.0, width=1.0, height=1.0,
+                font_size_pt=8, min_size_pt=20,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "min_size_pt" in str(exc.value)
+        assert "font_size_pt" in str(exc.value)
+
+    def test_nan_width_rejected(self, slide):
+        from pptx_mcp_server.engine.pptx_io import EngineError, ErrorCode
+        with pytest.raises(EngineError) as exc:
+            add_auto_fit_textbox(
+                slide, "x",
+                left=0.0, top=0.0, width=float("nan"), height=1.0,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "width" in str(exc.value)
+
+    def test_inf_height_rejected(self, slide):
+        from pptx_mcp_server.engine.pptx_io import EngineError, ErrorCode
+        with pytest.raises(EngineError) as exc:
+            add_auto_fit_textbox(
+                slide, "x",
+                left=0.0, top=0.0, width=1.0, height=float("inf"),
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+        assert "height" in str(exc.value)
+
+    def test_tiny_boundary_valid_ok(self, slide):
+        """境界有効値 (width=0.01, height=0.01) は通る."""
+        shape, actual = add_auto_fit_textbox(
+            slide, "x",
+            left=0.0, top=0.0, width=0.01, height=0.01,
+            font_size_pt=7, min_size_pt=7,
+        )
+        assert actual == 7.0
+        assert shape is not None
+
+    def test_equal_min_and_font_size_ok(self, slide):
+        """``min_size_pt == font_size_pt`` は許容される."""
+        shape, actual = add_auto_fit_textbox(
+            slide, "Hi",
+            left=0.0, top=0.0, width=1.0, height=0.5,
+            font_size_pt=10, min_size_pt=10,
+        )
+        assert actual == 10.0
+        assert shape is not None


### PR DESCRIPTION
## Summary

Closes #84 and #85 — both blockers on v0.2.0 being co-sign-grade per Anthropic + OpenAI PE production-readiness reviews.

### #84 — `*_file` wrappers returned bad `shape_index`

- `add_auto_fit_textbox_file` returned `shape_index=-1` on every successful call. Root cause: identity search against `slide.shapes` after `save_pptx` (which uses `os.replace` atomic rename — in-memory reference is detached). Fixed by recording `len(slide.shapes)` at the moment-of-insertion (python-pptx appends to the end).
- **Bonus find:** same identity-search antipattern lived in `flex.py::_build_declarative_item` for `text` children. Fixed alongside.
- Zero prior test coverage — filed `tests/test_server_tools.py` as the dedicated round-trip surface the Anthropic reviewer called out.

### #85 — silent acceptance of invalid geometry

Centralized helpers in new `engine/_validate.py` (~120 LOC, which was worth the dedicated module — inline would have triplicated boilerplate). Called at each public primitive entry point:

| Primitive | Rejects |
|---|---|
| `add_auto_fit_textbox` | width/height/font_size_pt/min_size_pt ≤ 0; min_size_pt > font_size_pt; NaN/inf |
| `add_flex_container` | width/height ≤ 0; padding/gap < 0; NaN/inf |
| `add_responsive_card_row` | width/max_height ≤ 0; gap/min_card_height < 0; max_height < min_card_height; NaN/inf |

All errors raise `EngineError(INVALID_PARAMETER)` with messages that name the bad parameter **and** the value so agents can self-correct.

Existing item-level validation (PR #72: `min_size > max_size`) is preserved — container geometry validation is orthogonal.

## Test plan

- [x] `python -m pytest` → **608 passed, 1 skipped** (up from 568, +40 new)
- [x] All existing tests pass unchanged (no behavioral regression for valid inputs)
- [x] `tests/test_server_tools.py` (new) covers `add_auto_fit_textbox_file`, `add_flex_container_file`, and `add_responsive_card_row` round-trips — explicit `shape_index != -1` regression tests included
- [x] `tests/test_shapes_auto_fit.py` — 11 new validation tests
- [x] `tests/test_flex.py` — 10 new container geometry validation tests
- [x] `tests/test_cards.py` — 10 new geometry validation tests

## Notes for reviewer

- `EngineError` has no `.message` attribute — tests use `str(exc.value)`, matching the existing convention in `test_flex.py`.
- `_validate.py` uses `math.isfinite` for NaN/inf handling as spec'd.
- No `server.py` changes — validation at the primitive entry point covers the MCP tool path transitively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)