### PR TITLE
feat(validation): real-font path via fontTools breaks heuristic echo chamber (closes #91)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
         run: python -m pytest tests/test_library_usage.py tests/test_packaging_extras.py -v
 
   calibration:
+    # Covers both the text_metrics calibration suite (tests/test_calibration.py)
+    # and the #91 real-font validation suite (tests/test_real_font_validation.py).
+    # Both need real TTF/TTC files installed, so we piggyback on one job rather
+    # than duplicating the apt setup.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -46,5 +50,5 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y fonts-liberation fonts-noto-cjk
-      - run: pip install -e ".[mcp,test]"
-      - run: python -m pytest tests/test_calibration.py -v
+      - run: pip install -e ".[mcp,test,validation]"
+      - run: python -m pytest tests/test_calibration.py tests/test_real_font_validation.py -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,43 @@ part of the default test run and also run in the library-only CI job
 If you need MCP-specific behavior, put it in `src/pptx_mcp_server/server.py`
 or a sibling module that is only imported when the CLI starts.
 
+## Validation
+
+`check_deck_extended` / `check_text_overflow` have two paths for overflow
+detection:
+
+- **`font_source="heuristic"`** (default) — zero-deps, uses the
+  `text_metrics` width heuristic. Fast, good for iteration, but shares its
+  model with `add_auto_fit_textbox`. If the heuristic drifts from real
+  PowerPoint font metrics (e.g. Yu Gothic advance tweaks, font substitution
+  policy changes), **both the auto-fit primitive and the validator drift
+  together** — a silent echo chamber.
+- **`font_source="real"`** (opt-in, `[validation]` extra) — measures
+  advance widths directly from TTF/TTC via fontTools, independent of the
+  heuristic. Requires `pip install pptx-mcp-server[validation]` and
+  `font_paths={font_name: ttf_path, ...}`. For zero-config probing use
+  `discover_system_fonts()`:
+
+  ```python
+  from pptx_mcp_server.engine.font_metrics import discover_system_fonts
+  from pptx_mcp_server.engine.validation import check_deck_extended
+
+  report = check_deck_extended(
+      prs, font_source="real", font_paths=discover_system_fonts()
+  )
+  ```
+
+When to use real vs heuristic:
+
+- CI / pre-commit quick checks → heuristic (fast, no font install required).
+- Before shipping a deck to production → real (catches drift the heuristic
+  would miss).
+- Debugging "PowerPoint clips but our validator says fine" → real path
+  likely disagrees with heuristic; that disagreement *is* the signal.
+
+Fonts that can't be resolved fall back to the heuristic per-paragraph and
+emit a `font_not_measured` warning so partial coverage is still useful.
+
 ## File safety
 
 `save_pptx` performs an atomic temp-file-then-rename (via `os.replace`), so

--- a/README.md
+++ b/README.md
@@ -164,10 +164,44 @@ Required (installed by `pip install pptx-mcp-server`):
 - [python-pptx](https://python-pptx.readthedocs.io/) -- PPTX file manipulation
 - [lxml](https://lxml.de/) -- XML processing
 
-Optional extra (installed by `pip install 'pptx-mcp-server[mcp]'`):
+Optional extras:
 
-- [mcp](https://modelcontextprotocol.io/) -- Model Context Protocol SDK
-  (required only for the `pptx-mcp-server` CLI / `pptx_mcp_server.server`)
+- `[mcp]` -- `pip install 'pptx-mcp-server[mcp]'` pulls the
+  [mcp](https://modelcontextprotocol.io/) SDK, required for the
+  `pptx-mcp-server` CLI / `pptx_mcp_server.server`.
+- `[validation]` -- `pip install 'pptx-mcp-server[validation]'` pulls
+  [fontTools](https://fonttools.readthedocs.io/) and enables the real-font
+  overflow validation path. See "Layout validation" below.
+
+### Layout validation
+
+`check_deck_extended` / `check_text_overflow` ship two paths for text overflow
+detection:
+
+- `font_source="heuristic"` (default) -- zero-deps; uses the in-tree width
+  heuristic (shared with `add_auto_fit_textbox`).
+- `font_source="real"` (opt-in, needs the `[validation]` extra) -- reads
+  real advance widths from TTF/TTC via fontTools. This gives an
+  **independent source of truth** against the heuristic, so that drift
+  between the heuristic and PowerPoint's actual rendering cannot hide an
+  overflow behind the auto-fit primitive.
+
+```python
+from pptx import Presentation
+from pptx_mcp_server.engine.font_metrics import discover_system_fonts
+from pptx_mcp_server.engine.validation import check_deck_extended
+
+prs = Presentation("deck.pptx")
+report = check_deck_extended(
+    prs,
+    font_source="real",
+    font_paths=discover_system_fonts(),  # or {"Arial": "/path/to/Arial.ttf"}
+)
+print(report["summary"])
+```
+
+Fonts that can't be resolved fall back to the heuristic per-paragraph and
+emit a `font_not_measured` warning so partial coverage is still useful.
 
 ### System tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
 
 [project.optional-dependencies]
 mcp = ["mcp>=1.0.0"]
+validation = ["fontTools>=4.40"]
 test = ["pytest>=7", "fontTools>=4.40"]
 
 [project.urls]

--- a/src/pptx_mcp_server/engine/font_metrics.py
+++ b/src/pptx_mcp_server/engine/font_metrics.py
@@ -1,0 +1,159 @@
+"""Real font advance-width measurement via fontTools.
+
+Used by ``check_text_overflow`` の real-font path (#91) として、
+``text_metrics`` ヒューリスティックとは独立した真実源を提供する。
+TTF/TTC の ``hmtx`` / ``cmap`` を直接読むため、ヒューリスティック
+の echo chamber を破壊できる。
+
+fontTools は optional: ``pip install pptx-mcp-server[validation]``
+を要求する。未インストール環境では ``_load_font`` が ImportError を
+送出するので、呼び出し側が friendly message に変換すること。
+
+本モジュールは ``tests/calibration_helpers.py`` から昇格したものである。
+テスト側はこのモジュールを re-export する薄いラッパに変更済み。
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Any, Dict, List
+
+
+# ---------------------------------------------------------------------------
+# fontTools ロード (optional)
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=16)
+def _load_font(path: str) -> Any:
+    """TTF/TTC を遅延読込しキャッシュする.
+
+    TTC の場合は先頭フェイスを返す。日本語システムフォントの TTC は
+    通常 Regular ウェイトから順に格納されているため、基準としては
+    先頭で十分である。
+
+    fontTools が未インストールの場合は ImportError を送出する
+    (呼び出し側で ``pip install ...[validation]`` メッセージに
+    変換することを想定)。
+    """
+    from fontTools.ttLib import TTCollection, TTFont  # type: ignore
+
+    if path.endswith(".ttc"):
+        coll = TTCollection(path)
+        return coll.fonts[0]
+    return TTFont(path, recalcTimestamp=False)
+
+
+def advance_width_inches(font_path: str, char: str, size_pt: float) -> float:
+    """``char`` の ``size_pt`` における advance 幅を inches で返す.
+
+    複数コードポイントが渡された場合は各コードポイントの advance を
+    加算する (合字・シェイピングは考慮しない点に注意。ヒューリスティック
+    と対比可能な粒度で測るのが目的である)。
+
+    cmap に glyph が存在しないとき ``KeyError`` を送出する。
+    """
+    font = _load_font(font_path)
+    cmap = font.getBestCmap()
+    hmtx = font["hmtx"]
+    units_per_em = font["head"].unitsPerEm
+    total_units = 0
+    for ch in char:
+        glyph_name = cmap.get(ord(ch))
+        if glyph_name is None:
+            raise KeyError(
+                f"Character {ch!r} (U+{ord(ch):04X}) not in font {font_path}"
+            )
+        advance, _ = hmtx[glyph_name]
+        total_units += advance
+    # 1 pt = 1/72 inch. advance_in_em = units / units_per_em.
+    return total_units / units_per_em * size_pt / 72.0
+
+
+def text_width_inches(font_path: str, text: str, size_pt: float) -> float:
+    """``text`` 全体の advance 幅合計を inches で返す.
+
+    cmap に無いコードポイントは幅 0 として黙って無視する
+    (例: 制御文字や異体字セレクタ)。ヒューリスティックとの対比
+    用途では "ほぼすべて" の文字で幅を得られれば十分なためである。
+    ``\n`` も幅 0 として無視する (行分割は呼び出し側の責務)。
+    """
+    font = _load_font(font_path)
+    cmap = font.getBestCmap()
+    hmtx = font["hmtx"]
+    units_per_em = font["head"].unitsPerEm
+    total_units = 0
+    for ch in text:
+        if ch == "\n":
+            continue
+        glyph_name = cmap.get(ord(ch))
+        if glyph_name is None:
+            continue
+        advance, _ = hmtx[glyph_name]
+        total_units += advance
+    return total_units / units_per_em * size_pt / 72.0
+
+
+# ---------------------------------------------------------------------------
+# システムフォント探索
+# ---------------------------------------------------------------------------
+
+
+# フォント名 → 候補パスのマップ。Linux CI (Liberation + Noto CJK)、
+# macOS (Arial + Hiragino + Yu Gothic)、Windows (Arial + Yu Gothic +
+# Meiryo) のいずれでも最低 1 本当たれば十分なように網羅的に列挙する。
+_FONT_CANDIDATES: Dict[str, List[str]] = {
+    "Arial": [
+        "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+        "/usr/share/fonts/truetype/liberation2/LiberationSans-Regular.ttf",
+        "/Library/Fonts/Arial.ttf",
+        "/System/Library/Fonts/Supplemental/Arial.ttf",
+        "/Windows/Fonts/arial.ttf",
+        "C:\\Windows\\Fonts\\arial.ttf",
+    ],
+    "Liberation Sans": [
+        "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+        "/usr/share/fonts/truetype/liberation2/LiberationSans-Regular.ttf",
+    ],
+    "Yu Gothic": [
+        "/Library/Fonts/Yu Gothic Medium.ttc",
+        "/System/Library/Fonts/YuGothicMedium.ttc",
+        "C:\\Windows\\Fonts\\YuGothM.ttc",
+        "/Windows/Fonts/YuGothM.ttc",
+    ],
+    "Meiryo": [
+        "C:\\Windows\\Fonts\\meiryo.ttc",
+        "/Windows/Fonts/meiryo.ttc",
+    ],
+    "Hiragino Sans": [
+        "/System/Library/Fonts/Hiragino Sans GB.ttc",
+        "/System/Library/Fonts/ヒラギノ角ゴシック W3.ttc",
+        "/Library/Fonts/Hiragino Sans GB.ttc",
+    ],
+    "Noto Sans CJK": [
+        "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+        "/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc",
+        "/usr/share/fonts/opentype/noto/NotoSansCJKjp-Regular.otf",
+    ],
+    "Noto Sans": [
+        "/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf",
+        "/usr/share/fonts/opentype/noto/NotoSans-Regular.ttf",
+    ],
+}
+
+
+def discover_system_fonts() -> Dict[str, str]:
+    """一般的な場所から font name → path のマップを構築して返す.
+
+    実在するパスのみを含む。何も見つからなければ空 dict を返す。
+    Consumers は ``check_text_overflow(..., font_paths=discover_system_fonts())``
+    の形で zero-config な real validation を実行できる。
+    """
+    resolved: Dict[str, str] = {}
+    for name, candidates in _FONT_CANDIDATES.items():
+        for p in candidates:
+            if os.path.exists(p):
+                resolved[name] = p
+                break
+    return resolved

--- a/src/pptx_mcp_server/engine/validation.py
+++ b/src/pptx_mcp_server/engine/validation.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import re
 import statistics
 from dataclasses import dataclass, field, asdict
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 from pptx import Presentation
 from pptx.enum.text import MSO_ANCHOR
@@ -20,6 +20,7 @@ from .layout_constants import (
     TEXTBOX_INNER_PADDING_PER_SIDE,
     TEXTBOX_INNER_PADDING_TOTAL,
 )
+from .pptx_io import EngineError, ErrorCode
 from .text_metrics import estimate_text_height, estimate_text_width, wrap_text
 
 # ---------------------------------------------------------------------------
@@ -416,11 +417,245 @@ def _estimate_frame_needed_height(
     return total, max_pt
 
 
+def _run_font_name(run, paragraph) -> Optional[str]:
+    """run の font.name を解決する。paragraph / defRPr への軽いフォールバックを伴う.
+
+    OOXML の継承チェーンを完全には再現しないが、ユーザが明示した
+    font name を検出するには十分である (master/layout テーマ継承までは
+    踏み込まない)。
+    """
+    try:
+        if run.font.name:
+            return str(run.font.name)
+    except Exception:
+        pass
+    try:
+        if paragraph.font.name:
+            return str(paragraph.font.name)
+    except Exception:
+        pass
+    return None
+
+
+def _real_wrap_lines(
+    font_path: str,
+    text: str,
+    max_width_inches: float,
+    size_pt: float,
+) -> int:
+    """実フォントの advance width でテキストを折り返した行数を返す.
+
+    ``text_metrics.wrap_text`` と同じトークン分割を用いるが、幅は
+    ``font_metrics.text_width_inches`` で実測する。行分割境界の完全一致
+    は求めず、行数推定でヒューリスティックと独立な数値を得るのが目的。
+
+    明示改行 ``\n`` は強制改行として扱い、空行も 1 行とカウントする。
+    """
+    from . import font_metrics  # 遅延 import: fontTools 未インストール時も本体はロード可
+
+    if not text:
+        return 0
+    total_lines = 0
+    segments = text.split("\n")
+    for seg in segments:
+        if seg == "":
+            total_lines += 1
+            continue
+        # text_metrics._tokenize を mirror する簡易トークナイザ
+        from .text_metrics import is_cjk
+
+        tokens: List[str] = []
+        buf = ""
+        for ch in seg:
+            if ch == " ":
+                if buf:
+                    tokens.append(buf)
+                    buf = ""
+                tokens.append(" ")
+            elif is_cjk(ch):
+                if buf:
+                    tokens.append(buf)
+                    buf = ""
+                tokens.append(ch)
+            else:
+                buf += ch
+        if buf:
+            tokens.append(buf)
+
+        current = ""
+        current_w = 0.0
+        lines = 0
+
+        def flush():
+            nonlocal current, current_w, lines
+            lines += 1
+            current = ""
+            current_w = 0.0
+
+        for tok in tokens:
+            tok_w = font_metrics.text_width_inches(font_path, tok, size_pt)
+            if (
+                len(tok) > 1
+                and not is_cjk(tok[0])
+                and tok != " "
+                and tok_w > max_width_inches
+            ):
+                # 長 ASCII ワードを char 単位で強制分割
+                for ch in tok:
+                    ch_w = font_metrics.text_width_inches(font_path, ch, size_pt)
+                    if current == "":
+                        current = ch
+                        current_w = ch_w
+                    elif current_w + ch_w <= max_width_inches:
+                        current += ch
+                        current_w += ch_w
+                    else:
+                        flush()
+                        current = ch
+                        current_w = ch_w
+                continue
+            if current == "":
+                if tok == " ":
+                    continue
+                current = tok
+                current_w = tok_w
+                continue
+            if current_w + tok_w <= max_width_inches:
+                current += tok
+                current_w += tok_w
+            else:
+                flush()
+                if tok == " ":
+                    continue
+                current = tok
+                current_w = tok_w
+        if current != "":
+            lines += 1
+        total_lines += max(1, lines)
+    return total_lines
+
+
+def _real_paragraph_height_in(
+    font_path: str,
+    text: str,
+    usable_width: float,
+    size_pt: float,
+    line_height_factor: float = 1.2,
+) -> float:
+    """実フォントで推定した段落高さ (inches) を返す.
+
+    ``estimate_text_height`` と同じ単位換算 ``size_pt * 0.0139 *
+    line_height_factor`` を行数に掛けるのみ。空段落は 1 行分。
+    """
+    if not text:
+        return size_pt * 0.0139 * line_height_factor
+    n_lines = _real_wrap_lines(font_path, text, usable_width, size_pt)
+    return max(1, n_lines) * size_pt * 0.0139 * line_height_factor
+
+
+def _resolve_font_path(
+    font_name: Optional[str],
+    font_paths: Dict[str, str],
+) -> Optional[str]:
+    """font name → path を解決する (大文字小文字を区別しない).
+
+    厳密一致に失敗した場合、小文字化したキーとのマッチをフォールバック
+    として試す。見つからなければ None を返す (呼び出し側でヒューリス
+    ティックへフォールバック)。
+    """
+    if not font_name:
+        return None
+    if font_name in font_paths:
+        return font_paths[font_name]
+    low = font_name.lower()
+    for k, v in font_paths.items():
+        if k.lower() == low:
+            return v
+    return None
+
+
+def _estimate_frame_needed_height_real(
+    text_frame,
+    usable_width: float,
+    font_paths: Dict[str, str],
+    *,
+    default_pt: float = 18.0,
+) -> Tuple[float, float, List[str]]:
+    """実フォントで段落単位の推定高さを合算する.
+
+    戻り値は ``(total_height_in, representative_pt, missing_fonts)``。
+    ``missing_fonts`` は font_paths に未登録だった font name のユニーク
+    リストである。すべての段落で解決不能ならば長さ 0 の empty list は
+    返らない ('missing' が 1 件以上入った状態で呼び出し側に返す)。
+    """
+    total = 0.0
+    max_pt: Optional[float] = None
+    missing_seen: Dict[str, bool] = {}
+
+    paragraphs = list(text_frame.paragraphs)
+    for para in paragraphs:
+        pt = _effective_paragraph_size(para, default_pt=default_pt)
+        if max_pt is None or pt > max_pt:
+            max_pt = pt
+        text = _paragraph_text(para)
+
+        # paragraph 内の先頭 run の font.name を代表として採用する。
+        # 段落内で font を切り替えるユーザは稀 (タイトルと本文は別 paragraph)。
+        font_name: Optional[str] = None
+        for run in para.runs:
+            fn = _run_font_name(run, para)
+            if fn:
+                font_name = fn
+                break
+
+        resolved = _resolve_font_path(font_name, font_paths)
+
+        if resolved is None:
+            # フォント未解決: ヒューリスティックにフォールバックし、missing を記録
+            if font_name:
+                missing_seen[font_name] = True
+            else:
+                missing_seen["<no font>"] = True
+            if text:
+                total += estimate_text_height(text, usable_width, pt)
+            else:
+                total += pt * 0.0139 * 1.2
+            continue
+
+        try:
+            total += _real_paragraph_height_in(resolved, text, usable_width, pt)
+        except Exception:
+            # 実フォント測定に失敗した (KeyError 等) 場合もヒューリスティックへ
+            missing_seen[font_name or "<font load error>"] = True
+            if text:
+                total += estimate_text_height(text, usable_width, pt)
+            else:
+                total += pt * 0.0139 * 1.2
+
+    if max_pt is None:
+        max_pt = default_pt
+    return total, max_pt, list(missing_seen.keys())
+
+
+def _check_fonttools_available() -> None:
+    """fontTools がロード可能かを確認する。未インストール時は EngineError を送出."""
+    try:
+        import fontTools.ttLib  # noqa: F401
+    except ImportError as e:
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            "font_source='real' requires fontTools. "
+            "Install: pip install pptx-mcp-server[validation]",
+        ) from e
+
+
 def check_text_overflow(
     presentation: Presentation,
     *,
     min_readable_pt: float = 8.0,
     overflow_tolerance_pct: float = 5.0,
+    font_source: Literal["heuristic", "real"] = "heuristic",
+    font_paths: Optional[Dict[str, str]] = None,
 ) -> List[ValidationFinding]:
     """テキストフレームの高さ溢れを検出する.
 
@@ -428,7 +663,35 @@ def check_text_overflow(
     差し引いた usable width に基づき、段落単位で有効フォントサイズを解決し、
     段落ごとの推定高さを合算する。合計が frame_height × (1 + tolerance/100)
     を超える場合に ``error`` finding を返す。
+
+    ``font_source='real'`` (Issue #91) では ``font_paths`` で与えた TTF/TTC
+    を fontTools で読み、実 advance width で行分割・高さを計算する。
+    ``add_auto_fit_textbox`` と ``check_text_overflow`` が同じヒューリス
+    ティックを共有して echo chamber を作る問題を回避するためのオプトイン
+    パスである。font が解決できなかった場合はその段落のみヒューリスティッ
+    クにフォールバックし、"font X not measured" の warning finding を別途
+    発行する (同一 slide/shape につき 1 件)。
+
+    Args:
+        min_readable_pt: overflow 解消の探索下限 (pt)。
+        overflow_tolerance_pct: ``frame_height`` に対する余裕率 (%)。
+        font_source: ``"heuristic"`` (既定、既存挙動) または ``"real"``。
+        font_paths: ``{font name: TTF/TTC path}`` マップ。``font_source=
+            "real"`` のとき必須に近い (なければ全段落で fallback が発生)。
+
+    Raises:
+        EngineError(INVALID_PARAMETER): fontTools 未インストール時に
+            ``font_source='real'`` を指定した場合。
     """
+    if font_source not in ("heuristic", "real"):
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            f"font_source must be 'heuristic' or 'real' (got {font_source!r})",
+        )
+    if font_source == "real":
+        _check_fonttools_available()
+    resolved_font_paths: Dict[str, str] = dict(font_paths or {})
+
     findings: List[ValidationFinding] = []
     tolerance_factor = 1 + overflow_tolerance_pct / 100.0
 
@@ -449,10 +712,40 @@ def check_text_overflow(
                 continue
 
             usable_width = max(0.1, frame_width - TEXTBOX_INNER_PADDING_TOTAL)
-            needed_height, font_size = _estimate_frame_needed_height(
-                tf, usable_width
-            )
+            missing_fonts: List[str] = []
+            if font_source == "real":
+                needed_height, font_size, missing_fonts = (
+                    _estimate_frame_needed_height_real(
+                        tf, usable_width, resolved_font_paths
+                    )
+                )
+            else:
+                needed_height, font_size = _estimate_frame_needed_height(
+                    tf, usable_width
+                )
             max_allowed = frame_height * tolerance_factor
+
+            # real path で未解決 font がある場合は warning finding を発行し、
+                # その shape は heuristic fallback 済み high/needed を使い続ける。
+            if font_source == "real" and missing_fonts:
+                name = _shape_name(shape, f"Shape {shape_i}")
+                missing_display = ", ".join(sorted(missing_fonts))
+                findings.append(
+                    ValidationFinding(
+                        severity="warning",
+                        slide_index=slide_index,
+                        shape_name=name,
+                        category="font_not_measured",
+                        message=(
+                            f"font(s) not measured (no font_paths entry): "
+                            f"{missing_display}; falling back to heuristic"
+                        ),
+                        suggested_fix=(
+                            "add the font to font_paths, or call "
+                            "discover_system_fonts() to pre-populate"
+                        ),
+                    )
+                )
 
             if needed_height > max_allowed:
                 # 収まる最大代表 pt を 0.5pt 刻みで探索する。段落間の比率を
@@ -1060,6 +1353,8 @@ def check_deck_extended(
     max_lines_title: int = 1,
     max_lines_subtitle: int = 2,
     title_font_threshold: float = 14.0,
+    font_source: Literal["heuristic", "real"] = "heuristic",
+    font_paths: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Any]:
     """deck 全体を走査し、既存 + 拡張チェックをまとめて返す.
 
@@ -1076,6 +1371,7 @@ def check_deck_extended(
                     "divider_collision": [...],
                     "inconsistent_gaps": [...],
                     "title_wrap": [...],
+                    "font_not_measured": [...],  # real-font path のみ
                 },
                 ...
             ],
@@ -1084,6 +1380,11 @@ def check_deck_extended(
 
     既存 ``check_slide_overlaps`` の警告文字列を ``overlaps`` と
     ``out_of_bounds`` に分割して格納する (既存キーは文字列リストのまま)。
+
+    Issue #91: ``font_source='real'`` + ``font_paths`` を与えると、
+    text_overflow のチェックに実 TTF advance width が使われる。解決できな
+    かったフォントは ``font_not_measured`` (warning) に記録され、段落単位
+    でヒューリスティックにフォールバックする。
 
     Severity mapping — ``summary`` の各カウンタに寄与するカテゴリは以下のとおり:
 
@@ -1095,6 +1396,7 @@ def check_deck_extended(
     - ``warnings``:
         - ``unreadable_text`` (``check_unreadable_text``)
         - ``title_wrap`` (``check_title_wrap``)
+        - ``font_not_measured`` (real-font path でフォント未解決)
     - ``infos``:
         - ``inconsistent_gaps`` (``check_inconsistent_gaps``)
 
@@ -1109,6 +1411,8 @@ def check_deck_extended(
         presentation,
         min_readable_pt=min_readable_pt,
         overflow_tolerance_pct=overflow_tolerance_pct,
+        font_source=font_source,
+        font_paths=font_paths,
     )
     unreadable = check_unreadable_text(
         presentation,
@@ -1147,6 +1451,7 @@ def check_deck_extended(
             "divider_collision": [],
             "inconsistent_gaps": [],
             "title_wrap": [],
+            "font_not_measured": [],
         }
 
     def _place(findings: List[ValidationFinding], key: str) -> None:
@@ -1156,7 +1461,12 @@ def check_deck_extended(
                 continue
             by_slide[f.slide_index][key].append(f.to_dict())
 
-    _place(text_overflow, "text_overflow")
+    # text_overflow リストには real-font path の font_not_measured warning も
+    # 混じる可能性がある。category で振り分けて別バケツへ格納する。
+    overflow_errors = [f for f in text_overflow if f.category == "text_overflow"]
+    font_missing = [f for f in text_overflow if f.category == "font_not_measured"]
+    _place(overflow_errors, "text_overflow")
+    _place(font_missing, "font_not_measured")
     _place(unreadable, "unreadable_text")
     _place(divider, "divider_collision")
     _place(gaps, "inconsistent_gaps")
@@ -1166,12 +1476,13 @@ def check_deck_extended(
 
     # summary: ValidationFinding 由来 + legacy (overlaps / out_of_bounds) を集計する。
     # 詳細な severity mapping は docstring 参照。
-    errors = sum(1 for f in text_overflow + divider if f.severity == "error")
+    errors = sum(1 for f in overflow_errors + divider if f.severity == "error")
     for slide_data in slides_out:
         errors += len(slide_data["overlaps"])
         errors += len(slide_data["out_of_bounds"])
     warnings_count = sum(1 for f in unreadable if f.severity == "warning")
     warnings_count += sum(1 for f in title_wrap if f.severity == "warning")
+    warnings_count += sum(1 for f in font_missing if f.severity == "warning")
     infos = sum(1 for f in gaps if f.severity == "info")
 
     return {

--- a/tests/calibration_helpers.py
+++ b/tests/calibration_helpers.py
@@ -1,56 +1,16 @@
-"""キャリブレーション用ヘルパ: TTF/OTF から実 advance 幅を読み出す.
+"""キャリブレーション用ヘルパ (後方互換の thin wrapper).
 
-`text_metrics` ヒューリスティックとは独立したモジュールである。
-fontTools の hmtx テーブルを直接参照するため、決定論的かつ
-システム依存のラスタライズ誤差を受けない。
+実装は ``pptx_mcp_server.engine.font_metrics`` に昇格済み (Issue #91)。
+既存 test/スクリプトが ``from tests.calibration_helpers import
+advance_width_inches`` で参照していたため、互換のため re-export する。
 
-fontTools は test extra でのみ要求されるため、このモジュールは
-`tests/` 配下に置き、本体パッケージには取り込まない。
+新規コードは ``pptx_mcp_server.engine.font_metrics`` から直接 import
+すること。
 """
 
 from __future__ import annotations
 
-from functools import lru_cache
-from typing import Any
-
-
-@lru_cache(maxsize=8)
-def _load_font(path: str) -> Any:
-    """TTF/TTC を遅延読込しキャッシュする.
-
-    TTC の場合は先頭フェイスを返す。日本語システムフォントの TTC は
-    通常 Regular ウェイトから順に格納されているため、キャリブレーション
-    基準としては先頭で十分である。
-    """
-    from fontTools.ttLib import TTCollection, TTFont
-
-    if path.endswith(".ttc"):
-        coll = TTCollection(path)
-        return coll.fonts[0]
-    return TTFont(path, recalcTimestamp=False)
-
-
-def advance_width_inches(font_path: str, char: str, size_pt: float) -> float:
-    """``char`` の ``size_pt`` における advance 幅を inches で返す.
-
-    複数コードポイントが渡された場合は各コードポイントの advance を
-    加算する (合字・シェイピングは考慮しない点に注意。ヒューリスティック
-    と対比可能な粒度で測るのが目的である)。
-
-    cmap に glyph が存在しないとき ``KeyError`` を送出する。
-    """
-    font = _load_font(font_path)
-    cmap = font.getBestCmap()
-    hmtx = font["hmtx"]
-    units_per_em = font["head"].unitsPerEm
-    total_units = 0
-    for ch in char:
-        glyph_name = cmap.get(ord(ch))
-        if glyph_name is None:
-            raise KeyError(
-                f"Character {ch!r} (U+{ord(ch):04X}) not in font {font_path}"
-            )
-        advance, _ = hmtx[glyph_name]
-        total_units += advance
-    # 1 pt = 1/72 inch. advance_in_em = units / units_per_em.
-    return total_units / units_per_em * size_pt / 72.0
+from pptx_mcp_server.engine.font_metrics import (  # noqa: F401
+    advance_width_inches,
+    text_width_inches,
+)

--- a/tests/test_real_font_validation.py
+++ b/tests/test_real_font_validation.py
@@ -1,0 +1,322 @@
+"""Issue #91: ``check_text_overflow`` の real-font path 検証.
+
+ヒューリスティックと実フォント advance width の echo chamber を破壊する
+ことが目的。本テストスイートは fontTools + 実フォント (Liberation Sans
+/ macOS Arial / Windows Arial / Noto CJK 等) が存在する環境でのみ
+実行される (``pytest.skip`` でフォント欠損を正直にスキップする)。
+
+テスト対象:
+    1. デフォルト ``font_source='heuristic'`` は既存挙動
+    2. 同じ入力で heuristic が "fits" と判定する一方、real path が
+       overflow を検出することで echo chamber の存在を証明する
+    3. ``font_paths`` で解決できないフォントはヒューリスティックに
+       フォールバックし、warning finding を発行する
+    4. fontTools 未インストール時に friendly message を出す
+    5. ``discover_system_fonts`` が macOS/Linux で ≥1 件返す
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+import pytest
+from pptx import Presentation
+from pptx.util import Inches, Pt
+
+
+# fontTools 欠損環境では本ファイル全体をスキップ。
+pytest.importorskip("fontTools.ttLib")
+
+
+from pptx_mcp_server.engine.font_metrics import (
+    advance_width_inches,
+    discover_system_fonts,
+    text_width_inches,
+)
+from pptx_mcp_server.engine.pptx_io import EngineError, ErrorCode
+from pptx_mcp_server.engine.validation import (
+    check_deck_extended,
+    check_text_overflow,
+)
+
+
+_ARIAL_CANDIDATES = [
+    "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+    "/usr/share/fonts/truetype/liberation2/LiberationSans-Regular.ttf",
+    "/Library/Fonts/Arial.ttf",
+    "/System/Library/Fonts/Supplemental/Arial.ttf",
+    "/Windows/Fonts/arial.ttf",
+    "C:\\Windows\\Fonts\\arial.ttf",
+]
+
+
+def _first_existing(paths: list[str]) -> str | None:
+    for p in paths:
+        if os.path.exists(p):
+            return p
+    return None
+
+
+@pytest.fixture(scope="module")
+def arial_path() -> str:
+    p = _first_existing(_ARIAL_CANDIDATES)
+    if p is None:
+        pytest.skip(
+            "Arial/Liberation Sans TTF not found — skip real-font tests. "
+            "On Ubuntu CI: apt install fonts-liberation."
+        )
+    return p
+
+
+def _make_deck_with_wide_text(
+    font_name: str = "Arial",
+    frame_width: float = 2.1,
+    frame_height: float = 0.35,
+    text: str = "W" * 14,
+    pt: float = 12.0,
+) -> Presentation:
+    """heuristic と real で行数が食い違う textbox を 1 つ含む deck を作る.
+
+    ``W`` 14 連は Arial 実測で usable width 2.0" (frame_width=2.1 - padding
+    0.10) を越え、real 経路では 2 行に折り返される。ヒューリスティックの
+    ASCII WIDE バケット repr (0.01172/pt) は W を ~10% 過小評価するため、
+    1 行で収まる判定となる。frame_height=0.35 は 1 行分 (0.20") には
+    余裕があり、2 行分 (0.40") は tolerance 1.05 (=0.3675) を超える。
+    """
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    tb = slide.shapes.add_textbox(
+        Inches(1.0), Inches(1.0), Inches(frame_width), Inches(frame_height)
+    )
+    tf = tb.text_frame
+    tf.word_wrap = True
+    tf.text = text
+    for para in tf.paragraphs:
+        for run in para.runs:
+            run.font.size = Pt(pt)
+            run.font.name = font_name
+    tb.name = "EchoChamberProbe"
+    return prs
+
+
+# ---------------------------------------------------------------------------
+# 1. Default (heuristic) path preserved
+# ---------------------------------------------------------------------------
+
+
+def test_default_heuristic_path_unchanged(arial_path: str) -> None:
+    """``font_source`` を渡さない既定動作 = 既存の heuristic 挙動."""
+    prs = _make_deck_with_wide_text()
+    findings = check_text_overflow(prs)
+    # ヒューリスティックでは 1 行で収まるので overflow 無し
+    overflow = [f for f in findings if f.category == "text_overflow"]
+    assert overflow == [], (
+        f"heuristic path should find no overflow for 14*'W' in 2.0\" frame; "
+        f"got: {overflow}"
+    )
+
+
+def test_explicit_heuristic_path_equivalent(arial_path: str) -> None:
+    """``font_source='heuristic'`` は明示指定でも既定と同じ結果を返す."""
+    prs = _make_deck_with_wide_text()
+    default = check_text_overflow(prs)
+    explicit = check_text_overflow(prs, font_source="heuristic")
+    assert [f.to_dict() for f in default] == [f.to_dict() for f in explicit]
+
+
+# ---------------------------------------------------------------------------
+# 2. Real path breaks the echo chamber (KEY TEST)
+# ---------------------------------------------------------------------------
+
+
+def test_real_path_catches_overflow_heuristic_misses(arial_path: str) -> None:
+    """heuristic は "fits" と言うが、real-font は overflow を正しく検出する.
+
+    この非対称性が echo chamber の核心。heuristic + auto-fit が同じ
+    下位モデルを共有する限り、両者は一致して沈黙する。real-font path
+    だけが独立した第三者として食い違いを検出できる。
+    """
+    prs = _make_deck_with_wide_text()
+
+    heur = [
+        f
+        for f in check_text_overflow(prs, font_source="heuristic")
+        if f.category == "text_overflow"
+    ]
+    real = [
+        f
+        for f in check_text_overflow(
+            prs, font_source="real", font_paths={"Arial": arial_path}
+        )
+        if f.category == "text_overflow"
+    ]
+    assert heur == [], f"heuristic must silently accept; got: {heur}"
+    assert len(real) == 1, (
+        f"real path must flag overflow (found independently of heuristic); "
+        f"got: {real}"
+    )
+    assert real[0].slide_index == 0
+    assert real[0].shape_name == "EchoChamberProbe"
+
+
+# ---------------------------------------------------------------------------
+# 3. Missing font fallback
+# ---------------------------------------------------------------------------
+
+
+def test_missing_font_falls_back_to_heuristic_with_warning(
+    arial_path: str,
+) -> None:
+    """``font_paths`` に font name が存在しない場合はヒューリスティック
+    にフォールバックし、``font_not_measured`` warning を発行する."""
+    prs = _make_deck_with_wide_text(font_name="NonExistentFont")
+    findings = check_text_overflow(
+        prs,
+        font_source="real",
+        font_paths={"SomeOtherFont": arial_path},
+    )
+    warns = [f for f in findings if f.category == "font_not_measured"]
+    assert len(warns) == 1, f"expected 1 warning; got: {warns}"
+    assert "NonExistentFont" in warns[0].message
+    assert warns[0].severity == "warning"
+    # overflow は heuristic fallback の結果 = 検出されない
+    overflow = [f for f in findings if f.category == "text_overflow"]
+    assert overflow == []
+
+
+# ---------------------------------------------------------------------------
+# 4. fontTools absent → friendly error
+# ---------------------------------------------------------------------------
+
+
+def test_fonttools_missing_raises_friendly_error(
+    monkeypatch: pytest.MonkeyPatch, arial_path: str
+) -> None:
+    """``fontTools`` が import できない環境で ``font_source='real'`` を
+    呼ぶと ``EngineError(INVALID_PARAMETER)`` + extras ヒントを返す."""
+    prs = _make_deck_with_wide_text()
+
+    import pptx_mcp_server.engine.validation as validation_mod
+
+    # validation._check_fonttools_available が import fontTools.ttLib を
+    # 試みる。ここでは builtins.__import__ を差し替え、fontTools を
+    # import した瞬間に ImportError を送出する。
+    import builtins
+    real_import = builtins.__import__
+
+    def _blocking_import(name, *args, **kwargs):
+        if name == "fontTools" or name.startswith("fontTools"):
+            raise ImportError(f"No module named {name!r} (simulated)")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocking_import)
+
+    with pytest.raises(EngineError) as exc_info:
+        check_text_overflow(
+            prs, font_source="real", font_paths={"Arial": arial_path}
+        )
+    assert exc_info.value.code == ErrorCode.INVALID_PARAMETER
+    msg = str(exc_info.value)
+    assert "fontTools" in msg
+    assert "[validation]" in msg
+
+
+# ---------------------------------------------------------------------------
+# 5. System font discovery
+# ---------------------------------------------------------------------------
+
+
+def test_discover_system_fonts_returns_at_least_one() -> None:
+    """macOS/Linux 標準環境では ≥1 件 返る. CI で全く見つからない場合は
+    skip する (test_library_only 等の barebones image への配慮)."""
+    fonts = discover_system_fonts()
+    if not fonts:
+        pytest.skip("no system fonts detected in this environment")
+    # 少なくとも Arial 系 or CJK 系のいずれかが見つかる筈
+    assert any(
+        k in fonts
+        for k in ("Arial", "Liberation Sans", "Yu Gothic", "Noto Sans CJK", "Hiragino Sans", "Meiryo")
+    ), f"no expected font key found in: {fonts}"
+
+
+def test_discover_system_fonts_paths_exist() -> None:
+    """返り値のパスはすべて実在する。"""
+    for name, path in discover_system_fonts().items():
+        assert os.path.exists(path), f"{name}: path does not exist: {path}"
+
+
+# ---------------------------------------------------------------------------
+# advance_width_inches / text_width_inches smoke
+# ---------------------------------------------------------------------------
+
+
+def test_advance_width_inches_linear_in_size(arial_path: str) -> None:
+    """advance 幅は size_pt に線形比例する."""
+    w10 = advance_width_inches(arial_path, "A", 10.0)
+    w20 = advance_width_inches(arial_path, "A", 20.0)
+    assert w10 > 0
+    assert w20 == pytest.approx(w10 * 2, rel=1e-6)
+
+
+def test_text_width_inches_sums_chars(arial_path: str) -> None:
+    """text_width_inches は per-char advance の合計に等しい."""
+    text = "Hello"
+    summed = sum(advance_width_inches(arial_path, ch, 12.0) for ch in text)
+    assert text_width_inches(arial_path, text, 12.0) == pytest.approx(summed, rel=1e-6)
+
+
+def test_text_width_inches_ignores_newlines(arial_path: str) -> None:
+    """``\\n`` は幅 0 として扱う."""
+    w_plain = text_width_inches(arial_path, "ab", 12.0)
+    w_nl = text_width_inches(arial_path, "a\nb", 12.0)
+    assert w_nl == pytest.approx(w_plain, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# check_deck_extended 統合
+# ---------------------------------------------------------------------------
+
+
+def test_check_deck_extended_surfaces_real_path_findings(arial_path: str) -> None:
+    """``check_deck_extended`` 経由でも real-font path の結果が流れ込む."""
+    prs = _make_deck_with_wide_text()
+
+    # heuristic では text_overflow = 0 のはず
+    heur_report = check_deck_extended(prs)
+    assert heur_report["summary"]["errors"] == 0
+
+    # real で呼ぶと text_overflow が 1 件検出され errors に加算される
+    real_report = check_deck_extended(
+        prs, font_source="real", font_paths={"Arial": arial_path}
+    )
+    slide_0 = real_report["slides"][0]
+    assert len(slide_0["text_overflow"]) == 1, slide_0
+    assert real_report["summary"]["errors"] >= 1
+
+
+def test_check_deck_extended_font_not_measured_warning(arial_path: str) -> None:
+    """未解決フォントは ``font_not_measured`` warning として slide-level
+    に格納され、summary.warnings に加算される."""
+    prs = _make_deck_with_wide_text(font_name="GhostFont")
+    report = check_deck_extended(
+        prs,
+        font_source="real",
+        font_paths={"OtherFont": arial_path},
+    )
+    slide_0 = report["slides"][0]
+    assert len(slide_0["font_not_measured"]) == 1, slide_0
+    assert report["summary"]["warnings"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# calibration_helpers 後方互換
+# ---------------------------------------------------------------------------
+
+
+def test_calibration_helpers_reexport_still_works(arial_path: str) -> None:
+    """``tests.calibration_helpers`` は engine モジュールの re-export を返す."""
+    from tests.calibration_helpers import advance_width_inches as legacy_adv
+
+    assert legacy_adv is advance_width_inches
+    assert legacy_adv(arial_path, "A", 10.0) > 0


### PR DESCRIPTION
## Summary

- `check_text_overflow` + `add_auto_fit_textbox` shared the same `text_metrics` heuristic. If the heuristic drifts vs real PowerPoint font metrics, both sides drift together and the validator stays silent while actual decks clip — the Anthropic PE reviewer's flagged most-likely 6-month regression.
- Add opt-in `font_source="real"` path backed by fontTools advance widths. Promote the test-only `calibration_helpers` into `engine/font_metrics.py`; gate fontTools behind a new `[validation]` extra.
- Plumb `font_source` + `font_paths` through `check_deck_extended`. Unresolved fonts fall back per-paragraph and emit a `font_not_measured` warning (summary.warnings).
- Add `discover_system_fonts()` for zero-config probing (Arial / Liberation / Yu Gothic / Meiryo / Hiragino / Noto CJK).

## Why this design

- Default remains `font_source="heuristic"` — no breaking change, no new runtime deps.
- Library consumers that don't want fontTools get the full engine as-is.
- `[validation]` is production-facing (no pytest), `[test]` still pins fontTools for the calibration suite.
- `tests/calibration_helpers.py` shrinks to a pure re-export shim so existing `test_calibration.py` imports keep working.

## Echo-chamber test

14×`W` in a 2.1"×0.35" frame at 12pt:

- Heuristic: 1 line at 0.20" → fits in frame (0.35" × 1.05 tolerance = 0.37") → **no overflow**
- Real (Arial advance widths via fontTools): 14 W's = 2.20" > 2.0" usable → force-split to 2 lines at 0.40" → **overflow detected**

This is the exact class of bug the PE reviewer predicted — heuristic says "fits" because it shares a model with auto-fit, while PowerPoint's real rendering disagrees.

## Test plan

- [x] `python -m pytest` → 581 passed, 1 skipped (up from 568).
- [x] `python -m pytest tests/test_real_font_validation.py -v` → 13 passed (on macOS).
- [x] Engine imports clean with fontTools shadowed out (heuristic-only path stays dep-free).
- [x] `check_deck_extended` surfaces real-path findings + `font_not_measured` warnings through slide-level buckets and `summary` counters.
- [x] CI: piggyback on existing `calibration` job (already installs `fonts-liberation` + `fonts-noto-cjk`); bump install to `[mcp,test,validation]` and run `test_real_font_validation.py` alongside `test_calibration.py`.

Closes #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)