### PR TITLE
chore(release): bump to v0.2.0 (Beta)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pptx-mcp-server"
-version = "0.1.0"
-description = "MCP server for PPTX presentation editing — create, read, and edit PowerPoint slides with professional formatting"
+version = "0.2.0"
+description = "Content-aware PPTX layout engine with Japanese-aware text metrics, CSS-flex-like primitives, and structural validator for agent-generated consulting decks"
 requires-python = ">=3.11"
 license = "MIT"
 readme = "README.md"
@@ -14,7 +14,7 @@ authors = [
 ]
 keywords = ["mcp", "pptx", "powerpoint", "presentation", "slides"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Bumps version and classifier for v0.2.0 release after the production-readiness review round closed 8 issues. Tag v0.2.0 after merge to trigger PyPI publish workflow.