### PR TITLE
feat(server): v0.3.0 structured MCP surface + normalized response (closes #97, #98, #99, #100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,120 @@
+# Changelog
+
+All notable changes to `pptx-mcp-server` are documented in this file.
+
+## v0.3.0 — BREAKING: structured MCP surface
+
+Flagged by OpenAI/Codex 5.4 as the remaining blockers to LOGO-READY status;
+closes #97, #98, #99, #100.
+
+### BREAKING CHANGES
+
+#### #97 — Structured MCP parameters (`*_json: str` removed)
+
+Every JSON-string-wrapped parameter was replaced with a native Python type.
+FastMCP generates JSON Schema from Python typing, so agents send native
+objects — no client-side string-encoding, no server-side `json.loads` layer.
+
+| Tool | Before | After |
+|------|--------|-------|
+| `pptx_add_flex_container` | `items_json: str` | `items: list[dict]` |
+| `pptx_add_responsive_card_row` | `cards_json: str` | `cards: list[dict]` |
+| `pptx_build_slide` | `spec_json: str` | `spec: dict` |
+| `pptx_build_deck` | `slides_json: str` | `slides: list[dict]` |
+| `pptx_add_chart` | `chart_json: str` | `chart: dict` |
+| `pptx_add_kpi_row` | `kpis_json: str` | `kpis: list[dict]` |
+| `pptx_add_table` | `rows_json: str` + `col_widths_json: str` | `rows: list[list[Any]]` + `col_widths: list[float] \| None` |
+| `pptx_add_bullet_block` | `items_json: str` | `bullets: list[str]` |
+| `pptx_edit_table_cells` | `edits_json: str` | `edits: list[dict]` |
+
+Dict-content validation (e.g. `CardSpec` unknown-key rejection, flex item
+sizing keys) continues to run at the tool boundary and returns
+`INVALID_PARAMETER` with `parameter` + `message` pointing at the bad card/item.
+
+#### #98 — `result` is always a dict
+
+Previously `result` was sometimes a string (default path), sometimes a dict
+(auto-render path), sometimes a JSON-encoded string (`check_layout` detailed
+path). Agents could not write a single parser.
+
+v0.3.0 normalizes: **`result` is always a dict**, minimally
+`{"message": "..."}`. Composite tools with auto-render integration add
+`preview_path` or `render_warning` as additional keys on the same dict
+(previously the payload was re-wrapped under a `value` key).
+
+```python
+# Before (v0.2.x)
+{"ok": true, "result": "Added content slide [1]: ..."}
+{"ok": true, "result": {"value": "Added ...", "preview_path": "/tmp/s.png"}}
+
+# After (v0.3.0)
+{"ok": true, "result": {"message": "Added content slide [1]: ..."}}
+{"ok": true, "result": {"message": "Added ...", "preview_path": "/tmp/s.png"}}
+```
+
+`_success()` now requires a dict argument; passing a non-dict raises
+`TypeError` defensively (catches regressions during development).
+
+#### #99 — Flatten double-decode in `pptx_check_layout(detailed=True)`
+
+The detailed path previously returned `_success(json.dumps(result))`,
+forcing consumers to `json.loads(response)["result"]` → still a string →
+`json.loads(that)`. Fixed to pass the dict inline:
+
+```python
+# Before (v0.2.x)
+json.loads(tool_response)["result"]   # → '{"slides":[...]}'  (still a string)
+
+# After (v0.3.0)
+json.loads(tool_response)["result"]   # → {"slides": [...]}   (single decode)
+```
+
+Non-detailed `pptx_check_layout` keeps the human-readable summary, wrapped
+per #98 under `result["message"]`.
+
+#### #100 — Consistent malformed-JSON handling
+
+With #97 in place, all raw `json.loads()` calls inside tool bodies are gone
+— FastMCP's type validation fires before the tool function runs, returning a
+structured error if the caller sent the wrong shape. The server layer now
+contains **zero** `json.loads()` / `JSONDecodeError` references in tool
+bodies (only the `json.dumps()` used to build the outer envelope remains).
+
+Malformed input no longer surfaces as `INTERNAL_ERROR: JSONDecodeError`;
+instead FastMCP returns a schema-validation error with parameter info.
+Explicit `isinstance` guards at tool entry catch the remaining edge cases
+(e.g. `rows=None`) with a dedicated `INVALID_PARAMETER` response carrying
+`parameter`, `hint`, and `issue` fields.
+
+### Non-breaking
+
+- README and in-process `INSTRUCTIONS` prompt updated to document the
+  v0.3.0 response shape and structured-param convention.
+- Test suite updated from 638 → 652 passing tests (1 skipped).
+  New coverage: `rows=None` rejection, `detailed=True` single-decode
+  regression, result-always-dict assertions across all primitive tools,
+  structured-param type-rejection tests for every converted tool.
+
+### Refactor (no behaviour change; closes #101, #102)
+
+- `INSTRUCTIONS` trimmed from 178 → 50 lines. Removed McKinsey-specific
+  layout rules, data density guidelines, color palette prose, and slide /
+  chart / icon / callout worked examples. Kept only parameter conventions,
+  workflow guidance, theme enumeration, response-shape docs, and
+  auto-render env vars. UX / styling belongs in the calling agent's
+  system prompt.
+- Structured-response helpers (`_success`, `_error`, `_err`,
+  `_success_with_render`) extracted into
+  `pptx_mcp_server._envelope` (module-private).
+- Auto-render gate (`_auto_render_enabled`, `_auto_render_timeout`,
+  timeout-enforced runner) extracted into `pptx_mcp_server._render`.
+  `server.py` keeps a thin `_auto_render` shim that injects its own
+  `render_slide` binding so `monkeypatch.setattr(server, "render_slide",
+  …)` tests stay green.
+- README tool count corrected (25 → 37); README tables now match
+  `@mcp.tool()` registrations 1:1.
+
+## v0.2.0 — Beta, structured responses, opt-in auto-render
+
+See prior issues #86 (auto-render opt-in) and #88 (structured `{ok,
+result|error}` envelope) for the earlier breaking changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,16 @@ source of truth.
 | MCP tool | `pptx_verb_noun` | `pptx_add_textbox` |
 | File-based wrapper | `verb_noun_file` | `add_textbox_file` |
 | In-memory primitive | `verb_noun` (no suffix) | `add_textbox` |
-| JSON input via MCP | `_json` suffix on the arg | `items_json` |
+| Structured MCP input | native typed arg (`list[dict]`, `dict`, etc.) | `items: list[dict]`, `spec: dict` |
 | Font size argument | `_pt` suffix | `font_size_pt` |
+
+> **v0.3.0 convention change (#97).** The `_json` suffix convention was
+> retired: MCP tools now take native `list` / `dict` arguments and let
+> FastMCP generate JSON Schema from the Python type annotation. Pre-v0.3.0
+> tools used JSON-stringified params (`items_json: str` → runtime
+> `json.loads`) which forced every caller to double-encode and hid type
+> errors behind `INTERNAL_ERROR: JSONDecodeError`. Do not add new
+> `*_json: str` params.
 | Colors | 6-hex, no `#` | `"051C2C"` |
 | Coordinates / dimensions | inches (float) | `left=1.0, width=10.0` |
 

--- a/README.md
+++ b/README.md
@@ -126,9 +126,18 @@ Adding a new script involves extending `_CJK_RANGES` (or a new script set),
 calibrating a width constant, and adding sentinel characters to
 `tests/test_calibration.py`. See `CONTRIBUTING.md` → "Adding a new script".
 
-## Response Shape (v0.2.0+)
+## Response Shape (v0.3.0+)
 
-> **BREAKING CHANGE (v0.2.0).** All MCP tool responses are now JSON-encoded and
+> **BREAKING CHANGE (v0.3.0).** `result` is now **always a dict**. Tools that
+> previously returned a raw human-readable string now wrap it in
+> `{"message": "..."}`. Composite tools with auto-render integration add
+> `preview_path` / `render_warning` keys to the same dict instead of wrapping
+> the primary payload under a `value` key. `pptx_check_layout(detailed=True)`
+> returns the findings dict inline — single `json.loads()` on the tool response
+> fully decodes it (previously the dict was re-encoded as a string under
+> `result`). See issues #98, #99.
+
+> **BREAKING CHANGE (v0.2.0).** All MCP tool responses are JSON-encoded and
 > wrapped in a `{ok, result | error}` envelope.  Previously tools returned raw
 > human-readable strings (success) and bracket-prefixed errors like
 > `"[INVALID_PARAMETER] ..."`.  Consumers must `json.loads()` the response and
@@ -137,7 +146,19 @@ calibrating a width constant, and adding sentinel characters to
 Success:
 
 ```json
-{"ok": true, "result": "Added content slide [1]: Revenue Analysis"}
+{"ok": true, "result": {"message": "Added content slide [1]: Revenue Analysis"}}
+```
+
+Success with auto-render:
+
+```json
+{"ok": true, "result": {"message": "Added content slide [1]: ...", "preview_path": "/tmp/slide-01.png"}}
+```
+
+Detailed layout check:
+
+```json
+{"ok": true, "result": {"slides": [...], "summary": {"errors": 0, "warnings": 0, "infos": 0}}}
 ```
 
 Error:
@@ -147,10 +168,10 @@ Error:
   "ok": false,
   "error": {
     "code": "INVALID_PARAMETER",
-    "parameter": "items_json",
-    "message": "items_json must be a JSON string, not a raw Python list.",
-    "hint": "Pass a JSON-stringified array, e.g., '[{\"sizing\":\"fixed\",\"size\":2,\"type\":\"rectangle\"}]'.",
-    "issue": 35
+    "parameter": "items",
+    "message": "items must be a list of dicts.",
+    "hint": "Pass a native Python list, e.g., [{\"sizing\":\"fixed\",\"size\":2,\"type\":\"rectangle\"}].",
+    "issue": 97
   }
 }
 ```
@@ -159,6 +180,41 @@ Error `code` values mirror `EngineError.code`: `INVALID_PARAMETER`,
 `FILE_NOT_FOUND`, `SLIDE_NOT_FOUND`, `SHAPE_NOT_FOUND`, `INDEX_OUT_OF_RANGE`,
 `INVALID_PPTX`, `TABLE_ERROR`, `CHART_ERROR`, `INTERNAL_ERROR`.  The
 `parameter`, `hint`, and `issue` fields are optional.
+
+## Structured Parameters (v0.3.0+)
+
+> **BREAKING CHANGE (v0.3.0).** `*_json: str` tool parameters were replaced
+> with structured types (native `list` / `dict`). FastMCP validates the top
+> level from Python type annotations; tools enforce dict-key contracts (e.g.
+> `CardSpec` unknown-key rejection) at the tool boundary. See issue #97.
+
+Before (v0.2.x):
+
+```python
+pptx_add_table(path, 0, rows_json='[["H1","H2"],["a","b"]]', 1, 1, 5)
+pptx_build_deck(path, slides_json='[{"layout":"content",...}]')
+```
+
+After (v0.3.0+):
+
+```python
+pptx_add_table(path, 0, rows=[["H1","H2"],["a","b"]], 1, 1, 5)
+pptx_build_deck(path, slides=[{"layout":"content", ...}])
+```
+
+Affected tools (and replaced param names):
+
+| Tool | Old param | New param |
+|------|-----------|-----------|
+| `pptx_add_flex_container` | `items_json: str` | `items: list[dict]` |
+| `pptx_add_responsive_card_row` | `cards_json: str` | `cards: list[dict]` |
+| `pptx_build_slide` | `spec_json: str` | `spec: dict` |
+| `pptx_build_deck` | `slides_json: str` | `slides: list[dict]` |
+| `pptx_add_chart` | `chart_json: str` | `chart: dict` |
+| `pptx_add_kpi_row` | `kpis_json: str` | `kpis: list[dict]` |
+| `pptx_add_table` | `rows_json: str` + `col_widths_json: str` | `rows: list[list]` + `col_widths: list[float] \| None` |
+| `pptx_add_bullet_block` | `items_json: str` | `bullets: list[str]` |
+| `pptx_edit_table_cells` | `edits_json: str` | `edits: list[dict]` |
 
 ## Auto-Render (opt-in; v0.2.0+)
 
@@ -177,12 +233,14 @@ export PPTX_MCP_AUTO_RENDER=1           # enable
 export PPTX_MCP_RENDER_TIMEOUT=10        # seconds (default 10)
 ```
 
-When enabled, the successful result payload becomes
-`{"value": "<legacy string>", "preview_path": "/path/to/slide-01.png"}`.  If
+When enabled, the successful result payload carries an additional
+`preview_path` key alongside `message`:
+`{"message": "<legacy string>", "preview_path": "/path/to/slide-01.png"}`. If
 the render times out or fails, the primary action still succeeds and the
-result payload carries a `render_warning` field instead of a `preview_path`.
-For explicit, synchronous rendering use `pptx_render_slide` directly — that
-tool is unaffected by this gate.
+result payload carries a `render_warning` field instead of a `preview_path`
+(v0.3.0 unifies this shape — prior versions wrapped under a `value` key, see
+issue #98). For explicit, synchronous rendering use `pptx_render_slide`
+directly — that tool is unaffected by this gate.
 
 ## Tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pptx-mcp-server"
-version = "0.2.0"
+version = "0.3.0"
 description = "Content-aware PPTX layout engine with Japanese-aware text metrics, CSS-flex-like primitives, and structural validator for agent-generated consulting decks"
 requires-python = ">=3.11"
 license = "MIT"

--- a/src/pptx_mcp_server/_envelope.py
+++ b/src/pptx_mcp_server/_envelope.py
@@ -3,11 +3,16 @@
 本モジュールは `server.py` から切り出したヘルパである。公開 API
 ではなく、モジュール名に先頭アンダースコアを付けている。
 
-Tool 戻り値はすべて JSON 文字列で、次の包に統一する (issue #88):
+Tool 戻り値はすべて JSON 文字列で、次の包に統一する (issue #88, #98):
 
-- 成功: ``{"ok": true, "result": <legacy value>}``
+- 成功: ``{"ok": true, "result": <dict>}``  — ``result`` は **常に dict**
 - 失敗: ``{"ok": false, "error": {"code": ..., "message": ...,
         "parameter"?: ..., "hint"?: ..., "issue"?: ...}}``
+
+v0.3.0 (#98): ``result`` は常に dict である。legacy で string を返していた
+tool は ``{"message": "..."}`` に wrap して ``_success`` に渡す。auto-render
+や追加情報は同じ dict に key を足す (``preview_path`` / ``render_warning``
+/ ``slides`` 等)。
 
 ``code`` は :class:`pptx_mcp_server.engine.EngineError` の ``ErrorCode``
 値と一致する (``INVALID_PARAMETER`` 等)。それ以外の例外は
@@ -22,13 +27,20 @@ from typing import Any, Dict, Optional
 from .engine import EngineError
 
 
-def _success(result: Any) -> str:
-    """Wrap a successful tool result in ``{"ok": true, "result": ...}``.
+def _success(result: Dict[str, Any]) -> str:
+    """Wrap a successful tool result in ``{"ok": true, "result": <dict>}``.
 
-    ``result`` は legacy tool の戻り値 (通常は human-readable string) を
-    そのまま格納する。JSON で表現できない object は呼び出し側で事前に
-    serialize すること。
+    v0.3.0 (#98): ``result`` は **常に dict**。legacy string を返していた
+    tool は ``{"message": "..."}`` の形で wrap して呼び出す。auto-render
+    や追加情報は同じ dict に key を足す (``preview_path`` / ``render_warning``
+    / ``slides`` 等)。
     """
+    if not isinstance(result, dict):
+        # Defensive guard: 呼び出し漏れ検出用。本 branch に落ちるのは bug。
+        raise TypeError(
+            f"_success() expects dict; got {type(result).__name__}. "
+            "v0.3.0 以降 result は常に dict を渡す (#98)."
+        )
     return json.dumps({"ok": True, "result": result}, ensure_ascii=False)
 
 
@@ -69,19 +81,23 @@ def _err(e: Exception) -> str:
     return _error("INTERNAL_ERROR", f"{type(e).__name__}: {e}")
 
 
-def _success_with_render(primary: Any, render_info: Dict[str, Any]) -> str:
-    """Compose a success payload plus the auto-render outcome.
+def _success_with_render(message: str, render_info: Dict[str, Any]) -> str:
+    """Compose a success payload plus the auto-render outcome (v0.3.0 shape).
 
-    - Render disabled → plain ``{"ok": true, "result": <primary>}``.
-    - Render succeeded → result wraps ``{"value": primary, "preview_path": ...}``.
-    - Render failed/timed out → result wraps ``{"value": primary,
-      "render_warning": {...}}``.
+    v0.3.0 (#98): ``result`` は常に dict で, ``message`` キーに legacy
+    human-readable string を入れる。auto-render の結果は同じ dict に
+    ``preview_path`` か ``render_warning`` を **追加** する。
+
+    - Render disabled → ``{"ok": true, "result": {"message": <msg>}}``
+    - Render succeeded → ``{"message": <msg>, "preview_path": ...}``
+    - Render failed/timed out → ``{"message": <msg>, "render_warning": {...}}``
     """
+    payload: Dict[str, Any] = {"message": message}
     if not render_info.get("rendered") and render_info.get("reason") == "disabled":
-        return _success(primary)
+        return _success(payload)
     if render_info.get("rendered"):
-        return _success(
-            {"value": primary, "preview_path": render_info.get("preview_path")}
-        )
+        payload["preview_path"] = render_info.get("preview_path")
+        return _success(payload)
     # Failed / timeout — primary still succeeded.
-    return _success({"value": primary, "render_warning": render_info})
+    payload["render_warning"] = render_info
+    return _success(payload)

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -2,38 +2,44 @@
 """
 pptx-mcp-server -- MCP server for PPTX presentation editing.
 
-Parameter conventions (new tools):
-- ``*_json``: JSON-stringified array/object input (例: ``rows_json``, ``kpis_json``,
-  ``cards_json``, ``items_json``). 生の Python list/dict ではなく必ず JSON 文字列で渡す。
+Parameter conventions (v0.3.0):
+- Structured parameters pass native Python types (``list[dict]``, ``dict``,
+  ``list[list[Any]]``) — FastMCP validates them from Python type annotations.
+  ``*_json: str`` が付いていた legacy API は v0.3.0 で撤廃された (#97)。
 - ``*_pt``: フォントサイズなど「ポイント単位」を明示する (例: ``font_size_pt``,
   ``min_size_pt``)。旧 tool の素の ``font_size`` は後方互換のため温存する。
 - ``colors``: ``"#"`` を含まない 6 桁 hex (例: ``"2251FF"``)。
 - coordinates: inches (float)。
 
-Response shape (v0.2.0; BREAKING change — see issue #88):
+Response shape (v0.3.0; BREAKING change — see issues #98, #99):
 
 All tool calls return a JSON string. Success payloads are wrapped as::
 
-    {"ok": true, "result": <legacy return value>}
+    {"ok": true, "result": {"message": "...", ...extra fields}}
+
+``result`` は **常に dict** であり, 最低限 ``message`` キーを持つ (#98)。
+auto-render が enabled の場合は ``preview_path`` が付与され, failure/timeout の
+場合は ``render_warning`` が付与される (shape は一貫して dict のまま)。
+``pptx_check_layout(detailed=True)`` は ``slides`` / ``summary`` を持つ
+dict をそのまま埋め込む — 呼び出し側は単 json.loads で decode 完了する (#99)。
 
 Error payloads are structured as::
 
     {"ok": false, "error": {
         "code": "INVALID_PARAMETER",
-        "parameter": "items_json",   // optional
+        "parameter": "items",         // optional
         "message": "...",
         "hint": "...",                // optional
         "issue": 35                    // optional GitHub issue reference
     }}
 
-Consumers should ``json.loads`` the response and branch on the ``ok`` field.
-The ``error.code`` field mirrors ``EngineError.code`` enum values
+``error.code`` field mirrors ``EngineError.code`` enum values
 (``INVALID_PARAMETER``, ``FILE_NOT_FOUND``, ``SLIDE_NOT_FOUND``, etc.).
 
-Auto-render (v0.2.0; BREAKING change — see issue #86):
+Auto-render (v0.2.0+):
 
 Composite / batch-build tools previously invoked LibreOffice for a PNG preview
-after every successful edit. This is now **opt-in** via the
+after every successful edit. This is **opt-in** via the
 ``PPTX_MCP_AUTO_RENDER=1`` environment variable, with a hard timeout controlled
 by ``PPTX_MCP_RENDER_TIMEOUT`` (default 10 seconds). If rendering times out
 or fails, the primary tool still succeeds — the render outcome is surfaced as
@@ -42,7 +48,7 @@ a ``render_warning`` field in the result payload.
 
 import json
 from dataclasses import fields
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional, Union
 
 try:
     from mcp.server.fastmcp import FastMCP
@@ -109,15 +115,16 @@ INSTRUCTIONS = """
 Neutral capability provider. Does not prescribe UX (confirmations, theme
 choice, etc.) — that belongs in the calling agent's system prompt.
 
-## Parameter Conventions
+## Parameter Conventions (v0.3.0)
+- Structured params use native Python types (`list[dict]`, `dict`,
+  `list[list[Any]]`). The legacy `*_json: str` forms were removed in #97.
 - `colors`: 6-hex without `#` (e.g., `"2251FF"`).
 - coordinates / sizes: inches (float).
 - `*_pt`: point-unit sizes (e.g., `font_size_pt`, `min_size_pt`).
-- `*_json`: JSON-stringified arrays/objects (pass as string).
 
 ## Workflow
 - `pptx_create` — new 16:9 PPTX.
-- `pptx_build_deck` — build an ENTIRE deck from JSON spec (preferred).
+- `pptx_build_deck` — build an ENTIRE deck from a list of slide specs (preferred).
 - `pptx_build_slide` — add single slides.
 - Primitive tools (`pptx_edit_text`, `pptx_format_shape`, …) for fine edits.
 - `pptx_check_layout` catches overlaps / overflow after building.
@@ -128,11 +135,18 @@ Pass `"theme": "<name>"` in slide specs for `build_slide` / `build_deck`.
 Available: `mckinsey` (default), `deloitte`, `neutral`. For custom palettes
 pass explicit `font_color` / `fill_color` hex values on elements instead.
 
-## Response Shape
-All tools return a JSON string. Parse with `json.loads`:
-- Success: `{"ok": true, "result": ...}`
+## Response Shape (v0.3.0)
+All tools return a JSON string. Parse with `json.loads`. `result` is ALWAYS
+a dict (never a raw string, never a nested-JSON-encoded string).
+
+- Success: `{"ok": true, "result": {"message": "...", ...extra}}`
 - Error:   `{"ok": false, "error": {"code": "INVALID_PARAMETER",
-            "parameter": "items_json", "message": "...", "hint": "..."}}`
+            "parameter": "items", "message": "...", "hint": "..."}}`
+
+Composite tools add optional keys to `result` without breaking the dict
+shape — `preview_path` on successful auto-render, `render_warning` on
+timeout/failure. `pptx_check_layout(detailed=True)` embeds its `slides` /
+`summary` findings directly into `result` (single-decode, #99).
 
 `error.code` mirrors `EngineError.code`: `INVALID_PARAMETER`, `FILE_NOT_FOUND`,
 `SLIDE_NOT_FOUND`, `SHAPE_NOT_FOUND`, `INDEX_OUT_OF_RANGE`, `INVALID_PPTX`,
@@ -175,7 +189,7 @@ def pptx_create(
 ) -> str:
     """Create a new blank PPTX file. Default is 16:9 widescreen."""
     try:
-        return _success(create_presentation(file_path, width_inches, height_inches))
+        return _success({"message": create_presentation(file_path, width_inches, height_inches)})
     except Exception as e:
         return _err(e)
 
@@ -184,7 +198,7 @@ def pptx_create(
 def pptx_get_info(file_path: str) -> str:
     """Get presentation overview: slide count, dimensions, shape summaries."""
     try:
-        return _success(get_presentation_info(file_path))
+        return _success({"message": get_presentation_info(file_path)})
     except Exception as e:
         return _err(e)
 
@@ -193,7 +207,7 @@ def pptx_get_info(file_path: str) -> str:
 def pptx_read_slide(file_path: str, slide_index: int) -> str:
     """Read detailed content of a slide -- all shapes, text, tables."""
     try:
-        return _success(read_slide(file_path, slide_index))
+        return _success({"message": read_slide(file_path, slide_index)})
     except Exception as e:
         return _err(e)
 
@@ -202,7 +216,7 @@ def pptx_read_slide(file_path: str, slide_index: int) -> str:
 def pptx_list_shapes(file_path: str, slide_index: int) -> str:
     """List all shapes on a slide with indices, types, positions, text preview."""
     try:
-        return _success(list_shapes(file_path, slide_index))
+        return _success({"message": list_shapes(file_path, slide_index)})
     except Exception as e:
         return _err(e)
 
@@ -213,7 +227,7 @@ def pptx_list_shapes(file_path: str, slide_index: int) -> str:
 def pptx_add_slide(file_path: str, layout_index: int = 6) -> str:
     """Add a new slide. Layout 6 = Blank (most common)."""
     try:
-        return _success(add_slide(file_path, layout_index))
+        return _success({"message": add_slide(file_path, layout_index)})
     except Exception as e:
         return _err(e)
 
@@ -222,7 +236,7 @@ def pptx_add_slide(file_path: str, layout_index: int = 6) -> str:
 def pptx_move_slide(file_path: str, from_index: int, to_index: int) -> str:
     """Move a slide from one position to another. 0-based indices."""
     try:
-        return _success(move_slide(file_path, from_index, to_index))
+        return _success({"message": move_slide(file_path, from_index, to_index)})
     except Exception as e:
         return _err(e)
 
@@ -231,7 +245,7 @@ def pptx_move_slide(file_path: str, from_index: int, to_index: int) -> str:
 def pptx_delete_slide(file_path: str, slide_index: int) -> str:
     """Delete a slide by 0-based index."""
     try:
-        return _success(delete_slide(file_path, slide_index))
+        return _success({"message": delete_slide(file_path, slide_index)})
     except Exception as e:
         return _err(e)
 
@@ -240,7 +254,7 @@ def pptx_delete_slide(file_path: str, slide_index: int) -> str:
 def pptx_duplicate_slide(file_path: str, slide_index: int) -> str:
     """Duplicate a slide (appended at end)."""
     try:
-        return _success(duplicate_slide(file_path, slide_index))
+        return _success({"message": duplicate_slide(file_path, slide_index)})
     except Exception as e:
         return _err(e)
 
@@ -249,7 +263,7 @@ def pptx_duplicate_slide(file_path: str, slide_index: int) -> str:
 def pptx_set_slide_background(file_path: str, slide_index: int, color: str) -> str:
     """Set solid background color for a slide. Color as hex e.g. '051C2C' (without #)."""
     try:
-        return _success(set_slide_background(file_path, slide_index, color))
+        return _success({"message": set_slide_background(file_path, slide_index, color)})
     except Exception as e:
         return _err(e)
 
@@ -258,7 +272,7 @@ def pptx_set_slide_background(file_path: str, slide_index: int, color: str) -> s
 def pptx_set_dimensions(file_path: str, width: float, height: float) -> str:
     """Set presentation slide dimensions in inches (applies to all slides)."""
     try:
-        return _success(set_slide_dimensions(file_path, width, height))
+        return _success({"message": set_slide_dimensions(file_path, width, height)})
     except Exception as e:
         return _err(e)
 
@@ -287,11 +301,11 @@ def pptx_add_textbox(
 ) -> str:
     """Add a text box to a slide. Position and size in inches. Alignment: left/center/right. Vertical anchor: top/middle/bottom."""
     try:
-        return _success(add_textbox(
+        return _success({"message": add_textbox(
             file_path, slide_index, left, top, width, height, text,
             font_name, font_size, font_color, bold, italic,
             alignment, vertical_anchor, word_wrap, line_spacing, underline,
-        ))
+        )})
     except Exception as e:
         return _err(e)
 
@@ -314,7 +328,7 @@ def pptx_add_auto_fit_textbox(
     vertical_anchor: str = "top",
     truncate_with_ellipsis: bool = True,
 ) -> str:
-    """Add a textbox that auto-shrinks font size to fit a fixed box. Starts from font_size_pt and steps down 0.5pt until text fits height, or reaches min_size_pt. If still overflowing at min and truncate_with_ellipsis=True, trailing chars are replaced with an ellipsis. Returns a JSON object with shape_index, shape_name, and actual_font_size."""
+    """Add a textbox that auto-shrinks font size to fit a fixed box. Starts from font_size_pt and steps down 0.5pt until text fits height, or reaches min_size_pt. If still overflowing at min and truncate_with_ellipsis=True, trailing chars are replaced with an ellipsis. Returns a dict with shape_index, shape_name, and actual_font_size."""
     try:
         result = add_auto_fit_textbox_file(
             file_path, slide_index, text, left, top, width, height,
@@ -327,6 +341,7 @@ def pptx_add_auto_fit_textbox(
             vertical_anchor=vertical_anchor,
             truncate_with_ellipsis=truncate_with_ellipsis,
         )
+        # engine returns a dict {shape_index, shape_name, actual_font_size, ...}
         return _success(result)
     except Exception as e:
         return _err(e)
@@ -336,7 +351,7 @@ def pptx_add_auto_fit_textbox(
 def pptx_add_flex_container(
     file_path: str,
     slide_index: int,
-    items_json: str,
+    items: List[Dict[str, Any]],
     left: float,
     top: float,
     width: float,
@@ -348,8 +363,8 @@ def pptx_add_flex_container(
 ) -> str:
     """Add a CSS-flexbox-style container that lays out child items along a main axis.
 
-    ``items_json`` は JSON-stringified array (``*_json`` 命名規約に沿う)。各要素 dict
-    のキーは以下:
+    ``items`` は Python list of dict (v0.3.0 で ``items_json: str`` から変更, #97)。
+    各要素 dict のキーは以下:
       - `sizing`: "fixed" | "grow" | "content"
       - `type`: "text" | "rectangle"
       - `size` (for fixed), `grow` (for grow, default 1), `content_size` (for content)
@@ -361,38 +376,18 @@ def pptx_add_flex_container(
     align cross-axis: "stretch" のみ現状サポート。"start" / "center" / "end" は
     `INVALID_PARAMETER` を返す (将来対応予定; #24 参照)。
 
-    例: ``items_json='[{"sizing":"fixed","size":2,"type":"rectangle"}]'``
+    例: ``items=[{"sizing":"fixed","size":2,"type":"rectangle"}]``
 
-    Returns JSON with allocations (per-item [left, top, width, height]) and shape identifiers created.
+    Returns a dict with allocations (per-item [left, top, width, height]) and shape identifiers created.
     """
     try:
-        if not isinstance(items_json, str):
-            return _error(
-                "INVALID_PARAMETER",
-                "items_json must be a JSON string, not a raw Python list.",
-                parameter="items_json",
-                hint=(
-                    "Pass a JSON-stringified array, e.g., "
-                    "'[{\"sizing\":\"fixed\",\"size\":2,\"type\":\"rectangle\"}]'."
-                ),
-                issue=35,
-            )
-        try:
-            items = json.loads(items_json)
-        except json.JSONDecodeError as e:
-            return _error(
-                "INVALID_PARAMETER",
-                f"Invalid JSON in items_json: {e}",
-                parameter="items_json",
-                hint="items_json must be a JSON-stringified array.",
-                issue=35,
-            )
         if not isinstance(items, list):
             return _error(
                 "INVALID_PARAMETER",
-                "items_json must decode to a JSON array.",
-                parameter="items_json",
-                issue=35,
+                "items must be a list of dicts.",
+                parameter="items",
+                hint="Pass a native Python list, e.g., [{\"sizing\":\"fixed\",\"size\":2,\"type\":\"rectangle\"}].",
+                issue=97,
             )
         result = add_flex_container_file(
             file_path, slide_index, items,
@@ -422,11 +417,11 @@ def pptx_edit_text(
 ) -> str:
     """Edit text content and formatting in an existing shape's paragraph. Supports all formatting: font, color, bold, italic, underline, alignment, line spacing."""
     try:
-        return _success(edit_text(
+        return _success({"message": edit_text(
             file_path, slide_index, shape_index, text, paragraph_index,
             font_name, font_size, font_color, bold, italic, underline,
             alignment, line_spacing,
-        ))
+        )})
     except Exception as e:
         return _err(e)
 
@@ -448,11 +443,11 @@ def pptx_add_paragraph(
 ) -> str:
     """Append a new paragraph to an existing shape's text frame. Useful for multi-line text."""
     try:
-        return _success(add_paragraph(
+        return _success({"message": add_paragraph(
             file_path, slide_index, shape_index, text,
             font_name, font_size, font_color, bold, italic, underline,
             alignment, line_spacing,
-        ))
+        )})
     except Exception as e:
         return _err(e)
 
@@ -481,11 +476,11 @@ def pptx_add_shape(
 ) -> str:
     """Add an auto shape. Types: rectangle, rounded_rectangle, oval, triangle, diamond, chevron, arrow_right, arrow_left, arrow_up, arrow_down, callout, star_5, hexagon, pentagon. Position/size in inches. Colors as hex. WARNING: text inside shapes renders BEHIND any shapes placed on top. For labels over background shapes, use pptx_add_textbox instead."""
     try:
-        return _success(add_shape(
+        return _success({"message": add_shape(
             file_path, slide_index, shape_type, left, top, width, height,
             fill_color, line_color, line_width, no_line,
             text, font_name, font_size, font_color, bold, alignment,
-        ))
+        )})
     except Exception as e:
         return _err(e)
 
@@ -502,7 +497,7 @@ def pptx_add_image(
 ) -> str:
     """Add an image (PNG, JPG, SVG) to a slide. Position in inches. If only width or height is given, aspect ratio is preserved. If both given, image stretches to fit."""
     try:
-        return _success(add_image(file_path, slide_index, image_path, left, top, width, height))
+        return _success({"message": add_image(file_path, slide_index, image_path, left, top, width, height)})
     except Exception as e:
         return _err(e)
 
@@ -511,7 +506,7 @@ def pptx_add_image(
 def pptx_delete_shape(file_path: str, slide_index: int, shape_index: int) -> str:
     """Delete a shape from a slide by its 0-based index."""
     try:
-        return _success(delete_shape(file_path, slide_index, shape_index))
+        return _success({"message": delete_shape(file_path, slide_index, shape_index)})
     except Exception as e:
         return _err(e)
 
@@ -534,11 +529,11 @@ def pptx_format_shape(
 ) -> str:
     """Reposition, resize, or restyle an existing shape. Dimensions in inches."""
     try:
-        return _success(format_shape(
+        return _success({"message": format_shape(
             file_path, slide_index, shape_index,
             left, top, width, height,
             fill_color, no_fill, line_color, line_width, no_line, rotation,
-        ))
+        )})
     except Exception as e:
         return _err(e)
 
@@ -549,11 +544,11 @@ def pptx_format_shape(
 def pptx_add_table(
     file_path: str,
     slide_index: int,
-    rows_json: str,
+    rows: List[List[Any]],
     left: float,
     top: float,
     width: float,
-    col_widths_json: str = "",
+    col_widths: Optional[List[float]] = None,
     row_height: float = 0.36,
     font_size: float = 12,
     header_bg: str = "051C2C",
@@ -562,16 +557,45 @@ def pptx_add_table(
     border_color: str = "D0D0D0",
     no_vertical_borders: bool = True,
 ) -> str:
-    """Add a professionally formatted table. rows_json: JSON 2D array e.g. '[["A","B"],["1","2"]]'. First row = header. col_widths_json: JSON array of fractions e.g. '[0.5, 0.5]'."""
+    """Add a professionally formatted table.
+
+    ``rows``: 2D list, e.g. ``[["Name","Score"],["Alice","95"]]``. First row = header.
+    ``col_widths``: optional list of fractions, e.g. ``[0.5, 0.5]``.
+
+    v0.3.0 (#97): ``rows_json`` / ``col_widths_json`` string params were
+    removed. Pass native Python lists directly.
+    """
     try:
-        rows = json.loads(rows_json)
-        col_widths = json.loads(col_widths_json) if col_widths_json else None
-        return _success(add_table(
+        if rows is None:
+            return _error(
+                "INVALID_PARAMETER",
+                "rows is required (list[list]).",
+                parameter="rows",
+                hint="Pass a 2D list, e.g. [[\"H1\",\"H2\"],[\"a\",\"b\"]].",
+                issue=97,
+            )
+        if not isinstance(rows, list):
+            return _error(
+                "INVALID_PARAMETER",
+                "rows must be a list of lists.",
+                parameter="rows",
+                hint="Pass a native 2D list (list[list[Any]]).",
+                issue=97,
+            )
+        if col_widths is not None and not isinstance(col_widths, list):
+            return _error(
+                "INVALID_PARAMETER",
+                "col_widths must be a list of floats or None.",
+                parameter="col_widths",
+                hint="Pass a native list, e.g. [0.5, 0.5].",
+                issue=97,
+            )
+        return _success({"message": add_table(
             file_path, slide_index, rows, left, top, width,
             col_widths, row_height, font_size,
             header_bg, header_fg, alt_row_bg, border_color,
             0.5, no_vertical_borders,
-        ))
+        )})
     except Exception as e:
         return _err(e)
 
@@ -592,10 +616,10 @@ def pptx_edit_table_cell(
 ) -> str:
     """Edit a single table cell's text and formatting."""
     try:
-        return _success(edit_table_cell(
+        return _success({"message": edit_table_cell(
             file_path, slide_index, shape_index, row, col,
             text, font_size, font_color, bold, bg_color, alignment,
-        ))
+        )})
     except Exception as e:
         return _err(e)
 
@@ -605,12 +629,23 @@ def pptx_edit_table_cells(
     file_path: str,
     slide_index: int,
     shape_index: int,
-    edits_json: str,
+    edits: List[Dict[str, Any]],
 ) -> str:
-    """Batch edit multiple table cells. edits_json: JSON array of objects e.g. '[{"row":0,"col":1,"text":"new"}]'. Each: {row, col, text?, font_size?, font_color?, bold?, bg_color?}."""
+    """Batch edit multiple table cells.
+
+    ``edits``: list of dicts, each ``{row, col, text?, font_size?, font_color?,
+    bold?, bg_color?}``. v0.3.0 (#97): was ``edits_json: str``.
+    """
     try:
-        edits = json.loads(edits_json)
-        return _success(edit_table_cells(file_path, slide_index, shape_index, edits))
+        if not isinstance(edits, list):
+            return _error(
+                "INVALID_PARAMETER",
+                "edits must be a list of dicts.",
+                parameter="edits",
+                hint="Pass a native list, e.g. [{\"row\":0,\"col\":1,\"text\":\"new\"}].",
+                issue=97,
+            )
+        return _success({"message": edit_table_cells(file_path, slide_index, shape_index, edits)})
     except Exception as e:
         return _err(e)
 
@@ -628,10 +663,10 @@ def pptx_format_table(
 ) -> str:
     """Apply bulk formatting to an entire table (font, header colors, alternating rows)."""
     try:
-        return _success(format_table(
+        return _success({"message": format_table(
             file_path, slide_index, shape_index,
             font_name, font_size, header_bg, header_fg, alt_row_bg,
-        ))
+        )})
     except Exception as e:
         return _err(e)
 
@@ -675,12 +710,26 @@ def pptx_add_section_divider(
 def pptx_add_kpi_row(
     file_path: str,
     slide_index: int,
-    kpis_json: str,
+    kpis: List[Dict[str, Any]],
     y: float,
 ) -> str:
-    """Add a row of KPI callout boxes. kpis_json: JSON array e.g. '[{"value":"107.8M","label":"Revenue"}]'. y = vertical position in inches. Auto-renders a preview PNG ONLY when PPTX_MCP_AUTO_RENDER=1."""
+    """Add a row of KPI callout boxes.
+
+    ``kpis``: list of dicts, e.g. ``[{"value":"107.8M","label":"Revenue"}]``.
+    ``y``: vertical position in inches.
+    v0.3.0 (#97): was ``kpis_json: str``.
+    Auto-renders a preview PNG ONLY when PPTX_MCP_AUTO_RENDER=1.
+    """
     try:
-        result = add_kpi_row(file_path, slide_index, kpis_json, y)
+        if not isinstance(kpis, list):
+            return _error(
+                "INVALID_PARAMETER",
+                "kpis must be a list of dicts.",
+                parameter="kpis",
+                hint="Pass a native list, e.g. [{\"value\":\"107.8M\",\"label\":\"Revenue\"}].",
+                issue=97,
+            )
+        result = add_kpi_row(file_path, slide_index, kpis, y)
         render_info = _auto_render(file_path, slide_index)
         return _success_with_render(result, render_info)
     except Exception as e:
@@ -691,15 +740,28 @@ def pptx_add_kpi_row(
 def pptx_add_bullet_block(
     file_path: str,
     slide_index: int,
-    items_json: str,
+    bullets: List[str],
     left: float,
     top: float,
     width: float,
     height: float,
 ) -> str:
-    """Add a bulleted text block with multiple items. items_json: JSON array of strings e.g. '["Item 1","Item 2"]'. Auto-renders a preview PNG ONLY when PPTX_MCP_AUTO_RENDER=1."""
+    """Add a bulleted text block with multiple items.
+
+    ``bullets``: list of strings, e.g. ``["Item 1","Item 2"]``.
+    v0.3.0 (#97): was ``items_json: str``.
+    Auto-renders a preview PNG ONLY when PPTX_MCP_AUTO_RENDER=1.
+    """
     try:
-        result = add_bullet_block(file_path, slide_index, items_json, left, top, width, height)
+        if not isinstance(bullets, list):
+            return _error(
+                "INVALID_PARAMETER",
+                "bullets must be a list of strings.",
+                parameter="bullets",
+                hint="Pass a native list, e.g. [\"Item 1\",\"Item 2\"].",
+                issue=97,
+            )
+        result = add_bullet_block(file_path, slide_index, bullets, left, top, width, height)
         render_info = _auto_render(file_path, slide_index)
         return _success_with_render(result, render_info)
     except Exception as e:
@@ -710,7 +772,7 @@ def pptx_add_bullet_block(
 def pptx_add_responsive_card_row(
     file_path: str,
     slide_index: int,
-    cards_json: str,
+    cards: List[Dict[str, Any]],
     left: float,
     top: float,
     width: float,
@@ -721,26 +783,39 @@ def pptx_add_responsive_card_row(
 ) -> str:
     """Add a row of variable-height cards that auto-size to content and align to the max content height.
 
-    cards_json: JSON array of card dicts. Each card supports keys: title, body, label,
+    ``cards``: list of card dicts. Each card supports keys: title, body, label,
     accent_color (hex, "" disables bar), fill_color, title_size_pt, body_size_pt,
     title_color, body_color, label_size_pt, label_color, padding.
+    v0.3.0 (#97): was ``cards_json: str``.
 
     height_mode:
       - "content": each card uses its own content height (heights may differ).
       - "max":     all cards take the max individual content height (bottoms align).
       - "fill":    all cards fill max_height (short content is centered vertically).
 
-    Returns a JSON object: {"cards": [{"left","top","width","height"}, ...], "consumed_height": float}.
+    Returns a dict: {"cards": [{"left","top","width","height"}, ...], "consumed_height": float}.
     Auto-renders a preview PNG ONLY when PPTX_MCP_AUTO_RENDER=1.
     """
     try:
-        card_dicts = json.loads(cards_json) if isinstance(cards_json, str) else cards_json
+        if not isinstance(cards, list):
+            return _error(
+                "INVALID_PARAMETER",
+                "cards must be a list of dicts.",
+                parameter="cards",
+                hint="Pass a native list, e.g. [{\"title\":\"A\",\"body\":\"...\"}].",
+                issue=97,
+            )
         # #43: CardSpec dataclass は未知キーを TypeError として弾くが、
         # MCP ツール層で明示的に ``INVALID_PARAMETER`` として報告し、
         # どのカード・どのキーが原因かを LLM エージェントが再試行時に
         # 解釈できる形式で返す。
         _card_known_keys = {f.name for f in fields(CardSpec)}
-        for i, spec in enumerate(card_dicts):
+        for i, spec in enumerate(cards):
+            if not isinstance(spec, dict):
+                raise EngineError(
+                    ErrorCode.INVALID_PARAMETER,
+                    f"card[{i}]: must be a dict, got {type(spec).__name__}.",
+                )
             unknown = set(spec.keys()) - _card_known_keys
             if unknown:
                 raise EngineError(
@@ -750,13 +825,13 @@ def pptx_add_responsive_card_row(
                         f"known keys: {sorted(_card_known_keys)}."
                     ),
                 )
-        cards = [CardSpec(**d) for d in card_dicts]
+        card_objs = [CardSpec(**d) for d in cards]
         prs = open_pptx(file_path)
         slide = _get_slide(prs, slide_index)
 
         placements, consumed = add_responsive_card_row(
             slide,
-            cards,
+            card_objs,
             left=left, top=top, width=width, max_height=max_height,
             gap=gap,
             height_mode=height_mode,  # type: ignore[arg-type]
@@ -765,7 +840,7 @@ def pptx_add_responsive_card_row(
 
         # CardPlacement を JSON 化可能な dict に変換する (save 前に行う)。
         # ここで serialize に失敗しても disk 上のファイルは変更されない (#34)。
-        result = {
+        result: Dict[str, Any] = {
             "cards": [
                 {
                     "left": p.left,
@@ -783,7 +858,12 @@ def pptx_add_responsive_card_row(
         save_pptx(prs, file_path)
 
         render_info = _auto_render(file_path, slide_index)
-        return _success_with_render(result, render_info)
+        # result は既に richer dict — auto-render の結果を同じ dict にマージ。
+        if render_info.get("rendered"):
+            result["preview_path"] = render_info.get("preview_path")
+        elif render_info.get("reason") != "disabled":
+            result["render_warning"] = render_info
+        return _success(result)
     except Exception as e:
         return _err(e)
 
@@ -793,22 +873,27 @@ def pptx_add_responsive_card_row(
 @mcp.tool()
 def pptx_build_slide(
     file_path: str,
-    spec_json: str,
+    spec: Dict[str, Any],
 ) -> str:
-    """Build an entire slide in ONE call from a JSON spec. Single file open/save. Much faster than individual tool calls. Auto-renders a preview PNG ONLY when PPTX_MCP_AUTO_RENDER=1.
+    """Build an entire slide in ONE call from a spec dict. Single file open/save.
+    Much faster than individual tool calls. Auto-renders a preview PNG ONLY when
+    PPTX_MCP_AUTO_RENDER=1.
 
-    spec_json format:
+    v0.3.0 (#97): was ``spec_json: str``; now accepts a native dict.
+
+    spec format:
+    ```python
     {
         "layout": "content" | "section_divider" | "blank",
         "title": "Action title",
-        "background": "051C2C",  (optional)
-        "source": "Source: ...", (optional)
-        "page_number": 1,       (optional)
+        "background": "051C2C",  # optional
+        "source": "Source: ...", # optional
+        "page_number": 1,        # optional
         "elements": [
             {"type": "textbox", "left": 0.9, "top": 1.2, "width": 11.5, "height": 0.3,
-             "text": "...", "font_size": 14, "font_color": "2251FF", "bold": true},
+             "text": "...", "font_size": 14, "font_color": "2251FF", "bold": True},
             {"type": "shape", "shape_type": "rectangle", "left": 0.9, "top": 2.0,
-             "width": 5.0, "height": 1.0, "fill_color": "F5F5F5", "no_line": true},
+             "width": 5.0, "height": 1.0, "fill_color": "F5F5F5", "no_line": True},
             {"type": "table", "rows": [["H1","H2"],["v1","v2"]], "left": 0.9,
              "top": 3.0, "width": 11.5, "col_widths": [0.5, 0.5]},
             {"type": "kpi_row", "kpis": [{"value":"100","label":"Metric"}], "y": 1.2},
@@ -817,9 +902,19 @@ def pptx_build_slide(
             {"type": "image", "image_path": "/path/img.png", "left": 1.0, "top": 1.0, "width": 3.0}
         ]
     }
-    LAYOUT GUIDE: Body area is 1.15" to 6.65" (5.5" usable). Distribute elements evenly."""
+    ```
+    LAYOUT GUIDE: Body area is 1.15\" to 6.65\" (5.5\" usable). Distribute elements evenly.
+    """
     try:
-        result = build_slide(file_path, spec_json)
+        if not isinstance(spec, dict):
+            return _error(
+                "INVALID_PARAMETER",
+                "spec must be a dict.",
+                parameter="spec",
+                hint="Pass a native dict; e.g. {\"layout\":\"content\",\"title\":\"...\"}.",
+                issue=97,
+            )
+        result = build_slide(file_path, spec)
         idx_str = result.split("[")[1].split("]")[0]
         render_info = _auto_render(file_path, int(idx_str))
         return _success_with_render(result, render_info)
@@ -830,14 +925,29 @@ def pptx_build_slide(
 @mcp.tool()
 def pptx_build_deck(
     file_path: str,
-    slides_json: str,
+    slides: List[Dict[str, Any]],
 ) -> str:
-    """Build an ENTIRE DECK in ONE call from a JSON array of slide specs. Single file open/save for all slides. Use this for generating complete presentations efficiently. Auto-renders a preview PNG of the last slide ONLY when PPTX_MCP_AUTO_RENDER=1.
+    """Build an ENTIRE DECK in ONE call from a list of slide specs. Single file
+    open/save for all slides. Use this for generating complete presentations
+    efficiently. Auto-renders a preview PNG of the last slide ONLY when
+    PPTX_MCP_AUTO_RENDER=1.
 
-    slides_json: JSON array where each element is a slide spec (same format as pptx_build_slide).
-    Example: '[{"layout":"content","title":"Slide 1","elements":[...]},{"layout":"section_divider","title":"Section"}]'"""
+    v0.3.0 (#97): was ``slides_json: str``; now accepts a native list.
+
+    ``slides``: list where each element is a slide spec (same format as pptx_build_slide).
+    Example: ``[{"layout":"content","title":"Slide 1","elements":[...]},
+               {"layout":"section_divider","title":"Section"}]``.
+    """
     try:
-        result = build_deck(file_path, slides_json)
+        if not isinstance(slides, list):
+            return _error(
+                "INVALID_PARAMETER",
+                "slides must be a list of dicts.",
+                parameter="slides",
+                hint="Pass a native list; e.g. [{\"layout\":\"content\",\"title\":\"...\"}].",
+                issue=97,
+            )
+        result = build_deck(file_path, slides)
         render_info = _auto_render(file_path, -1)
         return _success_with_render(result, render_info)
     except Exception as e:
@@ -932,10 +1042,10 @@ def pptx_list_icons(
     Common icons: briefcase, chart, person, globe, airplane, laptop, phone, car, building, arrow,
     calendar, clock, document, email, gear, handshake, key, lock, money, star, target, trophy, user."""
     try:
-        return _success(list_icons_formatted(
+        return _success({"message": list_icons_formatted(
             category=category or None,
             search=search or None,
-        ))
+        )})
     except Exception as e:
         return _err(e)
 
@@ -971,12 +1081,14 @@ def pptx_add_icon(
 def pptx_add_chart(
     file_path: str,
     slide_index: int,
-    chart_json: str,
+    chart: Dict[str, Any],
 ) -> str:
-    """Add a professional chart to a slide. chart_json is a JSON object with:
+    """Add a professional chart to a slide.
+
+    ``chart``: dict spec. v0.3.0 (#97): was ``chart_json: str``.
 
     Required: chart_type (column/stacked_column/bar/stacked_bar/line/pie/area/doughnut/radar),
-    categories (array of labels), series (array of {name, values, color?}).
+    categories (list of labels), series (list of {name, values, color?}).
 
     Optional: title, legend_position (bottom/top/right/left/null), data_labels_show (bool),
     data_labels_position, data_labels_number_format, axis_value_title, axis_value_min/max,
@@ -984,18 +1096,20 @@ def pptx_add_chart(
 
     Auto-renders a preview PNG ONLY when PPTX_MCP_AUTO_RENDER=1.
 
-    Example: '{"chart_type":"stacked_column","categories":["Q1","Q2"],"series":[{"name":"Rev","values":[10,20],"color":"2251FF"}],"data_labels_show":true}'"""
+    Example: ``{"chart_type":"stacked_column","categories":["Q1","Q2"],
+    "series":[{"name":"Rev","values":[10,20],"color":"2251FF"}],
+    "data_labels_show":True}``.
+    """
     try:
-        try:
-            spec = json.loads(chart_json) if isinstance(chart_json, str) else chart_json
-        except json.JSONDecodeError as e:
+        if not isinstance(chart, dict):
             return _error(
                 "INVALID_PARAMETER",
-                f"Invalid JSON in chart_json: {e}",
-                parameter="chart_json",
-                hint="chart_json must be a JSON-stringified object.",
+                "chart must be a dict.",
+                parameter="chart",
+                hint="Pass a native dict, e.g. {\"chart_type\":\"column\",\"categories\":[...],\"series\":[...]}.",
+                issue=97,
             )
-        result = add_chart(file_path, slide_index, spec)
+        result = add_chart(file_path, slide_index, chart)
         render_info = _auto_render(file_path, slide_index)
         return _success_with_render(result, render_info)
     except Exception as e:
@@ -1012,7 +1126,7 @@ def pptx_render_slide(
 ) -> str:
     """Render PPTX slide(s) to PNG image(s) for visual verification. Returns path(s) to PNG files that can be viewed with the Read tool. slide_index: 0-based (-1 = all slides). dpi: 150 for review, 300 for print."""
     try:
-        return _success(render_slide(file_path, slide_index, dpi=dpi))
+        return _success({"message": render_slide(file_path, slide_index, dpi=dpi)})
     except Exception as e:
         return _err(e)
 
@@ -1067,13 +1181,12 @@ def pptx_check_layout(
     """Validate slide layouts: overlaps, out-of-bounds, text overflow,
     unreadable font, title/divider collision, inconsistent gaps.
 
-    v0.2.0+: tool 戻り値は ``{"ok": true, "result": <payload>}`` で包まれる。
-    ``result`` 内は従来どおり:
+    v0.3.0+ (#99): detailed response is a flat dict — no double-encoded JSON.
 
-    - ``detailed=False`` (既定): legacy human-readable string
-      (``"All slides clean …"`` または ``"Found N layout issues:\\n…"``)。
-      #33 で導入された文字列フォーマットはそのまま維持される。
-    - ``detailed=True``: JSON 文字列 (中身は以下のスキーマ)。
+    - ``detailed=False`` (既定): ``result = {"message": "All slides clean …" |
+      "Found N layout issues:\\n…"}`` (legacy 文字列を ``message`` に wrap)。
+    - ``detailed=True``: ``result = {"slides": [...], "summary": {...}}``。
+      以前の ``json.dumps`` による inner-string encoding は撤廃された (#99)。
 
     ``detailed=True`` schema::
 
@@ -1097,8 +1210,9 @@ def pptx_check_layout(
             overflow_tolerance_pct=overflow_tolerance_pct,
         )
         if detailed:
-            return _success(json.dumps(result, ensure_ascii=False, indent=2))
-        return _success(_format_check_layout_summary(result))
+            # #99: pass the dict directly — single json.loads decodes the envelope.
+            return _success(result)
+        return _success({"message": _format_check_layout_summary(result)})
     except Exception as e:
         return _err(e)
 

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -436,11 +436,11 @@ def test_mcp_tool_rejects_unknown_height_mode(pptx_file):
     は既存 invalid-param エラー形式で弾かれる (#26 Problem B、境界側)."""
     from pptx_mcp_server.server import pptx_add_responsive_card_row
 
-    cards_json = json.dumps([{"title": "A", "body": "a"}])
+    cards = [{"title": "A", "body": "a"}]
     out = pptx_add_responsive_card_row(
         file_path=pptx_file,
         slide_index=0,
-        cards_json=cards_json,
+        cards=cards,
         left=0.5,
         top=0.5,
         width=10.0,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,9 +4,16 @@ Integration tests for MCP server tool functions.
 These tests call the tool functions directly (they are regular Python functions
 wrapped by the MCP decorator). All file-based operations use tmp_path.
 
-v0.2.0 response contract (issue #88):
-    - Success: json.dumps({"ok": true, "result": <legacy payload>})
+v0.3.0 response contract (issues #88, #98, #99):
+    - Success: json.dumps({"ok": true, "result": <dict>})
+      — ``result`` is ALWAYS a dict. Human-readable status messages are under
+        the ``message`` key (``result["message"]``).
     - Error:   json.dumps({"ok": false, "error": {"code", "message", ...}})
+
+v0.3.0 structured-params contract (issue #97):
+    - ``*_json: str`` parameters were removed. Tests pass native Python
+      structures (list / dict) to MCP tools.
+
 Tests unwrap via ``_unwrap_ok`` / ``_unwrap_err`` helpers below.
 """
 
@@ -49,20 +56,31 @@ from pptx_mcp_server.server import (
     pptx_check_layout,
     pptx_add_flex_container,
     pptx_add_responsive_card_row,
+    pptx_build_slide,
+    pptx_build_deck,
+    pptx_add_chart,
     _format_check_layout_summary,
     INSTRUCTIONS,
 )
 
 
-# ── Response-shape helpers (v0.2.0, issue #88) ──────────────────────────
+# ── Response-shape helpers (v0.3.0, issues #88, #98) ───────────────────
 
 def _unwrap_ok(payload: str):
-    """Parse a tool response and assert it is a success; return the result."""
+    """Parse a tool response and assert it is a success; return the result dict.
+
+    v0.3.0 (#98): ``result`` は **常に dict**。caller は ``result["message"]``
+    等のキーに明示的にアクセスする。
+    """
     parsed = json.loads(payload)
     assert isinstance(parsed, dict), f"response must be a JSON object, got {type(parsed)}"
     assert parsed.get("ok") is True, f"expected ok=true, got {parsed!r}"
     assert "result" in parsed, f"success payload must include 'result': {parsed!r}"
-    return parsed["result"]
+    result = parsed["result"]
+    assert isinstance(result, dict), (
+        f"v0.3.0 contract: result must be a dict, got {type(result).__name__}: {result!r}"
+    )
+    return result
 
 
 def _unwrap_err(payload: str) -> dict:
@@ -130,8 +148,8 @@ class TestCreatePptx:
         path = str(tmp_path / "new.pptx")
         result = pptx_create(path)
         assert os.path.exists(path)
-        msg = _unwrap_ok(result)
-        assert "Created" in msg
+        payload = _unwrap_ok(result)
+        assert "Created" in payload["message"]
 
 
 class TestFileBased:
@@ -139,22 +157,22 @@ class TestFileBased:
 
     def test_add_slide(self, deck):
         result = pptx_add_slide(deck)
-        assert "Added slide" in _unwrap_ok(result)
+        assert "Added slide" in _unwrap_ok(result)["message"]
         prs = open_pptx(deck)
         assert len(prs.slides) == 2
 
     def test_add_textbox(self, deck):
         result = pptx_add_textbox(deck, 0, 1, 1, 4, 0.5, text="Hello")
-        assert "Added textbox" in _unwrap_ok(result)
+        assert "Added textbox" in _unwrap_ok(result)["message"]
         prs = open_pptx(deck)
         slide = prs.slides[0]
         texts = [s.text_frame.text for s in slide.shapes if s.has_text_frame]
         assert "Hello" in texts
 
     def test_add_table(self, deck):
-        rows_json = json.dumps([["Name", "Score"], ["Alice", "95"]])
-        result = pptx_add_table(deck, 0, rows_json, 1, 1, 5)
-        assert "Added table" in _unwrap_ok(result)
+        rows = [["Name", "Score"], ["Alice", "95"]]
+        result = pptx_add_table(deck, 0, rows, 1, 1, 5)
+        assert "Added table" in _unwrap_ok(result)["message"]
         prs = open_pptx(deck)
         slide = prs.slides[0]
         table_shapes = [s for s in slide.shapes if s.has_table]
@@ -166,16 +184,15 @@ class TestCompositeTools:
 
     def test_add_content_slide(self, deck):
         result = pptx_add_content_slide(deck, "Revenue Analysis")
-        # auto-render disabled by default → result is plain string payload
         payload = _unwrap_ok(result)
-        assert "Added content slide" in payload
+        assert "Added content slide" in payload["message"]
         prs = open_pptx(deck)
         assert len(prs.slides) == 2  # original + content
 
     def test_add_section_divider(self, deck):
         result = pptx_add_section_divider(deck, "Q1 Results", subtitle="FY2024")
         payload = _unwrap_ok(result)
-        assert "Added section divider" in payload
+        assert "Added section divider" in payload["message"]
         prs = open_pptx(deck)
         assert len(prs.slides) == 2
 
@@ -200,58 +217,140 @@ class TestErrorCases:
         assert err["code"] == "INVALID_PARAMETER"
 
 
-class TestJsonParsing:
-    """JSON-based tools must parse input correctly and reject invalid JSON."""
+# ── Issue #97: structured params (native list/dict replace *_json: str) ──
 
-    def test_add_table_with_valid_json(self, deck):
-        rows = json.dumps([["X", "Y"], ["1", "2"]])
+class TestStructuredParams:
+    """Structured-param tools accept native Python values and reject bad types."""
+
+    def test_add_table_with_native_rows(self, deck):
+        rows = [["X", "Y"], ["1", "2"]]
         result = pptx_add_table(deck, 0, rows, 1, 1, 5)
-        assert "Added table" in _unwrap_ok(result)
+        assert "Added table" in _unwrap_ok(result)["message"]
 
-    def test_add_kpi_row_with_valid_json(self, deck):
-        kpis = json.dumps([{"value": "99", "label": "Score"}])
+    def test_add_table_rows_none_rejected(self, deck):
+        result = pptx_add_table(deck, 0, None, 1, 1, 5)  # type: ignore[arg-type]
+        err = _unwrap_err(result)
+        assert err["code"] == "INVALID_PARAMETER"
+        assert err["parameter"] == "rows"
+
+    def test_add_table_rows_wrong_type_rejected(self, deck):
+        result = pptx_add_table(deck, 0, "not a list", 1, 1, 5)  # type: ignore[arg-type]
+        err = _unwrap_err(result)
+        assert err["code"] == "INVALID_PARAMETER"
+        assert err["parameter"] == "rows"
+
+    def test_add_table_col_widths_wrong_type_rejected(self, deck):
+        result = pptx_add_table(deck, 0, [["a", "b"]], 1, 1, 5, col_widths="bad")  # type: ignore[arg-type]
+        err = _unwrap_err(result)
+        assert err["code"] == "INVALID_PARAMETER"
+        assert err["parameter"] == "col_widths"
+
+    def test_add_kpi_row_with_native_list(self, deck):
+        kpis = [{"value": "99", "label": "Score"}]
         result = pptx_add_kpi_row(deck, 0, kpis, 2.0)
         payload = _unwrap_ok(result)
-        # payload may be either the plain legacy string (render disabled) or
-        # a dict with {"value": ..., "render_warning"/"preview_path"} when enabled.
-        if isinstance(payload, dict):
-            payload = payload.get("value", "")
-        assert "Added 1 KPI" in payload
+        assert "Added 1 KPI" in payload["message"]
 
-    def test_invalid_json_returns_error(self, deck):
-        result = pptx_add_table(deck, 0, "not valid json", 1, 1, 5)
+    def test_add_kpi_row_wrong_type_rejected(self, deck):
+        result = pptx_add_kpi_row(deck, 0, "not a list", 2.0)  # type: ignore[arg-type]
         err = _unwrap_err(result)
-        # json.loads on gibberish raises JSONDecodeError → INTERNAL_ERROR wrap
-        assert err["code"] in {"INVALID_PARAMETER", "INTERNAL_ERROR"}
+        assert err["code"] == "INVALID_PARAMETER"
+        assert err["parameter"] == "kpis"
 
-    def test_add_bullet_block_with_valid_json(self, deck):
-        items = json.dumps(["Point A", "Point B"])
-        result = pptx_add_bullet_block(deck, 0, items, 1, 2, 5, 3)
+    def test_add_bullet_block_with_native_list(self, deck):
+        bullets = ["Point A", "Point B"]
+        result = pptx_add_bullet_block(deck, 0, bullets, 1, 2, 5, 3)
         payload = _unwrap_ok(result)
-        if isinstance(payload, dict):
-            payload = payload.get("value", "")
-        assert "Added bullet block" in payload
+        assert "Added bullet block" in payload["message"]
+
+    def test_add_bullet_block_wrong_type_rejected(self, deck):
+        result = pptx_add_bullet_block(deck, 0, "not a list", 1, 2, 5, 3)  # type: ignore[arg-type]
+        err = _unwrap_err(result)
+        assert err["code"] == "INVALID_PARAMETER"
+        assert err["parameter"] == "bullets"
+
+    def test_edit_table_cells_with_native_list(self, deck):
+        # First add a table so shape_index=0 is a table.
+        pptx_add_table(deck, 0, [["H1", "H2"], ["v1", "v2"]], 1, 1, 5)
+        prs = open_pptx(deck)
+        slide = prs.slides[0]
+        shape_idx = next(i for i, s in enumerate(slide.shapes) if s.has_table)
+        edits = [{"row": 0, "col": 1, "text": "new"}]
+        result = pptx_edit_table_cells(deck, 0, shape_idx, edits)
+        _unwrap_ok(result)
+
+    def test_edit_table_cells_wrong_type_rejected(self, deck):
+        result = pptx_edit_table_cells(deck, 0, 0, "bad")  # type: ignore[arg-type]
+        err = _unwrap_err(result)
+        assert err["code"] == "INVALID_PARAMETER"
+        assert err["parameter"] == "edits"
+
+    def test_build_slide_with_native_dict(self, deck):
+        spec = {"layout": "content", "title": "Hello", "elements": []}
+        result = pptx_build_slide(deck, spec)
+        payload = _unwrap_ok(result)
+        assert "Built slide" in payload["message"]
+
+    def test_build_slide_wrong_type_rejected(self, deck):
+        result = pptx_build_slide(deck, "not a dict")  # type: ignore[arg-type]
+        err = _unwrap_err(result)
+        assert err["code"] == "INVALID_PARAMETER"
+        assert err["parameter"] == "spec"
+
+    def test_build_deck_with_native_list(self, deck):
+        slides = [
+            {"layout": "content", "title": "S1", "elements": []},
+            {"layout": "content", "title": "S2", "elements": []},
+        ]
+        result = pptx_build_deck(deck, slides)
+        payload = _unwrap_ok(result)
+        assert "Built 2 slides" in payload["message"]
+
+    def test_build_deck_wrong_type_rejected(self, deck):
+        result = pptx_build_deck(deck, "not a list")  # type: ignore[arg-type]
+        err = _unwrap_err(result)
+        assert err["code"] == "INVALID_PARAMETER"
+        assert err["parameter"] == "slides"
+
+    def test_add_chart_with_native_dict(self, deck):
+        chart = {
+            "chart_type": "column",
+            "categories": ["A", "B"],
+            "series": [{"name": "S", "values": [1, 2]}],
+            "left": 1.0, "top": 1.0, "width": 5.0, "height": 3.0,
+        }
+        result = pptx_add_chart(deck, 0, chart)
+        _unwrap_ok(result)
+
+    def test_add_chart_wrong_type_rejected(self, deck):
+        result = pptx_add_chart(deck, 0, "not a dict")  # type: ignore[arg-type]
+        err = _unwrap_err(result)
+        assert err["code"] == "INVALID_PARAMETER"
+        assert err["parameter"] == "chart"
 
 
-# ── Issue #33: pptx_check_layout back-compat ────────────────────────
+# ── Issue #33 / #98: pptx_check_layout back-compat (wrapped in message) ───
 
 class TestCheckLayoutBackCompat:
-    """``pptx_check_layout`` wraps the legacy string in the new ``result`` field.
+    """``pptx_check_layout`` wraps the legacy string in result.message.
 
-    Issue #33 の legacy 文字列は ``result`` フィールドに入ったまま保持される。
-    v0.2.0 breaking: caller は ``_unwrap_ok`` で result を取り出す必要がある。
+    Issue #33 の legacy 文字列は ``result["message"]`` に入る (#98)。
+    ``detailed=True`` は ``result["slides"]`` / ``result["summary"]`` を
+    そのまま返し, 以前の double-encoded JSON 文字列 (#99) は撤廃された。
     """
 
-    def test_clean_deck_returns_legacy_string(self, deck):
+    def test_clean_deck_returns_legacy_string_in_message(self, deck):
         result = pptx_check_layout(deck)
         payload = _unwrap_ok(result)
-        assert isinstance(payload, str)
-        assert payload.startswith("All slides clean") or payload.startswith("Found")
+        msg = payload["message"]
+        assert isinstance(msg, str)
+        assert msg.startswith("All slides clean") or msg.startswith("Found")
 
     def test_clean_deck_wording_exact(self, deck):
         payload = _unwrap_ok(pptx_check_layout(deck))
-        if payload.startswith("All slides clean"):
-            assert payload == (
+        msg = payload["message"]
+        if msg.startswith("All slides clean"):
+            assert msg == (
                 "All slides clean — no overlaps, out-of-bounds, text overflow, "
                 "or readability issues detected."
             )
@@ -260,19 +359,27 @@ class TestCheckLayoutBackCompat:
         pptx_add_shape(deck, 0, "rectangle", 1.0, 1.0, 3.0, 2.0, fill_color="2251FF")
         pptx_add_shape(deck, 0, "rectangle", 2.0, 1.5, 3.0, 2.0, fill_color="FF0000")
         payload = _unwrap_ok(pptx_check_layout(deck))
-        assert isinstance(payload, str)
-        assert payload.startswith("Found")
-        assert "overlap" in payload.lower()
+        msg = payload["message"]
+        assert isinstance(msg, str)
+        assert msg.startswith("Found")
+        assert "overlap" in msg.lower()
 
-    def test_detailed_returns_json(self, deck):
+    def test_detailed_returns_flat_dict_no_inner_string(self, deck):
+        """#99: detailed=True must return the dict inline — single json.loads."""
         payload = _unwrap_ok(pptx_check_layout(deck, detailed=True))
-        # payload is itself a JSON string (legacy behaviour of detailed=True)
-        assert isinstance(payload, str)
-        parsed = json.loads(payload)
-        assert "slides" in parsed
-        assert "summary" in parsed
-        assert isinstance(parsed["slides"], list)
-        assert set(parsed["summary"].keys()) >= {"errors", "warnings", "infos"}
+        # payload itself is a dict (not a JSON-encoded string needing re-decode).
+        assert "slides" in payload
+        assert "summary" in payload
+        assert isinstance(payload["slides"], list)
+        assert set(payload["summary"].keys()) >= {"errors", "warnings", "infos"}
+
+    def test_detailed_single_json_loads_suffices(self, deck):
+        """#99 regression: one json.loads on the envelope fully decodes the result."""
+        raw = pptx_check_layout(deck, detailed=True)
+        parsed = json.loads(raw)
+        # No second json.loads needed on parsed["result"].
+        assert isinstance(parsed["result"], dict)
+        assert "slides" in parsed["result"]
 
     def test_format_helper_clean(self):
         empty = {"slides": [], "summary": {"errors": 0, "warnings": 0, "infos": 0}}
@@ -338,11 +445,11 @@ class TestResponsiveCardRowSaveOrder:
 
         monkeypatch.setattr(server_mod, "add_responsive_card_row", fake_add_row)
 
-        cards_json = json.dumps([{"title": "A", "body": "a"}])
+        cards = [{"title": "A", "body": "a"}]
         result = server_mod.pptx_add_responsive_card_row(
             file_path=deck,
             slide_index=0,
-            cards_json=cards_json,
+            cards=cards,
             left=0.5, top=0.5, width=10.0, max_height=3.0,
         )
         err = _unwrap_err(result)
@@ -356,17 +463,15 @@ class TestResponsiveCardRowSaveOrder:
     def test_happy_path_saves_once_and_returns_placements(self, deck):
         from pptx_mcp_server.server import pptx_add_responsive_card_row
 
-        cards_json = json.dumps(
-            [{"title": "A", "body": "aa"}, {"title": "B", "body": "bb"}]
-        )
+        cards = [{"title": "A", "body": "aa"}, {"title": "B", "body": "bb"}]
         result = pptx_add_responsive_card_row(
             file_path=deck,
             slide_index=0,
-            cards_json=cards_json,
+            cards=cards,
             left=0.5, top=0.5, width=10.0, max_height=3.0,
         )
         payload = _unwrap_ok(result)
-        # render disabled by default → payload is the plain cards dict.
+        # render disabled by default → payload carries the cards dict directly.
         assert "cards" in payload
         assert len(payload["cards"]) == 2
         assert {"left", "top", "width", "height"} <= set(payload["cards"][0].keys())
@@ -375,51 +480,41 @@ class TestResponsiveCardRowSaveOrder:
         assert len(prs.slides) >= 1
 
 
-# ── Issue #35: flex_container items_json ───────────────────────────
+# ── Issue #97: flex_container native items (was items_json) ─────────
 
-class TestFlexContainerItemsJson:
-    """``pptx_add_flex_container`` が items_json (JSON 文字列) を受け取る."""
+class TestFlexContainerItems:
+    """``pptx_add_flex_container`` が ``items: list[dict]`` を受け取る (#97)."""
 
-    def test_items_json_string_works(self, deck):
-        items_json = json.dumps(
-            [{"sizing": "fixed", "size": 2.0, "type": "rectangle", "fill_color": "2251FF"}]
-        )
+    def test_native_list_works(self, deck):
+        items = [
+            {"sizing": "fixed", "size": 2.0, "type": "rectangle", "fill_color": "2251FF"}
+        ]
         result = pptx_add_flex_container(
             file_path=deck,
             slide_index=0,
-            items_json=items_json,
+            items=items,
             left=0.5, top=0.5, width=10.0, height=1.0,
         )
         payload = _unwrap_ok(result)
         assert "allocations" in payload
 
-    def test_raw_list_rejected(self, deck):
+    def test_non_list_rejected(self, deck):
         result = pptx_add_flex_container(
             file_path=deck,
             slide_index=0,
-            items_json=[{"sizing": "fixed", "size": 2.0, "type": "rectangle"}],  # type: ignore[arg-type]
+            items="not a list",  # type: ignore[arg-type]
             left=0.5, top=0.5, width=10.0, height=1.0,
         )
         err = _unwrap_err(result)
         assert err["code"] == "INVALID_PARAMETER"
-        assert err.get("parameter") == "items_json"
+        assert err.get("parameter") == "items"
 
-    def test_invalid_json_rejected(self, deck):
+    def test_dict_rejected(self, deck):
+        """Passing a dict where a list is expected → INVALID_PARAMETER."""
         result = pptx_add_flex_container(
             file_path=deck,
             slide_index=0,
-            items_json="not valid json",
-            left=0.5, top=0.5, width=10.0, height=1.0,
-        )
-        err = _unwrap_err(result)
-        assert err["code"] == "INVALID_PARAMETER"
-        assert err.get("parameter") == "items_json"
-
-    def test_json_decoded_object_rejected(self, deck):
-        result = pptx_add_flex_container(
-            file_path=deck,
-            slide_index=0,
-            items_json='{"not": "array"}',
+            items={"not": "array"},  # type: ignore[arg-type]
             left=0.5, top=0.5, width=10.0, height=1.0,
         )
         err = _unwrap_err(result)
@@ -432,11 +527,11 @@ class TestResponsiveCardRowStrictKeys:
     """``pptx_add_responsive_card_row`` が未知キーを弾く (#43)."""
 
     def test_unknown_key_rejected_with_index_and_name(self, deck):
-        cards_json = json.dumps([{"title": "t", "body": "b", "typo": "x"}])
+        cards = [{"title": "t", "body": "b", "typo": "x"}]
         result = pptx_add_responsive_card_row(
             file_path=deck,
             slide_index=0,
-            cards_json=cards_json,
+            cards=cards,
             left=0.5, top=0.5, width=10.0, max_height=3.0,
         )
         err = _unwrap_err(result)
@@ -445,16 +540,14 @@ class TestResponsiveCardRowStrictKeys:
         assert "card[0]" in err["message"]
 
     def test_unknown_key_index_points_to_bad_card(self, deck):
-        cards_json = json.dumps(
-            [
-                {"title": "ok", "body": "ok"},
-                {"title": "bad", "body": "b", "oops": 1},
-            ]
-        )
+        cards = [
+            {"title": "ok", "body": "ok"},
+            {"title": "bad", "body": "b", "oops": 1},
+        ]
         result = pptx_add_responsive_card_row(
             file_path=deck,
             slide_index=0,
-            cards_json=cards_json,
+            cards=cards,
             left=0.5, top=0.5, width=10.0, max_height=3.0,
         )
         err = _unwrap_err(result)
@@ -463,16 +556,14 @@ class TestResponsiveCardRowStrictKeys:
         assert "oops" in err["message"]
 
     def test_valid_cards_ok_regression(self, deck):
-        cards_json = json.dumps(
-            [
-                {"title": "A", "body": "aa", "accent_color": "2251FF"},
-                {"title": "B", "body": "bb", "padding": 0.25},
-            ]
-        )
+        cards = [
+            {"title": "A", "body": "aa", "accent_color": "2251FF"},
+            {"title": "B", "body": "bb", "padding": 0.25},
+        ]
         result = pptx_add_responsive_card_row(
             file_path=deck,
             slide_index=0,
-            cards_json=cards_json,
+            cards=cards,
             left=0.5, top=0.5, width=10.0, max_height=3.0,
         )
         payload = _unwrap_ok(result)
@@ -480,17 +571,41 @@ class TestResponsiveCardRowStrictKeys:
         assert len(payload["cards"]) == 2
 
 
-# ── Issue #88: structured response contract ────────────────────────
+# ── Issues #88, #98: structured response contract ──────────────────
 
 class TestStructuredResponseContract:
-    """All tool returns follow the v0.2.0 ``{ok, result|error}`` contract."""
+    """All tool returns follow the v0.3.0 ``{ok, result|error}`` contract.
 
-    def test_success_shape_has_ok_and_result(self, tmp_path):
+    v0.3.0 (#98): ``result`` is ALWAYS a dict — tools wrap legacy string
+    payloads under ``result["message"]``.
+    """
+
+    def test_success_shape_has_ok_and_result_dict(self, tmp_path):
         path = str(tmp_path / "s.pptx")
         response = pptx_create(path)
         parsed = json.loads(response)
-        assert parsed == {"ok": True, "result": parsed["result"]}
-        assert isinstance(parsed["result"], str)
+        assert parsed["ok"] is True
+        assert isinstance(parsed["result"], dict)
+        assert "message" in parsed["result"]
+        assert isinstance(parsed["result"]["message"], str)
+
+    def test_all_primitive_tools_return_dict_result(self, deck):
+        """Every success path returns result: dict (never raw string)."""
+        responses = [
+            pptx_create(deck.replace(".pptx", "-new.pptx")),
+            pptx_get_info(deck),
+            pptx_add_slide(deck),
+            pptx_add_textbox(deck, 0, 1, 1, 3, 0.5, text="hi"),
+            pptx_add_shape(deck, 0, "rectangle", 1, 1, 2, 2),
+            pptx_add_content_slide(deck, "Title"),
+            pptx_add_section_divider(deck, "Section"),
+        ]
+        for r in responses:
+            parsed = json.loads(r)
+            assert parsed["ok"] is True, f"expected ok=true, got {parsed!r}"
+            assert isinstance(parsed["result"], dict), (
+                f"v0.3.0 contract: result must be a dict, got {parsed!r}"
+            )
 
     def test_caller_can_discriminate_on_ok(self, deck, tmp_path):
         ok_response = pptx_get_info(deck)
@@ -508,20 +623,19 @@ class TestStructuredResponseContract:
         assert err["code"] == "SLIDE_NOT_FOUND"
 
     def test_error_can_include_parameter_and_hint(self, deck):
-        """flex_container raw-list rejection sets parameter + hint + issue."""
+        """flex_container non-list rejection sets parameter + hint + issue."""
         err = _unwrap_err(pptx_add_flex_container(
             file_path=deck,
             slide_index=0,
-            items_json=[],  # type: ignore[arg-type]
+            items="bad",  # type: ignore[arg-type]
             left=0.5, top=0.5, width=10.0, height=1.0,
         ))
-        assert err["parameter"] == "items_json"
+        assert err["parameter"] == "items"
         assert "hint" in err
-        assert err.get("issue") == 35
+        assert err.get("issue") == 97
 
     def test_all_error_paths_return_valid_json(self, tmp_path):
         """Every error path must round-trip through json.loads cleanly."""
-        # A handful of representative error sources.
         responses = [
             pptx_get_info(str(tmp_path / "x.pptx")),
             pptx_read_slide(str(tmp_path / "x.pptx"), 0),
@@ -534,13 +648,15 @@ class TestStructuredResponseContract:
             assert parsed["error"]["message"]
 
 
-# ── Issue #86: auto_render opt-in + timeout ────────────────────────
+# ── Issue #86 / #98: auto_render opt-in + timeout, dict-only result ────
 
 class TestAutoRenderOptIn:
     """Auto-render is OFF by default; opt-in via PPTX_MCP_AUTO_RENDER.
 
-    See issue #86. All tests install monkey-patched ``render_slide`` so no
-    real LibreOffice subprocess ever fires.
+    See issue #86. v0.3.0 (#98): render info is merged into the ``result`` dict
+    alongside ``message`` — no more ``{"value": ...}`` wrapper.
+    All tests install monkey-patched ``render_slide`` so no real
+    LibreOffice subprocess ever fires.
     """
 
     def test_default_does_not_invoke_renderer(self, deck, monkeypatch):
@@ -557,11 +673,13 @@ class TestAutoRenderOptIn:
         monkeypatch.setattr(server_mod, "render_slide", fake_render)
 
         result = server_mod.pptx_add_content_slide(deck, "Title")
-        _unwrap_ok(result)
+        payload = _unwrap_ok(result)
+        assert "preview_path" not in payload
+        assert "render_warning" not in payload
         assert called["count"] == 0, "renderer should not fire when auto-render disabled"
 
     def test_env_var_enables_renderer(self, deck, monkeypatch):
-        """With PPTX_MCP_AUTO_RENDER=1, renderer IS called."""
+        """With PPTX_MCP_AUTO_RENDER=1, renderer IS called and preview_path lives in result."""
         from pptx_mcp_server import server as server_mod
 
         monkeypatch.setenv("PPTX_MCP_AUTO_RENDER", "1")
@@ -576,10 +694,9 @@ class TestAutoRenderOptIn:
         result = server_mod.pptx_add_content_slide(deck, "Title")
         payload = _unwrap_ok(result)
         assert called["count"] == 1, "renderer should fire when auto-render enabled"
-        # result is wrapped as {"value": <legacy>, "preview_path": ...}
-        assert isinstance(payload, dict)
+        # v0.3.0 shape: {"message": ..., "preview_path": ...}
         assert payload["preview_path"] == "/tmp/fake.png"
-        assert "Added content slide" in payload["value"]
+        assert "Added content slide" in payload["message"]
 
     def test_env_var_various_truthy_values(self, monkeypatch):
         from pptx_mcp_server import server as server_mod
@@ -613,11 +730,10 @@ class TestAutoRenderOptIn:
         # Must return well before the 20s the renderer would take.
         assert elapsed < 5.0, f"timeout did not kick in: {elapsed:.1f}s"
         payload = _unwrap_ok(result)
-        assert isinstance(payload, dict)
         assert "render_warning" in payload
         assert payload["render_warning"]["reason"] == "timeout"
         # primary action still succeeded.
-        assert "Added content slide" in payload["value"]
+        assert "Added content slide" in payload["message"]
 
     def test_render_failure_does_not_fail_tool(self, deck, monkeypatch):
         """Renderer raising an exception → tool still returns ok=true."""
@@ -632,7 +748,6 @@ class TestAutoRenderOptIn:
 
         result = server_mod.pptx_add_content_slide(deck, "Title")
         payload = _unwrap_ok(result)  # primary action still succeeds
-        assert isinstance(payload, dict)
         assert "render_warning" in payload
         assert payload["render_warning"]["reason"] == "failed"
         assert "libreoffice exploded" in payload["render_warning"]["error"]
@@ -652,7 +767,7 @@ class TestAutoRenderOptIn:
 
         # invalid slide_index → add_kpi_row raises before _auto_render runs.
         result = server_mod.pptx_add_kpi_row(
-            deck, 999, json.dumps([{"value": "1", "label": "x"}]), 2.0
+            deck, 999, [{"value": "1", "label": "x"}], 2.0
         )
         _unwrap_err(result)
         assert called["count"] == 0, "renderer fired despite primary-action error"
@@ -672,6 +787,24 @@ class TestAutoRenderOptIn:
 
         monkeypatch.setenv("PPTX_MCP_RENDER_TIMEOUT", "2.5")
         assert server_mod._auto_render_timeout() == 2.5
+
+    def test_responsive_card_row_merges_render_info_into_result(self, deck, monkeypatch):
+        """#98: responsive_card_row's rich-dict result merges preview_path in-place."""
+        from pptx_mcp_server import server as server_mod
+
+        monkeypatch.setenv("PPTX_MCP_AUTO_RENDER", "1")
+        monkeypatch.setattr(server_mod, "render_slide", lambda *a, **kw: "/tmp/cr.png")
+
+        cards = [{"title": "A", "body": "a"}]
+        result = server_mod.pptx_add_responsive_card_row(
+            file_path=deck,
+            slide_index=0,
+            cards=cards,
+            left=0.5, top=0.5, width=10.0, max_height=3.0,
+        )
+        payload = _unwrap_ok(result)
+        assert "cards" in payload
+        assert payload["preview_path"] == "/tmp/cr.png"
 
 
 # ── Issue #90: INSTRUCTIONS trimmed of product policy ──────────────


### PR DESCRIPTION
## Summary

Close the four MCP tool-surface blockers flagged by OpenAI/Codex 5.4 as the
remaining obstacles to LOGO-READY status. **Breaking change → v0.3.0.**

- **#97** — Every `*_json: str` MCP tool parameter replaced with a native
  typed argument (`list[dict]`, `dict`, `list[list[Any]]`, `list[str]`).
  FastMCP generates JSON Schema from Python typing — agents send native
  objects, no client-side string-encoding layer, no server-side
  `json.loads()`.
- **#98** — `result` is now **always** a dict. Human-readable status strings
  live under `result["message"]`. Composite tools merge `preview_path` /
  `render_warning` onto the same dict instead of the old
  `{"value": ..., "preview_path": ...}` wrapper.
- **#99** — `pptx_check_layout(detailed=True)` returns the findings dict
  inline (no more `_success(json.dumps(...))` double-encode). Single
  `json.loads()` on the envelope fully decodes the result.
- **#100** — Zero raw `json.loads()` calls remain in tool bodies. FastMCP
  type-validation handles malformed input before the tool runs; remaining
  edge cases (e.g. `rows=None`) get explicit isinstance guards that emit
  structured `INVALID_PARAMETER` with `parameter`/`hint`/`issue`.

## API changes (breaking)

| Tool | Before | After |
|------|--------|-------|
| `pptx_add_flex_container` | `items_json: str` | `items: list[dict]` |
| `pptx_add_responsive_card_row` | `cards_json: str` | `cards: list[dict]` |
| `pptx_build_slide` | `spec_json: str` | `spec: dict` |
| `pptx_build_deck` | `slides_json: str` | `slides: list[dict]` |
| `pptx_add_chart` | `chart_json: str` | `chart: dict` |
| `pptx_add_kpi_row` | `kpis_json: str` | `kpis: list[dict]` |
| `pptx_add_table` | `rows_json: str`, `col_widths_json: str` | `rows: list[list[Any]]`, `col_widths: list[float] \| None` |
| `pptx_add_bullet_block` | `items_json: str` | `bullets: list[str]` |
| `pptx_edit_table_cells` | `edits_json: str` | `edits: list[dict]` |

## Response shape changes (breaking)

```python
# Before (v0.2.x)
{"ok": True, "result": "Added content slide [1]: ..."}
{"ok": True, "result": {"value": "Added ...", "preview_path": "/tmp/s.png"}}
{"ok": True, "result": "<double-encoded JSON string of findings>"}  # check_layout detailed

# After (v0.3.0)
{"ok": True, "result": {"message": "Added content slide [1]: ..."}}
{"ok": True, "result": {"message": "Added ...", "preview_path": "/tmp/s.png"}}
{"ok": True, "result": {"slides": [...], "summary": {...}}}  # check_layout detailed
```

## Scope

- `src/pptx_mcp_server/server.py` — rewrite
- `tests/test_server.py` — update existing tests + new coverage for #97/#98/#99/#100
- `tests/test_cards.py` — single keyword-arg rename (`cards_json` → `cards`)
- `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md` (new) — document the breaking changes
- `pyproject.toml` — `0.2.0` → `0.3.0`
- Engine layer untouched (per task scope)

## Test plan
- [x] Full suite green: **652 passed, 1 skipped** (baseline was 638 → +14 new tests)
- [x] New tests cover: `rows=None` → `INVALID_PARAMETER`, every `*_json`→structured conversion (valid + invalid), `detailed=True` single-decode regression, all primitive tools return `result: dict`
- [x] FastMCP schema generation verified via `mcp._tool_manager._tools[...].parameters` inspection
- [ ] Claude Desktop smoke test (left to reviewer)

Closes #97, closes #98, closes #99, closes #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)