### PR TITLE
fix(v0.3.1): strict nested validation + FILE_NOT_FOUND + detailed layout message + drift cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,85 @@
 
 All notable changes to `pptx-mcp-server` are documented in this file.
 
+## v0.3.1 — close OpenAI/Codex 5.4 remaining blockers
+
+Flagged by the OpenAI/Codex 5.4 v0.3.0 review as the remaining partials that
+prevent LOGO-READY. Closes #105, #106, #107, #108.
+
+### Fixes
+
+#### #105 — Strict nested-key validation + legacy string-JSON fallback removal
+
+The v0.3.0 surface change (#97) converted `*_json: str` parameters to
+structured types but left several dict-shaped specs without unknown-key
+rejection. Adversarial input like `_validate_chart_data('column', ['A'],
+['oops'])` surfaced as `AttributeError` → `INTERNAL_ERROR` rather than a
+structured `INVALID_PARAMETER`.
+
+v0.3.1 adds `frozenset`-backed allowed-keys validation for every
+remaining dict-shaped spec:
+
+- `pptx_add_chart` → `_validate_chart_spec` + per-series key validation
+- `pptx_build_slide` / `pptx_build_deck` → `_validate_slide_spec`
+- `pptx_add_kpi_row` → `_validate_kpi_spec`
+- `pptx_edit_table_cells` → `_validate_edit_cells_spec`
+
+Unknown keys raise `EngineError(INVALID_PARAMETER, "<spec>: unknown keys
+[...]; allowed: [...]")`. Wrong types on critical fields (e.g. `series`
+not a list, `row` not int, `value` not str/number) are rejected cleanly
+without leaking `AttributeError` / `TypeError`.
+
+**BREAKING — engine layer only** (MCP layer unaffected): the legacy
+`isinstance(x, str)` → `json.loads` fallbacks in `build_slide`,
+`build_deck`, `add_kpi_row`, `add_bullet_block` engine wrappers were
+removed. Library consumers must now pass structured values. The MCP
+boundary already passed dicts since v0.3.0, so MCP clients are unaffected.
+
+#### #106 — `message` field in detailed layout result
+
+`pptx_check_layout(detailed=True)` now includes a human-readable
+`result["message"]` alongside `slides` / `summary`, so generic agents
+that read `result.message` work for every tool:
+
+```json
+{"ok": true, "result": {
+    "message": "Found 3 errors, 0 warnings, 12 info findings across 22 slides",
+    "slides": [...],
+    "summary": {...}
+}}
+```
+
+#### #107 — `FILE_NOT_FOUND` taxonomy fix for `pptx_check_layout`
+
+`pptx_check_layout` called `Presentation(file_path)` directly, so a
+missing file surfaced as `INTERNAL_ERROR: PackageNotFoundError`. It now
+routes through `engine.pptx_io.open_pptx`, which maps missing files to
+`EngineError(FILE_NOT_FOUND)` — consistent with every other tool.
+
+Audit confirmed no other direct `Presentation(path)` calls remain in
+`server.py`.
+
+#### #108 — Drift cleanup
+
+- Dropped the stale `"All 25 tools"` assertion in `tests/test_server.py`
+  (actual count is 37+). The test now asserts the core tools are
+  registered without pinning a hardcoded total.
+- CHANGELOG already recorded `INSTRUCTIONS` at 50 lines (accurate — the
+  v0.3.0 claim was never 41, contrary to some review drafts); no further
+  line-count edit needed.
+
+### Tests
+
+Coverage extended for each new validator path:
+
+- Chart / slide / KPI / edit-cell unknown-key rejection.
+- `build_slide(prs, '{"title":"x"}')` string input now raises
+  `EngineError(INVALID_PARAMETER)` — the legacy silent-parse is gone.
+- `pptx_check_layout("/nonexistent.pptx")` and
+  `pptx_check_layout("/nonexistent.pptx", detailed=True)` both return
+  `error.code == "FILE_NOT_FOUND"`.
+- `pptx_check_layout(path, detailed=True)` result contains `message`.
+
 ## v0.3.0 — BREAKING: structured MCP surface
 
 Flagged by OpenAI/Codex 5.4 as the remaining blockers to LOGO-READY status;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pptx-mcp-server"
-version = "0.3.0"
+version = "0.3.1"
 description = "Content-aware PPTX layout engine with Japanese-aware text metrics, CSS-flex-like primitives, and structural validator for agent-generated consulting decks"
 requires-python = ">=3.11"
 license = "MIT"

--- a/src/pptx_mcp_server/engine/charts.py
+++ b/src/pptx_mcp_server/engine/charts.py
@@ -66,7 +66,79 @@ _LEGEND_POSITION_MAP = {
 }
 
 # ---------------------------------------------------------------------------
-# Validation
+# Spec validation (strict-key)
+# ---------------------------------------------------------------------------
+
+# add_chart() spec 全体で許容するトップレベルキー。v0.3.1 で unknown キーを
+# 厳格に拒否するようにした (#105)。
+_CHART_SPEC_ALLOWED = frozenset({
+    "chart_type",
+    "left", "top", "width", "height",
+    "categories", "series",
+    "title",
+    "legend_position", "legend_font_size",
+    "data_labels_show", "data_labels_position", "data_labels_number_format",
+    "data_labels_font_size", "data_labels_font_color",
+    "axis_value_title", "axis_value_min", "axis_value_max",
+    "axis_value_major_unit", "axis_value_gridlines",
+    "axis_value_number_format", "axis_value_visible",
+    "axis_category_visible",
+    "gap_width", "overlap",
+    "theme",
+})
+
+# 各 series 要素で許容するキー。
+_CHART_SERIES_ALLOWED = frozenset({"name", "values", "color"})
+
+
+def _validate_chart_spec(chart: dict) -> None:
+    """chart_spec を受け取り unknown キーや型崩れを早期に弾く。
+
+    Raises ``EngineError(INVALID_PARAMETER)`` on shape problems.
+    """
+    if not isinstance(chart, dict):
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            f"chart spec must be a dict, got {type(chart).__name__}",
+        )
+    unknown = set(chart.keys()) - _CHART_SPEC_ALLOWED
+    if unknown:
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            f"chart: unknown keys {sorted(unknown)}; "
+            f"allowed: {sorted(_CHART_SPEC_ALLOWED)}",
+        )
+
+    categories = chart.get("categories", [])
+    if not isinstance(categories, list):
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            f"chart.categories must be a list, got {type(categories).__name__}",
+        )
+
+    series = chart.get("series", [])
+    if not isinstance(series, list):
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            f"chart.series must be a list, got {type(series).__name__}",
+        )
+    for i, s in enumerate(series):
+        if not isinstance(s, dict):
+            raise EngineError(
+                ErrorCode.INVALID_PARAMETER,
+                f"chart.series[{i}] must be a dict, got {type(s).__name__}",
+            )
+        unknown_s = set(s.keys()) - _CHART_SERIES_ALLOWED
+        if unknown_s:
+            raise EngineError(
+                ErrorCode.INVALID_PARAMETER,
+                f"chart.series[{i}]: unknown keys {sorted(unknown_s)}; "
+                f"allowed: {sorted(_CHART_SERIES_ALLOWED)}",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Data validation
 # ---------------------------------------------------------------------------
 
 
@@ -103,6 +175,11 @@ def _validate_chart_data(
 
     n_cats = len(categories)
     for i, s in enumerate(series):
+        if not isinstance(s, dict):
+            raise EngineError(
+                ErrorCode.INVALID_PARAMETER,
+                f"chart.series[{i}] must be a dict, got {type(s).__name__}",
+            )
         name = s.get("name", f"Series {i}")
 
         # values presence
@@ -421,6 +498,8 @@ def add_chart(file_path: str, slide_index: int, chart_spec: dict) -> str:
     Returns a summary string.
     """
     from ..theme import get_theme
+
+    _validate_chart_spec(chart_spec)
 
     prs = open_pptx(file_path)
     slide = _get_slide(prs, slide_index)

--- a/src/pptx_mcp_server/engine/composites.py
+++ b/src/pptx_mcp_server/engine/composites.py
@@ -23,6 +23,127 @@ from .connectors import _add_connector, _add_callout
 from ..theme import Theme, MCKINSEY, get_theme, resolve_color
 
 
+# ── Strict-key validation (#105) ───────────────────────────────
+#
+# v0.3.1 では chart / slide / deck / kpi / edit-cell の各 spec に対して
+# unknown キーを明示的に拒否する。flex.py / cards.py と同一のパターンを
+# 踏襲し, 型崩れは AttributeError や TypeError ではなく
+# EngineError(INVALID_PARAMETER) として surface する。
+
+_SLIDE_SPEC_ALLOWED = frozenset({
+    "layout",
+    "title",
+    "subtitle",
+    "background",
+    "source",
+    "page_number",
+    "theme",
+    "elements",
+})
+
+_KPI_ALLOWED = frozenset({"value", "label"})
+
+_EDIT_CELL_ALLOWED = frozenset({
+    "row", "col",
+    "text",
+    "font_size",
+    "font_color",
+    "bold",
+    "bg_color",
+})
+
+
+def _validate_slide_spec(spec: dict) -> None:
+    """build_slide / build_deck の 1 スライド分 spec を検証する。"""
+    if not isinstance(spec, dict):
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            f"slide spec must be a dict, got {type(spec).__name__}",
+        )
+    unknown = set(spec.keys()) - _SLIDE_SPEC_ALLOWED
+    if unknown:
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            f"slide: unknown keys {sorted(unknown)}; "
+            f"allowed: {sorted(_SLIDE_SPEC_ALLOWED)}",
+        )
+    elements = spec.get("elements", [])
+    if not isinstance(elements, list):
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            f"slide.elements must be a list, got {type(elements).__name__}",
+        )
+    for i, elem in enumerate(elements):
+        if not isinstance(elem, dict):
+            raise EngineError(
+                ErrorCode.INVALID_PARAMETER,
+                f"slide.elements[{i}] must be a dict, got {type(elem).__name__}",
+            )
+
+
+def _validate_kpi_spec(kpis: list) -> None:
+    """_add_kpi_row 用の kpi list を検証する。"""
+    if not isinstance(kpis, list):
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            f"kpis must be a list, got {type(kpis).__name__}",
+        )
+    for i, kpi in enumerate(kpis):
+        if not isinstance(kpi, dict):
+            raise EngineError(
+                ErrorCode.INVALID_PARAMETER,
+                f"kpis[{i}] must be a dict, got {type(kpi).__name__}",
+            )
+        unknown = set(kpi.keys()) - _KPI_ALLOWED
+        if unknown:
+            raise EngineError(
+                ErrorCode.INVALID_PARAMETER,
+                f"kpis[{i}]: unknown keys {sorted(unknown)}; "
+                f"allowed: {sorted(_KPI_ALLOWED)}",
+            )
+        value = kpi.get("value")
+        if value is not None and not isinstance(value, (str, int, float)):
+            raise EngineError(
+                ErrorCode.INVALID_PARAMETER,
+                f"kpis[{i}].value must be str or number, "
+                f"got {type(value).__name__}",
+            )
+
+
+def _validate_edit_cells_spec(edits: list) -> None:
+    """_edit_table_cells 用の edits list を検証する。"""
+    if not isinstance(edits, list):
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            f"edits must be a list, got {type(edits).__name__}",
+        )
+    for i, edit in enumerate(edits):
+        if not isinstance(edit, dict):
+            raise EngineError(
+                ErrorCode.INVALID_PARAMETER,
+                f"edits[{i}] must be a dict, got {type(edit).__name__}",
+            )
+        unknown = set(edit.keys()) - _EDIT_CELL_ALLOWED
+        if unknown:
+            raise EngineError(
+                ErrorCode.INVALID_PARAMETER,
+                f"edits[{i}]: unknown keys {sorted(unknown)}; "
+                f"allowed: {sorted(_EDIT_CELL_ALLOWED)}",
+            )
+        row = edit.get("row")
+        col = edit.get("col")
+        if row is not None and not isinstance(row, int):
+            raise EngineError(
+                ErrorCode.INVALID_PARAMETER,
+                f"edits[{i}].row must be int, got {type(row).__name__}",
+            )
+        if col is not None and not isinstance(col, int):
+            raise EngineError(
+                ErrorCode.INVALID_PARAMETER,
+                f"edits[{i}].col must be int, got {type(col).__name__}",
+            )
+
+
 # ── In-memory composite primitives ─────────────────────────────
 
 
@@ -239,6 +360,7 @@ def _add_kpi_row(slide, kpis, y, theme=None):
     Design: white card with left accent bar, large value, label below.
     kpis = [{"value": "107.8M", "label": "Revenue"}, ...]
     Returns list of shape indices."""
+    _validate_kpi_spec(kpis)
     if theme:
         left_margin = theme.margins.get("left", 0.9)
         right_margin = theme.margins.get("right", 0.9)
@@ -606,6 +728,8 @@ def _build_slide(prs, spec, theme=None):
 
     Returns (slide, slide_index).
     """
+    _validate_slide_spec(spec)
+
     # Theme resolution: explicit param > spec key > MCKINSEY default
     if theme is None:
         theme_name = spec.get("theme")
@@ -739,6 +863,12 @@ def _dispatch_element(slide, elem, etype, theme):
         )
 
     elif etype == "chart":
+        # strict-key validation for the embedded chart spec (#105)
+        from .charts import _validate_chart_spec as _vcs
+        # elem inherits slide-element shape — strip 'type' key before
+        # validating as chart spec.
+        chart_only = {k: v for k, v in elem.items() if k != "type"}
+        _vcs(chart_only)
         _add_chart(
             slide,
             chart_type=elem.get("chart_type", "column"),
@@ -837,11 +967,16 @@ def _dispatch_element(slide, elem, etype, theme):
             )
 
 
-def build_slide(file_path, spec_json):
-    """File-based wrapper: build an entire slide from a JSON spec.
-    One file open, one save. Returns slide index and element count."""
-    import json
-    spec = json.loads(spec_json) if isinstance(spec_json, str) else spec_json
+def build_slide(file_path, spec):
+    """File-based wrapper: build an entire slide from a spec dict.
+
+    One file open, one save. Returns slide index and element count.
+
+    v0.3.1 (#105): the legacy ``spec_json: str`` fallback was removed.
+    Library consumers must now pass a structured ``dict`` — same contract as
+    the MCP boundary. Passing a string raises ``EngineError(INVALID_PARAMETER)``
+    (caught by ``_validate_slide_spec``).
+    """
     prs = open_pptx(file_path)
     slide, idx = _build_slide(prs, spec)
     save_pptx(prs, file_path)
@@ -853,11 +988,19 @@ def build_slide(file_path, spec_json):
     return f"Built slide [{idx}] with {n_elements} elements: {title}{warning}"
 
 
-def build_deck(file_path, slides_json):
+def build_deck(file_path, slides):
     """File-based wrapper: build an entire deck from a list of slide specs.
-    Single file open/save for the whole deck."""
-    import json
-    slides = json.loads(slides_json) if isinstance(slides_json, str) else slides_json
+
+    Single file open/save for the whole deck.
+
+    v0.3.1 (#105): the legacy ``slides_json: str`` fallback was removed —
+    see :func:`build_slide` for details.
+    """
+    if not isinstance(slides, list):
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            f"slides must be a list, got {type(slides).__name__}",
+        )
     prs = open_pptx(file_path)
     results = []
     for i, spec in enumerate(slides):
@@ -889,10 +1032,11 @@ def add_section_divider(file_path, title, subtitle=""):
     return f"Added section divider [{idx}] with title: {title}"
 
 
-def add_kpi_row(file_path, slide_index, kpis_json, y):
-    """File-based wrapper: add a row of KPI callout boxes."""
-    import json
-    kpis = json.loads(kpis_json) if isinstance(kpis_json, str) else kpis_json
+def add_kpi_row(file_path, slide_index, kpis, y):
+    """File-based wrapper: add a row of KPI callout boxes.
+
+    v0.3.1 (#105): the legacy ``kpis_json: str`` fallback was removed.
+    """
     prs = open_pptx(file_path)
     slide = _get_slide(prs, slide_index)
     indices = _add_kpi_row(slide, kpis, y)
@@ -900,10 +1044,17 @@ def add_kpi_row(file_path, slide_index, kpis_json, y):
     return f"Added {len(kpis)} KPI boxes on slide [{slide_index}]"
 
 
-def add_bullet_block(file_path, slide_index, items_json, left, top, width, height):
-    """File-based wrapper: add a bulleted text block."""
-    import json
-    items = json.loads(items_json) if isinstance(items_json, str) else items_json
+def add_bullet_block(file_path, slide_index, items, left, top, width, height):
+    """File-based wrapper: add a bulleted text block.
+
+    v0.3.1 (#105): the legacy ``items_json: str`` fallback was removed —
+    pass ``items: list[str]`` directly.
+    """
+    if not isinstance(items, list):
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            f"items must be a list, got {type(items).__name__}",
+        )
     prs = open_pptx(file_path)
     slide = _get_slide(prs, slide_index)
     idx = _add_bullet_block(slide, items, left, top, width, height)

--- a/src/pptx_mcp_server/engine/tables.py
+++ b/src/pptx_mcp_server/engine/tables.py
@@ -179,6 +179,10 @@ def _edit_table_cells(
     theme=None,
 ):
     """In-memory: batch edit multiple table cells."""
+    # strict-key validation is injected lazily to avoid import cycles.
+    from .composites import _validate_edit_cells_spec
+    _validate_edit_cells_spec(edits)
+
     shape = _get_shape(slide, shape_index)
 
     if not shape.has_table:

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -1202,16 +1202,31 @@ def pptx_check_layout(
 
     Run after building a deck to catch layout issues before delivery."""
     try:
-        from pptx import Presentation
-        prs = Presentation(file_path)
+        # v0.3.1 (#107): route through ``open_pptx`` so missing files emit
+        # ``FILE_NOT_FOUND`` (consistent with every other tool) instead of
+        # the stray ``PackageNotFoundError`` → ``INTERNAL_ERROR``.
+        prs = open_pptx(file_path)
         result = check_deck_extended(
             prs,
             min_readable_pt=min_readable_pt,
             overflow_tolerance_pct=overflow_tolerance_pct,
         )
         if detailed:
-            # #99: pass the dict directly — single json.loads decodes the envelope.
-            return _success(result)
+            # v0.3.1 (#106): include a ``message`` field so generic
+            # ``result.message`` consumers work for every tool.
+            summary = result.get("summary", {})
+            n_slides = len(result.get("slides", []))
+            errors = summary.get("errors", 0)
+            warnings = summary.get("warnings", 0)
+            infos = summary.get("infos", 0)
+            if errors == 0 and warnings == 0:
+                message = f"All {n_slides} slides clean — 0 findings"
+            else:
+                message = (
+                    f"Found {errors} errors, {warnings} warnings, "
+                    f"{infos} info findings across {n_slides} slides"
+                )
+            return _success({"message": message, **result})
         return _success({"message": _format_check_layout_summary(result)})
     except Exception as e:
         return _err(e)

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -476,7 +476,9 @@ class TestBuildSlideChart:
         assert "Unknown element type" in str(exc_info.value)
 
     def test_build_slide_file_with_chart(self, pptx_file):
-        spec = json.dumps({
+        # v0.3.1 (#105): build_slide no longer accepts JSON strings — pass
+        # the structured dict directly.
+        spec = {
             "layout": "content",
             "title": "Revenue Breakdown",
             "elements": [
@@ -495,7 +497,7 @@ class TestBuildSlideChart:
                     "legend_position": "bottom",
                 }
             ],
-        })
+        }
         result = build_slide(pptx_file, spec)
         assert "Built slide" in result
         assert "1 elements" in result

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -104,10 +104,13 @@ def deck(tmp_path):
 
 
 class TestToolRegistration:
-    """All 25 tools must be registered on the MCP server."""
+    """All registered MCP tools must expose the expected core signatures."""
 
     def test_all_tools_registered(self):
-        # FastMCP stores tools internally; list them via the _tool_manager
+        # FastMCP stores tools internally; list them via the _tool_manager.
+        # v0.3.1 (#108): dropped hardcoded "25 tools" drift. The expected
+        # list is a *subset* — new tools can be added without editing this
+        # assertion as long as the core tools stay registered.
         tool_names = list(mcp._tool_manager._tools.keys())
         expected = [
             "pptx_create",
@@ -138,7 +141,8 @@ class TestToolRegistration:
         ]
         for name in expected:
             assert name in tool_names, f"Tool '{name}' not registered"
-        assert len(expected) == 25
+        # dynamic count — matches the live FastMCP registration.
+        assert len(tool_names) >= len(expected)
 
 
 class TestCreatePptx:
@@ -837,3 +841,248 @@ class TestInstructionsContent:
 
     def test_auto_render_opt_in_documented(self):
         assert "PPTX_MCP_AUTO_RENDER" in INSTRUCTIONS
+
+
+# ── v0.3.1 (#105/#106/#107/#108): OpenAI/Codex gap closures ────────────
+
+class TestStrictNestedValidation:
+    """#105: unknown keys in nested specs return structured INVALID_PARAMETER.
+
+    Adversarial shapes that used to leak ``AttributeError`` / ``TypeError``
+    are now rejected cleanly at the engine boundary.
+    """
+
+    def test_chart_spec_rejects_unknown_series_key(self, deck):
+        err = _unwrap_err(
+            pptx_add_chart(
+                deck,
+                slide_index=0,
+                chart={
+                    "chart_type": "column",
+                    "categories": ["A"],
+                    "series": [{"name": "S", "values": [1], "unknown_key": 1}],
+                },
+            )
+        )
+        assert err["code"] == "INVALID_PARAMETER"
+        assert "unknown_key" in err["message"]
+
+    def test_chart_spec_rejects_unknown_top_level_key(self, deck):
+        err = _unwrap_err(
+            pptx_add_chart(
+                deck,
+                slide_index=0,
+                chart={
+                    "chart_type": "column",
+                    "categories": ["A"],
+                    "series": [{"name": "S", "values": [1]}],
+                    "bogus_field": 42,
+                },
+            )
+        )
+        assert err["code"] == "INVALID_PARAMETER"
+        assert "bogus_field" in err["message"]
+
+    def test_chart_spec_series_string_not_dict(self, deck):
+        # The original adversarial case: series=['oops'] used to raise
+        # AttributeError: 'str' object has no attribute 'get'.
+        err = _unwrap_err(
+            pptx_add_chart(
+                deck,
+                slide_index=0,
+                chart={
+                    "chart_type": "column",
+                    "categories": ["A"],
+                    "series": ["oops"],
+                },
+            )
+        )
+        assert err["code"] == "INVALID_PARAMETER"
+        assert "series[0]" in err["message"]
+
+    def test_chart_spec_valid_still_works(self, deck):
+        payload = _unwrap_ok(
+            pptx_add_chart(
+                deck,
+                slide_index=0,
+                chart={
+                    "chart_type": "column",
+                    "categories": ["Q1", "Q2"],
+                    "series": [{"name": "Rev", "values": [10, 20]}],
+                },
+            )
+        )
+        assert "message" in payload
+
+    def test_build_slide_rejects_unknown_top_level_key(self, deck):
+        err = _unwrap_err(
+            pptx_build_slide(
+                deck,
+                spec={"unknown_field": 1, "title": "x"},
+            )
+        )
+        assert err["code"] == "INVALID_PARAMETER"
+        assert "unknown_field" in err["message"]
+
+    def test_build_slide_valid_still_works(self, deck):
+        payload = _unwrap_ok(
+            pptx_build_slide(deck, spec={"layout": "content", "title": "x"})
+        )
+        assert "message" in payload
+
+    def test_build_deck_rejects_unknown_key_in_slide(self, deck):
+        err = _unwrap_err(
+            pptx_build_deck(
+                deck,
+                slides=[{"layout": "content", "title": "x", "bogus": True}],
+            )
+        )
+        assert err["code"] == "INVALID_PARAMETER"
+        assert "bogus" in err["message"]
+
+    def test_kpi_row_rejects_unknown_key(self, deck):
+        err = _unwrap_err(
+            pptx_add_kpi_row(
+                deck,
+                slide_index=0,
+                kpis=[{"label": "x", "value": "y", "typo": 1}],
+                y=1.2,
+            )
+        )
+        assert err["code"] == "INVALID_PARAMETER"
+        assert "typo" in err["message"]
+
+    def test_kpi_row_valid_still_works(self, deck):
+        payload = _unwrap_ok(
+            pptx_add_kpi_row(
+                deck,
+                slide_index=0,
+                kpis=[{"label": "Rev", "value": "100"}],
+                y=1.2,
+            )
+        )
+        assert "message" in payload
+
+    def test_edit_cells_rejects_unknown_key(self, deck):
+        # Build a table first.
+        pptx_add_table(
+            deck, slide_index=0,
+            rows=[["H1", "H2"], ["a", "b"]],
+            left=1.0, top=1.0, width=6.0,
+        )
+        err = _unwrap_err(
+            pptx_edit_table_cells(
+                deck, slide_index=0, shape_index=0,
+                edits=[{"row": 0, "col": 0, "text": "X", "typo": 1}],
+            )
+        )
+        assert err["code"] == "INVALID_PARAMETER"
+        assert "typo" in err["message"]
+
+    def test_edit_cells_rejects_non_int_row(self, deck):
+        pptx_add_table(
+            deck, slide_index=0,
+            rows=[["H1", "H2"], ["a", "b"]],
+            left=1.0, top=1.0, width=6.0,
+        )
+        err = _unwrap_err(
+            pptx_edit_table_cells(
+                deck, slide_index=0, shape_index=0,
+                edits=[{"row": "zero", "col": 0, "text": "X"}],
+            )
+        )
+        assert err["code"] == "INVALID_PARAMETER"
+        assert "row" in err["message"]
+
+
+class TestEngineWrappersStringJsonRemoved:
+    """#105 Part B: engine wrappers no longer accept legacy string-JSON input."""
+
+    def test_build_slide_string_input_rejected(self, tmp_path):
+        from pptx_mcp_server.engine.composites import build_slide
+        from pptx_mcp_server.engine import create_presentation
+        from pptx_mcp_server.engine.pptx_io import EngineError, ErrorCode
+
+        path = str(tmp_path / "deck.pptx")
+        create_presentation(path)
+        with pytest.raises(EngineError) as exc:
+            build_slide(path, '{"title":"x"}')
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+
+    def test_build_deck_string_input_rejected(self, tmp_path):
+        from pptx_mcp_server.engine.composites import build_deck
+        from pptx_mcp_server.engine import create_presentation
+        from pptx_mcp_server.engine.pptx_io import EngineError, ErrorCode
+
+        path = str(tmp_path / "deck.pptx")
+        create_presentation(path)
+        with pytest.raises(EngineError) as exc:
+            build_deck(path, '[{"title":"x"}]')
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+
+    def test_add_bullet_block_string_input_rejected(self, tmp_path):
+        from pptx_mcp_server.engine.composites import add_bullet_block
+        from pptx_mcp_server.engine import create_presentation, add_slide
+        from pptx_mcp_server.engine.pptx_io import EngineError, ErrorCode
+
+        path = str(tmp_path / "deck.pptx")
+        create_presentation(path)
+        add_slide(path, layout_index=6)
+        with pytest.raises(EngineError) as exc:
+            add_bullet_block(
+                path, slide_index=0,
+                items='["a","b"]',
+                left=1.0, top=1.0, width=5.0, height=2.0,
+            )
+        assert exc.value.code == ErrorCode.INVALID_PARAMETER
+
+
+class TestCheckLayoutDetailedMessage:
+    """#106: ``detailed=True`` result includes a ``message`` field."""
+
+    def test_detailed_clean_has_message(self, deck):
+        payload = _unwrap_ok(pptx_check_layout(deck, detailed=True))
+        assert "message" in payload
+        assert "clean" in payload["message"].lower() or "finding" in payload["message"].lower()
+
+    def test_detailed_with_findings_has_message(self, deck):
+        # Introduce an overlap.
+        pptx_add_shape(deck, 0, "rectangle", 1.0, 1.0, 3.0, 2.0, fill_color="2251FF")
+        pptx_add_shape(deck, 0, "rectangle", 2.0, 1.5, 3.0, 2.0, fill_color="FF0000")
+        payload = _unwrap_ok(pptx_check_layout(deck, detailed=True))
+        assert "message" in payload
+        msg = payload["message"]
+        # Must mention "findings" or "clean" so generic agents can parse it.
+        assert "findings" in msg or "clean" in msg
+
+
+class TestCheckLayoutFileNotFound:
+    """#107: missing file → FILE_NOT_FOUND (not INTERNAL_ERROR)."""
+
+    def test_missing_file_returns_file_not_found(self, tmp_path):
+        nonexistent = str(tmp_path / "nope.pptx")
+        err = _unwrap_err(pptx_check_layout(nonexistent))
+        assert err["code"] == "FILE_NOT_FOUND"
+
+    def test_missing_file_detailed_returns_file_not_found(self, tmp_path):
+        nonexistent = str(tmp_path / "nope.pptx")
+        err = _unwrap_err(pptx_check_layout(nonexistent, detailed=True))
+        assert err["code"] == "FILE_NOT_FOUND"
+
+
+class TestNoStale25Tools:
+    """#108: no hardcoded '25 tools' assertion left in tests.
+
+    Historical comments referencing the cleanup are allowed; a
+    ``len(...) == 25`` hardcoded count assertion is not.
+    """
+
+    def test_no_hardcoded_25_tools_assertion(self):
+        # v0.3.1 (#108): the test asserts that the live FastMCP
+        # registration has at least the core tools, without a brittle
+        # hardcoded count. 37+ tools are registered today.
+        tool_names = list(mcp._tool_manager._tools.keys())
+        assert len(tool_names) > 25, (
+            "FastMCP should register well beyond the historical 25-tool "
+            f"baseline — got {len(tool_names)}"
+        )


### PR DESCRIPTION
## Summary

Closes the four remaining Codex gpt-5.4 v0.3.0 review blockers that prevent LOGO-READY status.

- **#105** — strict nested-key validation (chart / slide / deck / kpi / edit-cell specs) + removed legacy `isinstance(x, str)` JSON-string fallbacks from engine wrappers. The adversarial `series=['oops']` case that surfaced as `AttributeError → INTERNAL_ERROR` is now a structured `INVALID_PARAMETER` at the engine boundary.
- **#106** — `pptx_check_layout(detailed=True)` result now includes a `message` field so generic `result.message` consumers work for every tool.
- **#107** — `pptx_check_layout` routes file opens through `engine.pptx_io.open_pptx`, so missing files return `FILE_NOT_FOUND` instead of `INTERNAL_ERROR: PackageNotFoundError`. Audit confirmed no other direct `Presentation(path)` calls in `server.py`.
- **#108** — dropped the stale `assert len(expected) == 25` drift trap; replaced with a dynamic registration assertion. `INSTRUCTIONS` line-count in CHANGELOG already matches reality (50 lines) — no further edit needed.

Four new validators added, each with its own allowed-keys `frozenset`:

- `_validate_chart_spec` (+ per-series strict keys)
- `_validate_slide_spec`
- `_validate_kpi_spec`
- `_validate_edit_cells_spec`

**BREAKING — engine layer only** (MCP layer unaffected): the legacy `isinstance(x, str) → json.loads` fallbacks in `build_slide`, `build_deck`, `add_kpi_row`, `add_bullet_block` engine wrappers were removed. Library consumers must pass structured values. Documented in CHANGELOG.

Version bumped `0.3.0` → `0.3.1`.

## Test plan

- [x] 652 → 671 passing tests (1 skipped). No regressions.
- [x] Added 19 new tests covering: unknown-key rejection per spec, valid-input baseline, string-JSON input rejection (library layer), `detailed=True` `message` field, `FILE_NOT_FOUND` for missing file (default + detailed).
- [x] `grep -n "Presentation(" src/pptx_mcp_server/server.py` returns nothing.

Closes #105, closes #106, closes #107, closes #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)