### PR TITLE
feat(cards): add border_color + border_width to CardSpec (closes #111)

### DIFF
--- a/src/pptx_mcp_server/engine/cards.py
+++ b/src/pptx_mcp_server/engine/cards.py
@@ -53,6 +53,9 @@ _ACCENT_BAR_W: float = 0.08
 # 吸収し、PowerPoint 実描画でのクリップを避けるためのマージン。
 _BLOCK_HEIGHT_SLACK: float = 1.05
 
+# inches → points 換算係数 (``_add_shape`` の ``line_width`` は pt 単位)。
+_POINTS_PER_INCH: float = 72.0
+
 
 @dataclass
 class CardSpec:
@@ -78,6 +81,12 @@ class CardSpec:
         label_size_pt: ラベル font size (pt)。
         label_color: ラベル文字色 (6 桁 hex)。
         padding: カード内側 padding (inches、上下左右共通)。
+        border_color: カード枠線の色 (6 桁 hex、``#`` なし)。空文字列で
+            枠線を描画しない (既定)。
+        border_width: カード枠線の太さ (inches)。``0.0`` 以下で枠線を
+            描画しない (既定)。``border_color`` と ``border_width > 0`` の
+            両方を満たした場合のみ枠線を描画する。典型値は ``0.01``
+            (hairline 相当)。
     """
 
     title: str = ""
@@ -92,6 +101,8 @@ class CardSpec:
     label_size_pt: float = 9
     label_color: str = "666666"
     padding: float = 0.2
+    border_color: str = ""
+    border_width: float = 0.0
 
 
 @dataclass
@@ -184,17 +195,37 @@ def _render_card(
     ``mode="fill"`` かつ content が h より短い場合、label は先頭固定のまま
     title + body のグループを垂直方向に中央揃えで配置する。
     """
-    # 1) 背景矩形
-    _add_shape(
-        slide,
-        shape_type="rectangle",
-        left=left,
-        top=top,
-        width=w,
-        height=h,
-        fill_color=card.fill_color,
-        no_line=True,
-    )
+    # 1) 背景矩形。``border_color`` が非空かつ ``border_width > 0`` の
+    #    両方が揃った場合のみ枠線を描く。片方だけ指定された (例:
+    #    ``border_color`` 指定 + ``border_width=0``) 場合は枠線を描かず
+    #    既定の no-line に落とす (defensive; 0 幅の枠線は視覚的に意味が
+    #    無く、PowerPoint 側の挙動に任せるとハイラインが出るケースが
+    #    あるため明示的に抑止する)。
+    if card.border_color and card.border_width > 0:
+        _add_shape(
+            slide,
+            shape_type="rectangle",
+            left=left,
+            top=top,
+            width=w,
+            height=h,
+            fill_color=card.fill_color,
+            line_color=card.border_color,
+            # ``_add_shape`` の ``line_width`` は pt 単位だが、CardSpec は
+            # 他の寸法と一貫して inches で受け取るため、ここで pt へ変換する。
+            line_width=card.border_width * _POINTS_PER_INCH,
+        )
+    else:
+        _add_shape(
+            slide,
+            shape_type="rectangle",
+            left=left,
+            top=top,
+            width=w,
+            height=h,
+            fill_color=card.fill_color,
+            no_line=True,
+        )
 
     # 2) 任意の左アクセントバー
     if card.accent_color:

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -568,3 +568,144 @@ class TestCardRowGeometryValidation:
             max_height=1.0, min_card_height=1.0,
         )
         assert len(placements) == 1
+
+
+# -----------------------------------------------------------------------------
+# #111: CardSpec border fields
+# -----------------------------------------------------------------------------
+
+
+class TestCardSpecBorder:
+    """``CardSpec.border_color`` / ``border_width`` による枠線描画 (#111).
+
+    背景矩形の ``shape.line`` に枠線が設定されるかをケース別に検証する。
+    ``border_color`` + ``border_width > 0`` の両方が揃ったときだけ描画し、
+    片方欠落の場合は既定の no-line に落ちる。
+    """
+
+    def test_border_color_and_width_draws_visible_line(self, slide):
+        """``border_color='E0E0E0'`` + ``border_width=0.01`` で背景矩形に
+        枠線が引かれ、``shape.line.color.rgb`` が指定色と一致する."""
+        from pptx.dml.color import RGBColor
+        from pptx.enum.dml import MSO_FILL
+
+        cards = [CardSpec(title="T", body="body", border_color="E0E0E0", border_width=0.01)]
+        add_responsive_card_row(
+            slide, cards,
+            left=0.5, top=0.5, width=5.0, max_height=3.0,
+            gap=0.2, height_mode="max",
+        )
+
+        bg = list(slide.shapes)[0]
+        # 塗り潰された (= background ではない) 線が付いている
+        assert bg.line.fill.type == MSO_FILL.SOLID
+        assert bg.line.color.rgb == RGBColor(0xE0, 0xE0, 0xE0)
+        # line width は pt 単位で記録される (0.01 inch × 72 ≈ 0.72 pt)
+        # EMU での width > 0 を確認
+        assert bg.line.width > 0
+
+    def test_default_no_border_sets_line_background(self, slide):
+        """border 指定無しの既定では従来どおり ``shape.line.fill.type`` が
+        ``MSO_FILL.BACKGROUND`` (no-line) になる (回帰防止)."""
+        from pptx.enum.dml import MSO_FILL
+
+        cards = [CardSpec(title="T", body="body")]
+        add_responsive_card_row(
+            slide, cards,
+            left=0.5, top=0.5, width=5.0, max_height=3.0,
+            gap=0.2, height_mode="max",
+        )
+
+        bg = list(slide.shapes)[0]
+        assert bg.line.fill.type == MSO_FILL.BACKGROUND
+
+    def test_border_color_with_zero_width_silently_disables(self, slide):
+        """``border_color`` が非空でも ``border_width=0`` なら枠線を描かない
+        (defensive; 0 幅枠線は視覚的に意味が無いため no-line に落とす)."""
+        from pptx.enum.dml import MSO_FILL
+
+        cards = [CardSpec(title="T", body="body", border_color="E0E0E0", border_width=0.0)]
+        add_responsive_card_row(
+            slide, cards,
+            left=0.5, top=0.5, width=5.0, max_height=3.0,
+            gap=0.2, height_mode="max",
+        )
+
+        bg = list(slide.shapes)[0]
+        assert bg.line.fill.type == MSO_FILL.BACKGROUND
+
+    def test_border_width_with_empty_color_silently_disables(self, slide):
+        """``border_width > 0`` でも ``border_color`` が空なら no-line."""
+        from pptx.enum.dml import MSO_FILL
+
+        cards = [CardSpec(title="T", body="body", border_color="", border_width=0.01)]
+        add_responsive_card_row(
+            slide, cards,
+            left=0.5, top=0.5, width=5.0, max_height=3.0,
+            gap=0.2, height_mode="max",
+        )
+
+        bg = list(slide.shapes)[0]
+        assert bg.line.fill.type == MSO_FILL.BACKGROUND
+
+    def test_mcp_tool_passes_border_fields_through(self, pptx_file):
+        """``pptx_add_responsive_card_row`` MCP ツール経由で
+        ``border_color`` / ``border_width`` を dict に乗せて渡せる
+        (strict-key validation が ``fields(CardSpec)`` 経由なので
+        新フィールドも自動で許可される)."""
+        import json
+
+        from pptx import Presentation
+        from pptx.dml.color import RGBColor
+        from pptx.enum.dml import MSO_FILL
+
+        from pptx_mcp_server.server import pptx_add_responsive_card_row
+
+        cards = [
+            {"title": "A", "body": "a", "border_color": "CCCCCC", "border_width": 0.01},
+            {"title": "B", "body": "b", "border_color": "CCCCCC", "border_width": 0.01},
+        ]
+        out = pptx_add_responsive_card_row(
+            file_path=pptx_file,
+            slide_index=0,
+            cards=cards,
+            left=0.5,
+            top=0.5,
+            width=10.0,
+            max_height=3.0,
+            gap=0.2,
+            height_mode="max",
+            min_card_height=1.0,
+        )
+        # 成功レスポンス: JSON 形式、エラーは含まない
+        assert "INVALID_PARAMETER" not in out
+        parsed = json.loads(out)
+        assert parsed.get("ok") is True
+        assert len(parsed["result"]["cards"]) == 2
+
+        # 実ファイルを開いて最初の shape (card 0 の背景) の line 色を確認
+        prs = Presentation(pptx_file)
+        slide0 = prs.slides[0]
+        bg0 = list(slide0.shapes)[0]
+        assert bg0.line.fill.type == MSO_FILL.SOLID
+        assert bg0.line.color.rgb == RGBColor(0xCC, 0xCC, 0xCC)
+
+    def test_mcp_tool_rejects_unknown_key_still(self, pptx_file):
+        """``border_color`` と無関係のタイポは依然として拒否される
+        (strict-key validation の回帰防止)."""
+        from pptx_mcp_server.server import pptx_add_responsive_card_row
+
+        cards = [{"title": "A", "border_colorrr": "CCCCCC"}]
+        out = pptx_add_responsive_card_row(
+            file_path=pptx_file,
+            slide_index=0,
+            cards=cards,
+            left=0.5,
+            top=0.5,
+            width=10.0,
+            max_height=3.0,
+            gap=0.2,
+            height_mode="max",
+            min_card_height=1.0,
+        )
+        assert "INVALID_PARAMETER" in out or "unknown" in out


### PR DESCRIPTION
## Summary
- Add `border_color` (6-hex) and `border_width` (inches) optional fields to `CardSpec`.
- When both are set (non-empty color + positive width), the card background rectangle is drawn with an outlined stroke via `_add_shape(line_color=..., line_width=...)`. Otherwise the existing `no_line=True` behavior is preserved.
- `border_width` is in inches for consistency with other CardSpec dimensions; converted internally to points (×72) because `_add_shape.line_width` is Pt.
- Defensive: empty color OR non-positive width falls back to no-line.
- Strict-key validation in `server.py` already uses `fields(CardSpec)`, so new fields are auto-accepted without further changes.

## Test plan
- [x] `python -m pytest tests/test_cards.py -v` → 34 passed (6 new)
- [x] `python -m pytest` → 683 passed, 1 skipped (no regressions)
- [x] New tests cover: color+width→visible line (RGB match), default→no-line, width=0→no-line, empty color→no-line, MCP tool pass-through, strict unknown-key rejection

Closes #111

Generated with [Claude Code](https://claude.com/claude-code)