### PR TITLE
feat(theme): add 'ir' preset for Japanese corporate IR decks (closes #113)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,19 @@ and is only required when launching the `pptx-mcp-server` CLI / importing
 `tests/test_library_usage.py` enforces that, and
 `tests/test_packaging_extras.py` enforces the packaging side of the split.
 
+### Built-in themes
+
+`pptx_mcp_server.theme` ships four passive theme presets. Pick one by passing
+`"theme": "<name>"` in a slide/deck spec, or import the module constant
+directly (`MCKINSEY`, `DELOITTE`, `NEUTRAL`, `IR`):
+
+| Name | Description |
+|------|-------------|
+| `mckinsey` | McKinsey-inspired. Dark navy (`#051C2C`) primary + bright blue (`#2251FF`) accent on white. 16:9 widescreen (13.333x7.5"). |
+| `deloitte` | Deloitte-inspired. Navy (`#002776`) primary + green (`#81BC00`) accent with multi-color palette. 16:9 widescreen. |
+| `neutral` | Clean, universally safe. Dark gray (`#333333`) primary + soft blue (`#4A90D9`) accent. 16:9 widescreen. |
+| `ir` | Japanese corporate IR / quarterly-report style. Cream background (`#F8F9F5`), deep navy (`#0A2540`) primary + blue (`#1E3A8A`) accent. HD widescreen dimensions (20x11.25"). Yu Gothic east-asian font. |
+
 ### Supported scripts
 
 The auto-layout engine (`pptx_mcp_server.engine.text_metrics`) uses a

--- a/src/pptx_mcp_server/theme.py
+++ b/src/pptx_mcp_server/theme.py
@@ -1,8 +1,9 @@
 """
 Theme definitions for presentation styling.
 
-Provides a Theme dataclass, built-in themes (McKinsey, Deloitte, Neutral),
-a theme registry for lookup by name, and color utilities (tint/shade).
+Provides a Theme dataclass, built-in themes (``mckinsey``, ``deloitte``,
+``neutral``, ``ir``), a theme registry for lookup by name, and color
+utilities (tint/shade).
 """
 
 from __future__ import annotations
@@ -336,3 +337,77 @@ NEUTRAL = Theme(
     },
 )
 register_theme(NEUTRAL)
+
+
+# 日本の上場企業の IR (四半期決算) 資料向けプリセット。
+# クリーム色の背景 (#F8F9F5) とディープネイビー (#0A2540) を基調とし、
+# HD ワイド (20.0 x 11.25 インチ) で Yu Gothic を東アジア字形に固定する。
+IR = Theme(
+    name="ir",
+    colors={
+        "primary": "#0A2540",          # deep navy
+        "accent": "#1E3A8A",           # blue accent
+        "background": "#F8F9F5",       # cream
+        "text_primary": "#1A1A1A",
+        "text_secondary": "#6B7280",
+        "rule_strong": "#C0C0C0",
+        "rule_subtle": "#E0E0E0",
+        "highlight_row": "#F0F0F0",    # for data tables
+        "positive": "#059669",         # green for +% figures
+        "negative": "#DC2626",
+    },
+    fonts={
+        "title": "Arial",
+        "body": "Arial",
+        # 明示的に east-asian typeface を指定し、非 JP Windows での中国語
+        # フォントへの自動 fallback を防ぐ (issue #40)。
+        "east_asian": "Yu Gothic",
+    },
+    sizes={
+        "title": 28,
+        "subtitle": 14,
+        "body": 11,
+        "table": 10,
+        "caption": 9,
+        "footnote": 8,
+    },
+    slide={
+        "width": 20.0,   # HD widescreen (IR spec)
+        "height": 11.25,
+    },
+    margins={
+        "left": 1.0,
+        "right": 1.0,
+        "top": 0.6,
+    },
+    layout={
+        "title_top": 0.6,
+        "title_height": 0.8,
+        "divider_top": 1.7,
+        "body_top": 1.85,
+        "footer_top": 10.3,
+    },
+    table={
+        "header_bg": "background",
+        "header_fg": "text_primary",
+        "alt_row_bg": "highlight_row",
+        "border_color": "rule_subtle",
+        "no_vertical_borders": True,
+        "row_height": 0.5,
+        "border_width": 0.5,
+    },
+    chart_colors=[
+        "#1E3A8A",  # primary navy
+        "#3B82F6",  # lighter blue
+        "#059669",  # green
+        "#DC2626",  # red
+        "#6B7280",  # gray
+        "#C0C0C0",  # rule gray
+    ],
+    connector={
+        "color": "rule_strong",
+        "width": 1.0,
+        "arrow_end": "none",
+    },
+)
+register_theme(IR)

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 
 import pytest
 
-from pptx_mcp_server.theme import MCKINSEY, Theme, resolve_color
+import importlib
+
+from pptx_mcp_server.theme import IR, MCKINSEY, Theme, get_theme, list_themes, resolve_color
 
 
 class TestMcKinseyThemeStructure:
@@ -74,3 +76,53 @@ class TestResolveColor:
 
     def test_none_theme_passes_through(self):
         assert resolve_color(None, "#ABCDEF") == "#ABCDEF"
+
+
+class TestIRTheme:
+    """IR theme: クリーム背景 + ネイビーの和製コーポレート IR プリセット。"""
+
+    def test_get_theme_returns_ir(self):
+        theme = get_theme("ir")
+        assert theme is not None
+        assert theme is IR
+        # 必須色キーが揃っていること
+        expected_color_keys = {
+            "primary",
+            "accent",
+            "background",
+            "rule_strong",
+            "rule_subtle",
+            "highlight_row",
+            "positive",
+            "negative",
+            "text_primary",
+            "text_secondary",
+        }
+        assert expected_color_keys.issubset(theme.colors.keys())
+
+    def test_slide_dimensions_hd_widescreen(self):
+        # IR spec: 20.0 x 11.25 インチ (HD ワイド)。既定の 13.333 x 7.5 ではない。
+        assert IR.slide["width"] == 20.0
+        assert IR.slide["height"] == 11.25
+
+    def test_east_asian_font_is_yu_gothic(self):
+        assert IR.fonts["east_asian"] == "Yu Gothic"
+
+    def test_chart_colors_has_six_entries(self):
+        assert len(IR.chart_colors) == 6
+
+    def test_ir_in_list_themes(self):
+        assert "ir" in list_themes()
+
+    def test_registration_is_idempotent(self):
+        # theme.py を再 import しても重複登録されない (register_theme は上書き)。
+        before = len(list_themes())
+        import pptx_mcp_server.theme as theme_module
+
+        importlib.reload(theme_module)
+        # reload 後も "ir" は 1 回だけ登録されている。
+        from pptx_mcp_server.theme import list_themes as list_themes_reloaded
+
+        after = len(list_themes_reloaded())
+        assert after == before
+        assert list_themes_reloaded().count("ir") == 1


### PR DESCRIPTION
## Summary

- Add fourth built-in theme `ir` to `src/pptx_mcp_server/theme.py`, tuned for Japanese public-company IR / quarterly-report decks
- Cream background (`#F8F9F5`), deep navy (`#0A2540`) primary + blue (`#1E3A8A`) accent, Yu Gothic east-asian font, HD widescreen (20.0 x 11.25")
- Registered via `register_theme(IR)`; discoverable via `get_theme("ir")` / `list_themes()`
- Module-level docstring now enumerates all four presets (`mckinsey`, `deloitte`, `neutral`, `ir`)
- README gains a "Built-in themes" table listing the four presets

## Test plan

- [x] `python -m pytest tests/test_theme.py -v` → 20 passed (6 new `TestIRTheme` tests: expected color keys, slide dims, Yu Gothic font, 6-entry chart palette, `list_themes()` membership, reload idempotency)
- [x] `python -m pytest` full suite → 677 passed, 1 skipped

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)