### PR TITLE
feat(engine): add_data_table primitive for IR/consulting table layouts (closes #110)

### DIFF
--- a/src/pptx_mcp_server/engine/__init__.py
+++ b/src/pptx_mcp_server/engine/__init__.py
@@ -106,6 +106,10 @@ from .cards import (
     CardPlacement,
     add_responsive_card_row,
 )
+from .tables_grid import (
+    TableColumnSpec,
+    add_data_table,
+)
 
 __all__ = [
     # Layout constants
@@ -142,6 +146,8 @@ __all__ = [
     "FlexItem", "add_flex_container", "add_flex_container_file",
     # Cards
     "CardSpec", "CardHeightMode", "CardPlacement", "add_responsive_card_row",
+    # Data tables (textbox grid)
+    "TableColumnSpec", "add_data_table",
     # Rendering
     "render_slide", "render_slide_to_path",
 ]

--- a/src/pptx_mcp_server/engine/tables_grid.py
+++ b/src/pptx_mcp_server/engine/tables_grid.py
@@ -1,0 +1,321 @@
+"""データテーブルを textbox グリッドとして描画するプリミティブ.
+
+# 設計メモ
+
+IR / コンサルの資料で多用される「数値が並ぶ密なテーブル」は、python-pptx の
+``Table`` オブジェクトでは表現しづらい。既定の枠線、セル幅・alignment の
+制御しにくさが理由である。そこで本モジュールは ``Table`` オブジェクトを使わ
+ず、各セルを個別の **textbox** として並べる grid layout を提供する。
+
+主な機能:
+    - ヘッダー行 / データ行を 1 セル = 1 textbox で描画する。
+    - alt-row (縞模様) の背景シェーディング。
+    - 特定 1 行のハイライトシェーディング (alt-row より優先)。
+    - 行間・ヘッダー直下のヘアライン罫線 (< 0.02" の細長い矩形として描画)。
+    - 列幅は呼び出し側で合計幅と整合させる。合計が ``width`` と一致しない
+      場合は比例スケーリングで揃える (呼び出し側の意図を殺さないよう、
+      ``EngineError`` は出さず黙って調整する)。
+
+設計判断:
+    - python-pptx ``Table`` は使わない (枠線・alignment の制御が不足)。
+    - 各セルは ``add_auto_fit_textbox`` を ``wrap=False`` で呼び出し、セル幅
+      からはみ出す場合は末尾を省略記号で切り詰める。
+    - 背景シェーディングは textbox より **先に** 追加することで、確実に
+      textbox の背後 (z-order 下) に置かれる。
+    - 列幅合計不一致は ``(width / sum(column.width))`` のスケーリング係数で
+      各列幅に掛けて強制一致させる (#110)。
+
+Issue: #110
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from typing import Any, Literal
+
+from .pptx_io import EngineError, ErrorCode
+from .shapes import _add_shape, add_auto_fit_textbox
+
+
+# ヘアライン罫線の既定厚 (inches)。< 0.02" は PowerPoint / LibreOffice の
+# 描画エンジンで 1 px 相当にクランプされることが多く、意図した細線となる。
+_HAIRLINE_THICKNESS: float = 0.01
+
+
+@dataclass
+class TableColumnSpec:
+    """テーブルの 1 列の仕様.
+
+    Attributes:
+        header: ヘッダーセルに表示する文字列。
+        align: データセルの水平方向 alignment。"left" | "center" | "right"。
+        width: 列幅 (inches)。合計が ``add_data_table`` の ``width`` と一致
+            しない場合は比例スケーリングで揃えられる。
+        font_size_pt: データセルの開始 font size (pt)。auto-fit で縮小され得る。
+        header_bold: ヘッダー文字を太字にするか。
+        header_font_size_pt: ヘッダーの開始 font size (pt)。
+        value_color: データセルの文字色 (6 桁 hex、``#`` なし)。
+        header_color: ヘッダーの文字色 (6 桁 hex)。
+    """
+
+    header: str
+    align: Literal["left", "center", "right"] = "left"
+    width: float = 1.5
+    font_size_pt: float = 10
+    header_bold: bool = True
+    header_font_size_pt: float = 10
+    value_color: str = "333333"
+    header_color: str = "6B7280"
+
+
+def _scale_column_widths(
+    columns: list[TableColumnSpec],
+    total_width: float,
+) -> list[float]:
+    """列幅の合計を ``total_width`` に強制一致させる.
+
+    呼び出し側の列幅比を保ったまま、合計が ``total_width`` となるよう
+    スケーリング係数を掛ける。いずれかの列幅が非正の場合は
+    ``INVALID_PARAMETER`` を投げる。
+    """
+    for i, c in enumerate(columns):
+        if c.width <= 0:
+            raise EngineError(
+                ErrorCode.INVALID_PARAMETER,
+                f"columns[{i}].width must be > 0, got {c.width}",
+            )
+    raw_sum = sum(c.width for c in columns)
+    if raw_sum <= 0:
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            "columns widths sum must be > 0",
+        )
+    factor = total_width / raw_sum
+    return [c.width * factor for c in columns]
+
+
+def _stringify(value: Any) -> str:
+    """セル値を表示用文字列に変換する.
+
+    None は空文字列、その他は ``str()`` に委譲する。float の表記整形は呼び
+    出し側の責務とする (本モジュールでは何も format しない)。
+    """
+    if value is None:
+        return ""
+    return str(value)
+
+
+def add_data_table(
+    slide,
+    rows: list[list[Any]],
+    columns: list[TableColumnSpec],
+    *,
+    left: float,
+    top: float,
+    width: float,
+    row_height: float = 0.35,
+    header_height: float = 0.4,
+    alt_row_color: str | None = None,
+    highlight_row_index: int | None = None,
+    highlight_color: str = "F0F0F0",
+    rule_color: str | None = "E0E0E0",
+    rule_thickness: float = _HAIRLINE_THICKNESS,
+    header_rule: bool = True,
+    font_name: str = "Arial",
+) -> dict:
+    """行 × 列の grid として ``rows`` を描画する.
+
+    各セルは個別の textbox として配置される (python-pptx の ``Table``
+    オブジェクトは使わない)。alt-row シェーディング、ハイライト行、ヘア
+    ライン罫線を組み合わせて IR / コンサル資料向けの密なテーブルを
+    表現する。
+
+    Args:
+        slide: 描画対象の python-pptx スライドオブジェクト。
+        rows: データ行のリスト。各行は ``len(columns)`` 個の値を持つ必要
+            がある。値は ``str`` / ``int`` / ``float`` / ``None`` 等、``str()``
+            で文字列化できる任意の型。
+        columns: 列仕様のリスト。header, align, width 等を定義する。
+        left: テーブル左端 x 座標 (inches)。
+        top: テーブル上端 y 座標 (inches)。
+        width: テーブル全幅 (inches)。列幅の合計はこの値に比例スケーリング
+            される (呼び出し側の列幅比は保持される)。
+        row_height: データ行 1 行の高さ (inches)。
+        header_height: ヘッダー行の高さ (inches)。
+        alt_row_color: 偶数 index (0-indexed で 1, 3, 5...) 行の背景色。None
+            でシェーディング無効。
+        highlight_row_index: ハイライト 1 行の index (0-indexed、データ行
+            基準)。None で無効。alt-row と重なる場合はハイライトが優先。
+        highlight_color: ハイライト行の背景色 (6 桁 hex)。
+        rule_color: 行間 / ヘッダー下の罫線色。None で罫線無効。
+        rule_thickness: 罫線の太さ (inches)。既定 0.01" はヘアライン相当。
+        header_rule: ヘッダーとデータ行の間に罫線を引くか。
+        font_name: セルのフォント名。
+
+    Returns:
+        dict: ``{"consumed_height": float, "header_y_bottom": float,
+        "shape_count": int}``。``consumed_height`` はテーブル全体の占有高、
+        ``header_y_bottom`` はヘッダー行の下端 y 座標、``shape_count`` は
+        追加された shape 数。
+
+    Raises:
+        EngineError: 各行の長さが ``len(columns)`` と一致しない、列幅が
+            非正、``highlight_row_index`` が範囲外などの場合
+            (``INVALID_PARAMETER``)。
+    """
+    # ── 入力検証 ─────────────────────────────────────────
+    if not columns:
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            "columns must be a non-empty list",
+        )
+    if width <= 0 or row_height <= 0 or header_height <= 0:
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            "width, row_height, header_height must all be > 0",
+        )
+
+    n_cols = len(columns)
+    for ri, row in enumerate(rows):
+        if len(row) != n_cols:
+            raise EngineError(
+                ErrorCode.INVALID_PARAMETER,
+                (
+                    f"rows[{ri}] has {len(row)} values, but columns has "
+                    f"{n_cols} entries"
+                ),
+            )
+
+    if highlight_row_index is not None:
+        if highlight_row_index < 0 or highlight_row_index >= len(rows):
+            raise EngineError(
+                ErrorCode.INVALID_PARAMETER,
+                (
+                    f"highlight_row_index {highlight_row_index} out of range "
+                    f"(rows has {len(rows)} entries)"
+                ),
+            )
+
+    # ── 列幅のスケーリング ──────────────────────────────
+    scaled_widths = _scale_column_widths(columns, width)
+
+    shape_count_before = len(slide.shapes)
+
+    # ── 1) 背景シェーディング (alt-row / highlight) ────
+    # テキストセルより **先** に追加することで z-order で背後に置く。
+    data_top = top + header_height
+    for ri in range(len(rows)):
+        row_top = data_top + ri * row_height
+        fill: str | None = None
+        # alt-row: 1, 3, 5, ... 行目 (0-indexed で奇数)
+        if alt_row_color and ri % 2 == 1:
+            fill = alt_row_color
+        # highlight: 指定行は alt-row より優先
+        if highlight_row_index is not None and ri == highlight_row_index:
+            fill = highlight_color
+        if fill is not None:
+            _add_shape(
+                slide,
+                "rectangle",
+                left,
+                row_top,
+                width,
+                row_height,
+                fill_color=fill,
+                no_line=True,
+            )
+
+    # ── 2) ヘッダー罫線 / 行間罫線 ──────────────────────
+    if rule_color is not None:
+        # ヘッダー直下
+        if header_rule:
+            _add_shape(
+                slide,
+                "rectangle",
+                left,
+                top + header_height - rule_thickness / 2,
+                width,
+                rule_thickness,
+                fill_color=rule_color,
+                no_line=True,
+            )
+        # 各データ行の下端 (最終行を含む)
+        for ri in range(len(rows)):
+            rule_y = data_top + (ri + 1) * row_height - rule_thickness / 2
+            _add_shape(
+                slide,
+                "rectangle",
+                left,
+                rule_y,
+                width,
+                rule_thickness,
+                fill_color=rule_color,
+                no_line=True,
+            )
+
+    # ── 3) ヘッダーセル ─────────────────────────────────
+    col_x: list[float] = []
+    x_cursor = left
+    for w in scaled_widths:
+        col_x.append(x_cursor)
+        x_cursor += w
+
+    for ci, col in enumerate(columns):
+        add_auto_fit_textbox(
+            slide,
+            col.header,
+            col_x[ci],
+            top,
+            scaled_widths[ci],
+            header_height,
+            font_name=font_name,
+            font_size_pt=col.header_font_size_pt,
+            min_size_pt=max(6.0, col.header_font_size_pt - 3.0),
+            bold=col.header_bold,
+            color_hex=col.header_color,
+            align=col.align,
+            vertical_anchor="middle",
+            wrap=False,
+            truncate_with_ellipsis=True,
+        )
+
+    # ── 4) データセル ───────────────────────────────────
+    for ri, row in enumerate(rows):
+        row_top = data_top + ri * row_height
+        for ci, value in enumerate(row):
+            col = columns[ci]
+            add_auto_fit_textbox(
+                slide,
+                _stringify(value),
+                col_x[ci],
+                row_top,
+                scaled_widths[ci],
+                row_height,
+                font_name=font_name,
+                font_size_pt=col.font_size_pt,
+                min_size_pt=max(6.0, col.font_size_pt - 3.0),
+                bold=False,
+                color_hex=col.value_color,
+                align=col.align,
+                vertical_anchor="middle",
+                wrap=False,
+                truncate_with_ellipsis=True,
+            )
+
+    # ── 返り値 ─────────────────────────────────────────
+    consumed_height = header_height + row_height * len(rows)
+    # 行が空でも ``header_rule`` が有効ならその厚みだけ余計に占有する
+    # (レイアウト呼び出し側が次要素の y を決めるとき、罫線までを含めた
+    # 下端が欲しいケースが多いため算入する)。
+    if not rows and header_rule and rule_color is not None:
+        consumed_height += rule_thickness
+
+    return {
+        "consumed_height": consumed_height,
+        "header_y_bottom": top + header_height,
+        "shape_count": len(slide.shapes) - shape_count_before,
+    }
+
+
+# 公開キー (server.py の strict validation で使う)
+TABLE_COLUMN_SPEC_KEYS: frozenset[str] = frozenset(f.name for f in fields(TableColumnSpec))

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -106,6 +106,8 @@ from .engine import (
     check_deck_extended,
     CardSpec,
     add_responsive_card_row,
+    TableColumnSpec,
+    add_data_table,
 )
 from .engine.pptx_io import open_pptx, save_pptx, _get_slide
 
@@ -859,6 +861,128 @@ def pptx_add_responsive_card_row(
 
         render_info = _auto_render(file_path, slide_index)
         # result は既に richer dict — auto-render の結果を同じ dict にマージ。
+        if render_info.get("rendered"):
+            result["preview_path"] = render_info.get("preview_path")
+        elif render_info.get("reason") != "disabled":
+            result["render_warning"] = render_info
+        return _success(result)
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def pptx_add_data_table(
+    file_path: str,
+    slide_index: int,
+    rows: List[List[Any]],
+    columns: List[Dict[str, Any]],
+    left: float,
+    top: float,
+    width: float,
+    row_height: float = 0.35,
+    header_height: float = 0.4,
+    alt_row_color: Optional[str] = None,
+    highlight_row_index: Optional[int] = None,
+    highlight_color: str = "F0F0F0",
+    rule_color: Optional[str] = "E0E0E0",
+    rule_thickness: float = 0.01,
+    header_rule: bool = True,
+    font_name: str = "Arial",
+) -> str:
+    """Add a financial/dense data table rendered as a textbox grid (NOT python-pptx Table).
+
+    For IR / consulting decks where python-pptx's ``Table`` object is too
+    opinionated (default borders, rigid alignment). Lays out each cell as an
+    individual textbox, with optional alt-row shading, highlight row, and
+    hairline horizontal rules.
+
+    ``rows``: list of rows; each row is a list of values (``str``/``int``/
+    ``float``/``None``, stringified via ``str()``). Length must match
+    ``len(columns)``.
+
+    ``columns``: list of column spec dicts with keys (all optional except ``header``):
+      - ``header`` (str, required): column header text
+      - ``align`` ("left" | "center" | "right", default "left")
+      - ``width`` (float, default 1.5): relative column width — auto-scaled to total ``width``
+      - ``font_size_pt`` (float, default 10)
+      - ``header_bold`` (bool, default True)
+      - ``header_font_size_pt`` (float, default 10)
+      - ``value_color`` (hex, default "333333")
+      - ``header_color`` (hex, default "6B7280")
+
+    Column widths are proportionally scaled so their sum matches ``width``.
+
+    Returns: ``{"consumed_height": float, "header_y_bottom": float, "shape_count": int}``.
+    """
+    try:
+        if not isinstance(rows, list):
+            return _error(
+                "INVALID_PARAMETER",
+                "rows must be a list of lists.",
+                parameter="rows",
+                hint="Pass e.g. [[\"AAPL\", 189.2], [\"MSFT\", 412.0]].",
+                issue=110,
+            )
+        if not isinstance(columns, list) or not columns:
+            return _error(
+                "INVALID_PARAMETER",
+                "columns must be a non-empty list of dicts.",
+                parameter="columns",
+                hint="Pass e.g. [{\"header\":\"Ticker\"},{\"header\":\"Price\",\"align\":\"right\"}].",
+                issue=110,
+            )
+
+        # ColumnSpec 未知キーは strict rejection (cards.py と同じポリシー)。
+        _col_known_keys = {f.name for f in fields(TableColumnSpec)}
+        for i, spec in enumerate(columns):
+            if not isinstance(spec, dict):
+                raise EngineError(
+                    ErrorCode.INVALID_PARAMETER,
+                    f"columns[{i}]: must be a dict, got {type(spec).__name__}.",
+                )
+            if "header" not in spec:
+                raise EngineError(
+                    ErrorCode.INVALID_PARAMETER,
+                    f"columns[{i}]: missing required key 'header'.",
+                )
+            unknown = set(spec.keys()) - _col_known_keys
+            if unknown:
+                raise EngineError(
+                    ErrorCode.INVALID_PARAMETER,
+                    (
+                        f"columns[{i}]: unknown keys {sorted(unknown)}; "
+                        f"known keys: {sorted(_col_known_keys)}."
+                    ),
+                )
+
+        column_objs = [TableColumnSpec(**d) for d in columns]
+
+        prs = open_pptx(file_path)
+        slide = _get_slide(prs, slide_index)
+
+        result = add_data_table(
+            slide,
+            rows,
+            column_objs,
+            left=left,
+            top=top,
+            width=width,
+            row_height=row_height,
+            header_height=header_height,
+            alt_row_color=alt_row_color,
+            highlight_row_index=highlight_row_index,
+            highlight_color=highlight_color,
+            rule_color=rule_color,
+            rule_thickness=rule_thickness,
+            header_rule=header_rule,
+            font_name=font_name,
+        )
+
+        # save 前に return 値構築が終わっているため、以降の save 失敗で
+        # 中途半端な状態にならない (#34 と同じポリシー)。
+        save_pptx(prs, file_path)
+
+        render_info = _auto_render(file_path, slide_index)
         if render_info.get("rendered"):
             result["preview_path"] = render_info.get("preview_path")
         elif render_info.get("reason") != "disabled":

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -1,0 +1,214 @@
+"""データテーブル (textbox grid) プリミティブのテスト.
+
+``add_data_table`` の shape 数・alt-row / highlight 背景・alignment・
+入力検証・空行時の consumed_height を検証する。Issue #110。
+"""
+
+from __future__ import annotations
+
+import pytest
+from pptx.enum.shapes import MSO_SHAPE_TYPE
+from pptx.enum.text import PP_ALIGN
+
+from pptx_mcp_server.engine.pptx_io import EngineError, ErrorCode
+from pptx_mcp_server.engine.tables_grid import (
+    TableColumnSpec,
+    add_data_table,
+)
+
+
+def _count_auto_shapes(slide) -> int:
+    return sum(1 for s in slide.shapes if s.shape_type == MSO_SHAPE_TYPE.AUTO_SHAPE)
+
+
+def _count_textboxes(slide) -> int:
+    return sum(
+        1 for s in slide.shapes if s.shape_type == MSO_SHAPE_TYPE.TEXT_BOX
+    )
+
+
+def test_basic_3x4_grid_shape_count(slide):
+    """基本: 4 列 × 3 行 (+ ヘッダー行) のテーブルが期待通りの shape 数を生成する.
+
+    期待内訳:
+        - 4 ヘッダー textbox
+        - 12 データセル textbox (3 行 × 4 列)
+        - 4 罫線 (ヘッダー下 1 + データ行下 3)、alt-row・highlight は無効
+    合計 textbox 16、罫線 (auto_shape) 4。
+    """
+    columns = [
+        TableColumnSpec(header="Ticker", align="left", width=1.0),
+        TableColumnSpec(header="Name", align="left", width=2.0),
+        TableColumnSpec(header="Price", align="right", width=1.0),
+        TableColumnSpec(header="YoY", align="right", width=1.0),
+    ]
+    rows = [
+        ["AAPL", "Apple Inc.", 189.2, "+12.3%"],
+        ["MSFT", "Microsoft", 412.0, "+8.1%"],
+        ["GOOG", "Alphabet", 178.5, "+15.4%"],
+    ]
+
+    result = add_data_table(
+        slide, rows, columns,
+        left=0.5, top=1.0, width=6.0,
+        alt_row_color=None,
+        highlight_row_index=None,
+    )
+
+    assert _count_textboxes(slide) == 16
+    # 罫線: ヘッダー下 + 3 データ行下
+    assert _count_auto_shapes(slide) == 4
+    assert result["shape_count"] == 20
+    assert result["header_y_bottom"] == pytest.approx(1.4, abs=1e-6)
+    assert result["consumed_height"] == pytest.approx(0.4 + 3 * 0.35, abs=1e-6)
+
+
+def test_alt_row_color_adds_background_rectangles(slide):
+    """alt_row_color 指定で、奇数 index 行の背景シェーディングが追加される.
+
+    4 行データ → index 1, 3 の 2 行がシェーディング。既定罫線 (4 + 1) も
+    合わせて auto_shape 数を検証する。
+    """
+    columns = [
+        TableColumnSpec(header="A", width=1.0),
+        TableColumnSpec(header="B", width=1.0),
+    ]
+    rows = [
+        ["a0", "b0"],
+        ["a1", "b1"],
+        ["a2", "b2"],
+        ["a3", "b3"],
+    ]
+    add_data_table(
+        slide, rows, columns,
+        left=0.5, top=1.0, width=2.0,
+        alt_row_color="F8F8F5",
+    )
+
+    # alt-row (2) + 罫線 (1 ヘッダー + 4 行下) = 7 auto_shape
+    assert _count_auto_shapes(slide) == 7
+    # textbox: 2 ヘッダー + 8 データ = 10
+    assert _count_textboxes(slide) == 10
+
+
+def test_highlight_row_adds_one_extra_rectangle(slide):
+    """highlight_row_index=2 で 1 行分のハイライト矩形が追加される.
+
+    alt-row 無効時、ハイライトの背景矩形 1 枚 + 罫線のみ。
+    """
+    columns = [TableColumnSpec(header="X", width=1.0)]
+    rows = [["v0"], ["v1"], ["v2"], ["v3"]]
+    add_data_table(
+        slide, rows, columns,
+        left=0.5, top=1.0, width=1.0,
+        highlight_row_index=2,
+    )
+
+    # highlight (1) + 罫線 (1 ヘッダー + 4 行下) = 6 auto_shape
+    assert _count_auto_shapes(slide) == 6
+
+
+def test_numeric_column_right_aligned(slide):
+    """右揃え指定の列はヘッダー・データとも paragraph alignment が RIGHT になる."""
+    columns = [
+        TableColumnSpec(header="Ticker", align="left", width=1.0),
+        TableColumnSpec(header="Price", align="right", width=1.0),
+    ]
+    rows = [["AAPL", 189.2]]
+    add_data_table(
+        slide, rows, columns,
+        left=0.5, top=1.0, width=2.0,
+        alt_row_color=None,
+        rule_color=None,  # 罫線を無効化して shape 数を絞る
+    )
+
+    # 罫線を無効化したので textbox 4 枚のみ:
+    #   [header0-left, header1-right, cell00-left, cell01-right]
+    textboxes = [
+        s for s in slide.shapes if s.shape_type == MSO_SHAPE_TYPE.TEXT_BOX
+    ]
+    assert len(textboxes) == 4
+
+    # 右揃え: index 1 (header), 3 (data cell)
+    assert textboxes[1].text_frame.paragraphs[0].alignment == PP_ALIGN.RIGHT
+    assert textboxes[3].text_frame.paragraphs[0].alignment == PP_ALIGN.RIGHT
+    # 左揃え: index 0, 2
+    assert textboxes[0].text_frame.paragraphs[0].alignment == PP_ALIGN.LEFT
+    assert textboxes[2].text_frame.paragraphs[0].alignment == PP_ALIGN.LEFT
+
+
+def test_mismatched_row_length_raises(slide):
+    """行長が列数と一致しない場合 INVALID_PARAMETER を投げる."""
+    columns = [
+        TableColumnSpec(header="A", width=1.0),
+        TableColumnSpec(header="B", width=1.0),
+    ]
+    rows = [["only-one-value"]]  # 列数 2 に対して 1 要素のみ
+    with pytest.raises(EngineError) as ei:
+        add_data_table(
+            slide, rows, columns,
+            left=0.5, top=1.0, width=2.0,
+        )
+    assert ei.value.code == ErrorCode.INVALID_PARAMETER
+
+
+def test_column_widths_proportionally_scaled(slide):
+    """列幅合計が ``width`` と一致しない場合、比例スケーリングで強制一致する.
+
+    列幅 [2, 2, 2] (合計 6)、``width=3`` を指定した場合、各列幅は 1.0 に
+    スケールされる。ヘッダー textbox の left 座標で検証する。
+    """
+    columns = [
+        TableColumnSpec(header="A", width=2.0),
+        TableColumnSpec(header="B", width=2.0),
+        TableColumnSpec(header="C", width=2.0),
+    ]
+    rows: list[list[str]] = []
+    add_data_table(
+        slide, rows, columns,
+        left=0.5, top=1.0, width=3.0,
+        rule_color=None,
+    )
+
+    # ヘッダー textbox 3 枚、left 座標を確認
+    textboxes = [
+        s for s in slide.shapes if s.shape_type == MSO_SHAPE_TYPE.TEXT_BOX
+    ]
+    assert len(textboxes) == 3
+    EMU = 914400
+    lefts = [tb.left / EMU for tb in textboxes]
+    # 0.5, 1.5, 2.5 と等間隔 (1.0" 幅) に並ぶ
+    assert lefts[0] == pytest.approx(0.5, abs=1e-3)
+    assert lefts[1] == pytest.approx(1.5, abs=1e-3)
+    assert lefts[2] == pytest.approx(2.5, abs=1e-3)
+
+
+def test_empty_rows_returns_header_height_plus_rule(slide):
+    """rows が空のとき consumed_height は ``header_height + rule_thickness`` となる.
+
+    header_rule が有効 (既定) の場合、ヘッダー下罫線の厚みを consumed に
+    算入する契約。これにより caller は次要素 y を ``top + consumed_height``
+    として安全に計算できる。
+    """
+    columns = [TableColumnSpec(header="H", width=1.0)]
+    result = add_data_table(
+        slide, [], columns,
+        left=0.5, top=1.0, width=1.0,
+        header_height=0.4,
+        rule_thickness=0.01,
+    )
+    # 0.4 (header) + 0.01 (header rule) = 0.41
+    assert result["consumed_height"] == pytest.approx(0.41, abs=1e-6)
+    assert result["header_y_bottom"] == pytest.approx(1.4, abs=1e-6)
+
+
+def test_highlight_row_out_of_range_raises(slide):
+    """highlight_row_index が rows の範囲外なら INVALID_PARAMETER."""
+    columns = [TableColumnSpec(header="X", width=1.0)]
+    with pytest.raises(EngineError) as ei:
+        add_data_table(
+            slide, [["a"], ["b"]], columns,
+            left=0.5, top=1.0, width=1.0,
+            highlight_row_index=5,
+        )
+    assert ei.value.code == ErrorCode.INVALID_PARAMETER


### PR DESCRIPTION
## Summary
- New textbox-grid `add_data_table` primitive in `engine/tables_grid.py` (distinct from `engine/tables.py` which wraps python-pptx `Table`). Each cell is an individual auto-fit textbox, enabling alt-row shading, highlight row, and hairline horizontal rules — the style used by IR/consulting decks.
- `pptx_add_data_table` MCP tool with strict-key validation (rejects unknown `TableColumnSpec` keys, requires `header`).
- 8 tests in `tests/test_data_table.py`.

## Design decisions (underspecified in issue)
- **Column widths**: proportionally scaled to match total `width`, not strict-match. Preserves caller's relative-width intent without raising on sum drift.
- **Rules**: single hairline thickness (0.01") for both header rule and per-row rules. Renders as 1 px in PPTX/LibreOffice. Simpler than dual-weight.
- **Empty rows + `header_rule`**: `consumed_height = header_height + rule_thickness` so callers can chain y-positions safely.
- **Stringification**: `None` → `""`, all other values → `str(value)`. Numeric formatting is caller responsibility (issue explicitly excluded per-cell formatting).

## Test plan
- [x] `pytest tests/test_data_table.py -v` — 8/8 passing
- [x] `pytest` — 679 passed, 1 skipped (no regressions vs. prior 685; delta is from timeline/IR-theme branches not in this PR)
- [x] MCP tool registered: 38 tools total (was 37)

Closes #110.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>