### PR TITLE
feat(timeline): add_milestone_timeline primitive for IR growth charts

### DIFF
--- a/src/pptx_mcp_server/engine/__init__.py
+++ b/src/pptx_mcp_server/engine/__init__.py
@@ -110,6 +110,11 @@ from .tables_grid import (
     TableColumnSpec,
     add_data_table,
 )
+from .timeline import (
+    TimelinePhase,
+    TimelineMilestone,
+    add_milestone_timeline,
+)
 
 __all__ = [
     # Layout constants
@@ -148,6 +153,8 @@ __all__ = [
     "CardSpec", "CardHeightMode", "CardPlacement", "add_responsive_card_row",
     # Data tables (textbox grid)
     "TableColumnSpec", "add_data_table",
+    # Timeline
+    "TimelinePhase", "TimelineMilestone", "add_milestone_timeline",
     # Rendering
     "render_slide", "render_slide_to_path",
 ]

--- a/src/pptx_mcp_server/engine/timeline.py
+++ b/src/pptx_mcp_server/engine/timeline.py
@@ -1,0 +1,514 @@
+"""マイルストーン・タイムラインプリミティブ.
+
+IR デッキの成長ストーリースライドで頻出する「フェーズ帯 + 垂直ルール +
+年次マイルストーン注記」の構図を、既存チャート領域の上に重ねて描画する
+プリミティブである。呼び出し元は別途チャートを配置し、その ``chart_top``
+および ``chart_bottom`` を本関数に渡すことで、フェーズ境界線とマイルストー
+ン・ルールを同じ垂直レンジに整列させる。
+
+# 設計メモ
+- フェーズ帯は ``add_flex_container`` の ``direction="row"`` + N 個の均等
+  ``grow=1`` 項目で構成する。帯内の各項目は「index_label (小) + label
+  (太字) + year_range (小)」の 3 ブロックを縦積みで描画する。
+- フェーズ境界ルール (``N-1`` 本) はフェーズ帯の下端から ``chart_bottom``
+  まで垂直に伸びる極細矩形である。``width = 0.01"`` で描く (dashed line
+  はサポート対象外; 要件は「視覚的に罫線として機能する」こと)。
+- マイルストーン・ルールは、各マイルストーンの ``x_pos`` (0.0-1.0) を
+  ``left + x_pos * width`` に変換し、フェーズ帯の下端から ``chart_bottom
+  - 1.5"`` (primary) まで垂直に伸ばす。ルール直上にテキストボックスを
+  置き、``year`` (太字・大) と ``label`` (細・小) を上下に並べる。
+- マイルストーン帯の座標系はチャート領域 (``left`` ~ ``left + width``) を
+  ``[0, 1]`` に射影したものである。チャート・データ点そのものの x 座標は
+  caller が別途計測して渡す前提 (MVP では shape ツリーから chart data を
+  取得できないため)。
+
+# 本関数のスコープ外
+- ダッシュライン描画 (視覚的にはソリッド極細罫線で代替する)。
+- x_pos のフェーズ境界との衝突解消 (caller 責任。本関数はマイルストーン
+  ルールを境界上に重ねても警告しない)。
+- チャート・データ点の自動抽出 (x_pos は caller が 0.0-1.0 で渡す)。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .pptx_io import EngineError, ErrorCode
+from .shapes import _add_shape, add_auto_fit_textbox
+
+
+# マイルストーン帯のスタイル → 文字色・太字・ルール色のマッピング。
+# primary はナビー基調で IR 資料の主要イベント (IPO 等) を強調する想定。
+# secondary はグレー基調で補助イベント (プロダクトローンチ等) 向け。
+_STYLE_PRIMARY_COLOR: str = "051C2C"   # navy
+_STYLE_SECONDARY_COLOR: str = "666666"  # mid gray
+
+# フェーズ帯内部レイアウト。index_label・label・year_range の 3 ブロック
+# を縦積みにする。各ブロックの高さ比率はフェーズ帯全体 (``phase_band_height``)
+# を基準に算出する。
+_PHASE_INDEX_HEIGHT_RATIO: float = 0.25
+_PHASE_LABEL_HEIGHT_RATIO: float = 0.45
+_PHASE_YEAR_HEIGHT_RATIO: float = 0.30
+
+# 垂直ルールの幅 (inches)。PowerPoint では 0.01" 程度が hairline 相当。
+_RULE_WIDTH: float = 0.01
+
+# マイルストーン・ルールの下端余白 (primary スタイル)。チャート底ではなく
+# 少し内側で止めることで、caller が配置したチャート・データ点と被せ過ぎ
+# ないようにする。
+_PRIMARY_RULE_BOTTOM_MARGIN: float = 1.5
+# secondary スタイルはやや短め (caller のチャート枠下側を大きく空ける)。
+_SECONDARY_RULE_BOTTOM_MARGIN: float = 2.0
+
+# マイルストーンラベル矩形の高さ (inches)。
+_MILESTONE_LABEL_HEIGHT: float = 0.7
+# マイルストーンラベルはルールの真上に中央揃えで配置する。幅はこの定数で
+# 左右対称に広げる (画面内に収まらない極端な x_pos には caller が責任を持つ)。
+_MILESTONE_LABEL_HALF_WIDTH: float = 0.9
+
+
+@dataclass
+class TimelinePhase:
+    """タイムラインの 1 フェーズ.
+
+    Attributes:
+        label: フェーズ名 (例: ``"事業基盤の確立"``)。
+        index_label: フェーズ番号などの短い ID 文字列 (例: ``"01"``)。
+        year_range: 期間表記 (例: ``"2012 — 2016"``)。
+    """
+
+    label: str
+    index_label: str
+    year_range: str
+
+
+@dataclass
+class TimelineMilestone:
+    """タイムライン上の 1 マイルストーン.
+
+    Attributes:
+        x_pos: チャート領域の幅を ``[0.0, 1.0]`` に正規化した水平位置。
+        year: 年次表記 (例: ``"2016"``)。
+        label: イベント説明 (改行可。例: ``"IPO\\n東証マザーズ上場"``)。
+        style: ``"primary"`` (ナビー基調) または ``"secondary"`` (グレー基調)。
+    """
+
+    x_pos: float
+    year: str
+    label: str
+    style: str = "primary"
+
+
+def _style_color(style: str) -> str:
+    if style == "primary":
+        return _STYLE_PRIMARY_COLOR
+    if style == "secondary":
+        return _STYLE_SECONDARY_COLOR
+    raise EngineError(
+        ErrorCode.INVALID_PARAMETER,
+        f"Unknown milestone style {style!r}; expected 'primary' or 'secondary'.",
+    )
+
+
+def _style_rule_bottom_margin(style: str) -> float:
+    if style == "primary":
+        return _PRIMARY_RULE_BOTTOM_MARGIN
+    return _SECONDARY_RULE_BOTTOM_MARGIN
+
+
+def _validate_inputs(
+    phases: list[TimelinePhase],
+    milestones: list[TimelineMilestone],
+    *,
+    left: float,
+    top: float,
+    width: float,
+    phase_band_height: float,
+    chart_top: float,
+    chart_bottom: float,
+) -> None:
+    """入力パラメタをまとめて検証する.
+
+    caller のロジックバグをサイレントにスライド外配置へ落とさないよう、
+    エントリポイントで失敗シグナルを返す。
+
+    Raises:
+        EngineError: 下記のいずれかに該当するとき (``INVALID_PARAMETER``)。
+            - ``chart_top >= chart_bottom``
+            - ``width``・``phase_band_height`` が負
+            - ``milestone.x_pos`` が ``[0.0, 1.0]`` を外れる
+            - ``milestone.style`` が ``'primary'``・``'secondary'`` 以外
+    """
+    if width < 0:
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            f"width={width:.2f} must be >= 0.",
+        )
+    if phase_band_height < 0:
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            f"phase_band_height={phase_band_height:.2f} must be >= 0.",
+        )
+    if chart_top >= chart_bottom:
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            (
+                f"chart_top={chart_top:.2f} must be < "
+                f"chart_bottom={chart_bottom:.2f}."
+            ),
+        )
+    for i, m in enumerate(milestones):
+        if not (0.0 <= m.x_pos <= 1.0):
+            raise EngineError(
+                ErrorCode.INVALID_PARAMETER,
+                (
+                    f"milestones[{i}]: x_pos={m.x_pos:.3f} must be in "
+                    "[0.0, 1.0] (relative to chart area)."
+                ),
+            )
+        if m.style not in ("primary", "secondary"):
+            raise EngineError(
+                ErrorCode.INVALID_PARAMETER,
+                (
+                    f"milestones[{i}]: style={m.style!r} must be "
+                    "'primary' or 'secondary'."
+                ),
+            )
+
+
+def _render_phase_band(
+    slide,
+    phases: list[TimelinePhase],
+    *,
+    left: float,
+    top: float,
+    width: float,
+    phase_band_height: float,
+) -> tuple[list[dict], list[float]]:
+    """フェーズ帯を描画し、各フェーズの右端 x 座標 (境界候補) を返す.
+
+    戻り値:
+        - phase_shapes: 各フェーズについて ``{"shape_index", "actual_font_size"}``
+          の 3 ブロック (index・label・year_range) を追加順に記録。
+        - right_edges: len(phases) 個の x 座標。最後の要素はフェーズ帯の
+          右端で、境界ルールの描画対象ではない (``right_edges[:-1]`` が
+          inter-phase 境界に対応する)。
+    """
+    phase_shapes: list[dict] = []
+    right_edges: list[float] = []
+
+    n = len(phases)
+    if n == 0 or phase_band_height <= 0 or width <= 0:
+        return phase_shapes, right_edges
+
+    # 均等幅: gap は設けず、隣接フェーズは境界ルールで分離する想定。
+    cell_w = width / n
+
+    index_h = phase_band_height * _PHASE_INDEX_HEIGHT_RATIO
+    label_h = phase_band_height * _PHASE_LABEL_HEIGHT_RATIO
+    year_h = phase_band_height * _PHASE_YEAR_HEIGHT_RATIO
+
+    for i, phase in enumerate(phases):
+        cell_left = left + i * cell_w
+        cursor_y = top
+
+        # index_label (小)
+        idx_before = len(slide.shapes)
+        _shape, actual = add_auto_fit_textbox(
+            slide,
+            phase.index_label,
+            cell_left,
+            cursor_y,
+            cell_w,
+            index_h,
+            font_size_pt=10,
+            min_size_pt=7,
+            bold=True,
+            color_hex=_STYLE_PRIMARY_COLOR,
+            align="left",
+            vertical_anchor="top",
+        )
+        phase_shapes.append({
+            "kind": "phase_index",
+            "phase_index": i,
+            "shape_index": idx_before,
+            "actual_font_size": actual,
+        })
+        cursor_y += index_h
+
+        # label (太字・中)
+        idx_before = len(slide.shapes)
+        _shape, actual = add_auto_fit_textbox(
+            slide,
+            phase.label,
+            cell_left,
+            cursor_y,
+            cell_w,
+            label_h,
+            font_size_pt=13,
+            min_size_pt=9,
+            bold=True,
+            color_hex=_STYLE_PRIMARY_COLOR,
+            align="left",
+            vertical_anchor="top",
+        )
+        phase_shapes.append({
+            "kind": "phase_label",
+            "phase_index": i,
+            "shape_index": idx_before,
+            "actual_font_size": actual,
+        })
+        cursor_y += label_h
+
+        # year_range (小・グレー)
+        idx_before = len(slide.shapes)
+        _shape, actual = add_auto_fit_textbox(
+            slide,
+            phase.year_range,
+            cell_left,
+            cursor_y,
+            cell_w,
+            year_h,
+            font_size_pt=9,
+            min_size_pt=7,
+            bold=False,
+            color_hex=_STYLE_SECONDARY_COLOR,
+            align="left",
+            vertical_anchor="top",
+        )
+        phase_shapes.append({
+            "kind": "phase_year",
+            "phase_index": i,
+            "shape_index": idx_before,
+            "actual_font_size": actual,
+        })
+
+        right_edges.append(cell_left + cell_w)
+
+    return phase_shapes, right_edges
+
+
+def _render_phase_rules(
+    slide,
+    right_edges: list[float],
+    *,
+    top: float,
+    bottom: float,
+    color: str,
+) -> list[dict]:
+    """フェーズ境界の垂直ルールを描画する.
+
+    ``right_edges`` は ``_render_phase_band`` が返す各フェーズの右端 x 座標。
+    最後の要素はフェーズ帯の右端 (= チャート領域の右端) であり、境界では
+    ないのでここでは無視する (``[:-1]``)。
+    """
+    rule_shapes: list[dict] = []
+    if bottom <= top:
+        return rule_shapes
+    height = bottom - top
+    # 最後の要素を除いた N-1 本を境界として描画する
+    for boundary_index, x in enumerate(right_edges[:-1]):
+        idx = _add_shape(
+            slide,
+            "rectangle",
+            x - _RULE_WIDTH / 2,
+            top,
+            _RULE_WIDTH,
+            height,
+            fill_color=color,
+            no_line=True,
+        )
+        rule_shapes.append({
+            "kind": "phase_rule",
+            "boundary_index": boundary_index,
+            "shape_index": idx,
+        })
+    return rule_shapes
+
+
+def _render_milestones(
+    slide,
+    milestones: list[TimelineMilestone],
+    *,
+    left: float,
+    width: float,
+    rule_top: float,
+    chart_bottom: float,
+    rule_color: str,
+    font_size_pt: float,
+    year_font_size_pt: float,
+) -> tuple[list[dict], list[dict]]:
+    """マイルストーン・ルールと注記テキストを描画する.
+
+    各マイルストーンにつき:
+      1. 垂直ルール (``rule_top`` から ``chart_bottom - style_margin``)
+      2. year + label を 1 つのテキストボックスにまとめた注記 (ルール直上)
+
+    Returns:
+        ``(rule_shapes, label_shapes)``。それぞれ len = len(milestones)。
+    """
+    rule_shapes: list[dict] = []
+    label_shapes: list[dict] = []
+
+    for i, m in enumerate(milestones):
+        x = left + m.x_pos * width
+        color = _style_color(m.style)
+        rule_bottom_margin = _style_rule_bottom_margin(m.style)
+        rule_bottom = chart_bottom - rule_bottom_margin
+
+        # rule_top > rule_bottom (= chart_bottom が十分低くない) ケースでは
+        # ルールを描画しない (サイレントに逆向き矩形を描くより安全)。
+        if rule_bottom > rule_top:
+            idx = _add_shape(
+                slide,
+                "rectangle",
+                x - _RULE_WIDTH / 2,
+                rule_top,
+                _RULE_WIDTH,
+                rule_bottom - rule_top,
+                fill_color=rule_color,
+                no_line=True,
+            )
+            rule_shapes.append({
+                "kind": "milestone_rule",
+                "milestone_index": i,
+                "shape_index": idx,
+            })
+
+        # ラベル矩形はルールの直上に配置する。ルール自体が描けなくても
+        # ラベルは残す (テキストとして最低限の情報を提供する)。
+        label_left = x - _MILESTONE_LABEL_HALF_WIDTH
+        label_top = max(rule_top - _MILESTONE_LABEL_HEIGHT, 0.0)
+
+        # 1 つの textbox に year + label を詰める。改行で区切る。
+        combined = f"{m.year}\n{m.label}" if m.label else m.year
+        idx_before = len(slide.shapes)
+        _shape, actual = add_auto_fit_textbox(
+            slide,
+            combined,
+            label_left,
+            label_top,
+            _MILESTONE_LABEL_HALF_WIDTH * 2,
+            _MILESTONE_LABEL_HEIGHT,
+            font_size_pt=max(font_size_pt, year_font_size_pt),
+            min_size_pt=min(font_size_pt, year_font_size_pt) - 1,
+            bold=(m.style == "primary"),
+            color_hex=color,
+            align="center",
+            vertical_anchor="bottom",
+        )
+        label_shapes.append({
+            "kind": "milestone_label",
+            "milestone_index": i,
+            "shape_index": idx_before,
+            "actual_font_size": actual,
+        })
+
+    return rule_shapes, label_shapes
+
+
+def add_milestone_timeline(
+    slide,
+    phases: list[TimelinePhase],
+    milestones: list[TimelineMilestone],
+    *,
+    left: float,
+    top: float,
+    width: float,
+    phase_band_height: float = 0.9,
+    chart_top: float,
+    chart_bottom: float,
+    phase_rule_color: str = "E0E0E0",
+    milestone_rule_color: str = "C0C0C0",
+    milestone_font_size_pt: float = 9,
+    milestone_year_font_size_pt: float = 11,
+    theme: str = "mckinsey",
+) -> dict:
+    """フェーズ帯 + 垂直ルール + マイルストーン注記を描画する.
+
+    呼び出し元は本関数に先立ってチャート等を ``chart_top`` から
+    ``chart_bottom`` の垂直レンジに配置する想定である。本関数はチャート
+    自体は描かず、その上に重ねる「注記レイヤ」を担当する。
+
+    Args:
+        slide: 対象スライド。
+        phases: フェーズの順序付きリスト。空リスト可 (フェーズ帯をスキップ)。
+        milestones: マイルストーンの順序付きリスト。空リスト可。
+        left: タイムライン領域の左端 (inches)。
+        top: タイムライン領域 (フェーズ帯) の上端 (inches)。
+        width: タイムライン領域の幅 (inches)。チャート領域の幅と一致させる。
+        phase_band_height: フェーズ帯の高さ (inches)。
+        chart_top: チャート領域の上端 (inches)。マイルストーン・ルールの
+            上端 (= ``top + phase_band_height``) と等しいか低い位置を想定する。
+        chart_bottom: チャート領域の下端 (inches)。境界ルール・マイルス
+            トーン・ルールの下限の基準となる。
+        phase_rule_color: フェーズ境界ルールの色 (hex、``#`` なし)。
+        milestone_rule_color: マイルストーン・ルールの色 (hex)。
+        milestone_font_size_pt: マイルストーン label (年を除く) の font size。
+        milestone_year_font_size_pt: マイルストーン year の font size。
+        theme: テーマ名 (将来拡張用; 現状は hex 色を直接指定できるため
+            参照しない)。
+
+    Returns:
+        ``{"phase_shapes": [...], "milestone_shapes": [...],
+           "rule_shapes": [...], "consumed_height": phase_band_height}``
+        の dict。``phase_shapes`` は各フェーズ 3 要素 (index/label/year) を
+        含み、``rule_shapes`` はフェーズ境界ルールとマイルストーン・ルールを
+        混在させた全ルールを追加順に含む。``milestone_shapes`` は各マイルス
+        トーンの注記テキストを含む。
+
+    Raises:
+        EngineError: 入力が無効なとき (``INVALID_PARAMETER``)。
+    """
+    _validate_inputs(
+        phases,
+        milestones,
+        left=left,
+        top=top,
+        width=width,
+        phase_band_height=phase_band_height,
+        chart_top=chart_top,
+        chart_bottom=chart_bottom,
+    )
+
+    phase_shapes, right_edges = _render_phase_band(
+        slide,
+        phases,
+        left=left,
+        top=top,
+        width=width,
+        phase_band_height=phase_band_height,
+    )
+
+    # フェーズ帯の下端 = マイルストーン・ルールの上端。
+    rule_top = top + phase_band_height
+
+    phase_rule_shapes = _render_phase_rules(
+        slide,
+        right_edges,
+        top=rule_top,
+        bottom=chart_bottom,
+        color=phase_rule_color,
+    )
+
+    milestone_rule_shapes, milestone_label_shapes = _render_milestones(
+        slide,
+        milestones,
+        left=left,
+        width=width,
+        rule_top=rule_top,
+        chart_bottom=chart_bottom,
+        rule_color=milestone_rule_color,
+        font_size_pt=milestone_font_size_pt,
+        year_font_size_pt=milestone_year_font_size_pt,
+    )
+
+    # rule_shapes は「フェーズ境界 → マイルストーン」の順でまとめる。
+    rule_shapes = phase_rule_shapes + milestone_rule_shapes
+
+    return {
+        "phase_shapes": phase_shapes,
+        "milestone_shapes": milestone_label_shapes,
+        "rule_shapes": rule_shapes,
+        "consumed_height": phase_band_height,
+    }

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -108,6 +108,9 @@ from .engine import (
     add_responsive_card_row,
     TableColumnSpec,
     add_data_table,
+    TimelinePhase,
+    TimelineMilestone,
+    add_milestone_timeline,
 )
 from .engine.pptx_io import open_pptx, save_pptx, _get_slide
 
@@ -980,6 +983,122 @@ def pptx_add_data_table(
 
         # save 前に return 値構築が終わっているため、以降の save 失敗で
         # 中途半端な状態にならない (#34 と同じポリシー)。
+        save_pptx(prs, file_path)
+
+        render_info = _auto_render(file_path, slide_index)
+        if render_info.get("rendered"):
+            result["preview_path"] = render_info.get("preview_path")
+        elif render_info.get("reason") != "disabled":
+            result["render_warning"] = render_info
+        return _success(result)
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def pptx_add_milestone_timeline(
+    file_path: str,
+    slide_index: int,
+    phases: List[Dict[str, Any]],
+    milestones: List[Dict[str, Any]],
+    left: float,
+    top: float,
+    width: float,
+    chart_top: float,
+    chart_bottom: float,
+    phase_band_height: float = 0.9,
+    phase_rule_color: str = "E0E0E0",
+    milestone_rule_color: str = "C0C0C0",
+    milestone_font_size_pt: float = 9,
+    milestone_year_font_size_pt: float = 11,
+    theme: str = "mckinsey",
+) -> str:
+    """Overlay a phase band + vertical rules + year-labeled milestone annotations on an existing chart area.
+
+    For IR-style growth-story slides: place your chart first (at
+    ``chart_top``..``chart_bottom`` vertical range), then call this tool with
+    the same ``left``/``width`` to paint phase labels and milestone callouts.
+
+    ``phases``: list of dicts with keys ``label``, ``index_label``,
+    ``year_range`` (all strings). Empty list skips the phase band.
+
+    ``milestones``: list of dicts with keys ``x_pos`` (0.0-1.0 relative to
+    chart area width), ``year``, ``label`` (``\\n`` for line breaks), and
+    optional ``style`` (``"primary"`` | ``"secondary"``).
+    """
+    try:
+        if not isinstance(phases, list):
+            return _error(
+                "INVALID_PARAMETER",
+                "phases must be a list of dicts.",
+                parameter="phases",
+                hint="Pass a native list, e.g. [{\"label\":\"Phase 1\",\"index_label\":\"01\",\"year_range\":\"2012-2016\"}].",
+            )
+        if not isinstance(milestones, list):
+            return _error(
+                "INVALID_PARAMETER",
+                "milestones must be a list of dicts.",
+                parameter="milestones",
+                hint="Pass a native list, e.g. [{\"x_pos\":0.5,\"year\":\"2016\",\"label\":\"IPO\"}].",
+            )
+
+        _phase_known = {f.name for f in fields(TimelinePhase)}
+        for i, spec in enumerate(phases):
+            if not isinstance(spec, dict):
+                raise EngineError(
+                    ErrorCode.INVALID_PARAMETER,
+                    f"phases[{i}]: must be a dict, got {type(spec).__name__}.",
+                )
+            unknown = set(spec.keys()) - _phase_known
+            if unknown:
+                raise EngineError(
+                    ErrorCode.INVALID_PARAMETER,
+                    (
+                        f"phases[{i}]: unknown keys {sorted(unknown)}; "
+                        f"known keys: {sorted(_phase_known)}."
+                    ),
+                )
+
+        _milestone_known = {f.name for f in fields(TimelineMilestone)}
+        for i, spec in enumerate(milestones):
+            if not isinstance(spec, dict):
+                raise EngineError(
+                    ErrorCode.INVALID_PARAMETER,
+                    f"milestones[{i}]: must be a dict, got {type(spec).__name__}.",
+                )
+            unknown = set(spec.keys()) - _milestone_known
+            if unknown:
+                raise EngineError(
+                    ErrorCode.INVALID_PARAMETER,
+                    (
+                        f"milestones[{i}]: unknown keys {sorted(unknown)}; "
+                        f"known keys: {sorted(_milestone_known)}."
+                    ),
+                )
+
+        phase_objs = [TimelinePhase(**d) for d in phases]
+        milestone_objs = [TimelineMilestone(**d) for d in milestones]
+
+        prs = open_pptx(file_path)
+        slide = _get_slide(prs, slide_index)
+
+        result = add_milestone_timeline(
+            slide,
+            phase_objs,
+            milestone_objs,
+            left=left,
+            top=top,
+            width=width,
+            phase_band_height=phase_band_height,
+            chart_top=chart_top,
+            chart_bottom=chart_bottom,
+            phase_rule_color=phase_rule_color,
+            milestone_rule_color=milestone_rule_color,
+            milestone_font_size_pt=milestone_font_size_pt,
+            milestone_year_font_size_pt=milestone_year_font_size_pt,
+            theme=theme,
+        )
+
         save_pptx(prs, file_path)
 
         render_info = _auto_render(file_path, slide_index)

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,0 +1,207 @@
+"""``add_milestone_timeline`` プリミティブのテスト.
+
+IR 成長ストーリースライド向けに、フェーズ帯 + 垂直ルール + マイルストーン
+注記を既存チャート領域に重ねるプリミティブを検証する。shape 追加数・
+位置・入力検証の各挙動を網羅する。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pptx_mcp_server.engine.pptx_io import EngineError, ErrorCode
+from pptx_mcp_server.engine.timeline import (
+    TimelineMilestone,
+    TimelinePhase,
+    add_milestone_timeline,
+)
+
+
+# EMU → inches 換算 (1 inch = 914400 EMU)
+def _in(emu: int) -> float:
+    return emu / 914400
+
+
+def test_three_phases_four_milestones_shape_counts(slide):
+    """3 フェーズ + 4 マイルストーンで各 shape 数が仕様通りか検証する.
+
+    期待値:
+      - phase_shapes: 3 × 3 (index/label/year) = 9
+      - rule_shapes:  (3-1) phase rules + 4 milestone rules = 6
+      - milestone_shapes: 4
+    """
+    phases = [
+        TimelinePhase(label="事業基盤の確立", index_label="01", year_range="2012 — 2016"),
+        TimelinePhase(label="事業拡大", index_label="02", year_range="2017 — 2020"),
+        TimelinePhase(label="プラットフォーム化", index_label="03", year_range="2021 — 現在"),
+    ]
+    milestones = [
+        TimelineMilestone(x_pos=0.20, year="2016", label="IPO\n東証マザーズ上場"),
+        TimelineMilestone(x_pos=0.45, year="2019", label="BillFlow 提供開始", style="secondary"),
+        TimelineMilestone(x_pos=0.70, year="2022", label="海外展開"),
+        TimelineMilestone(x_pos=0.90, year="2024", label="東証プライム上場"),
+    ]
+    result = add_milestone_timeline(
+        slide,
+        phases,
+        milestones,
+        left=0.9, top=1.15, width=11.533,
+        phase_band_height=0.9,
+        chart_top=2.05, chart_bottom=6.5,
+    )
+
+    assert len(result["phase_shapes"]) == 9
+    assert len(result["rule_shapes"]) == 6
+    assert len(result["milestone_shapes"]) == 4
+    assert result["consumed_height"] == pytest.approx(0.9)
+
+
+def test_empty_phases_with_milestones(slide):
+    """フェーズなし・マイルストーン 2 つのとき、フェーズ関連 shape は 0 のまま.
+
+    ``chart_top``/``chart_bottom`` とマイルストーン・ルールのみ描画される。
+    """
+    milestones = [
+        TimelineMilestone(x_pos=0.3, year="2016", label="A"),
+        TimelineMilestone(x_pos=0.7, year="2020", label="B"),
+    ]
+    result = add_milestone_timeline(
+        slide,
+        [],
+        milestones,
+        left=1.0, top=1.0, width=10.0,
+        phase_band_height=0.9,
+        chart_top=2.0, chart_bottom=6.5,
+    )
+
+    assert result["phase_shapes"] == []
+    # phase rules 0 (境界なし) + milestone rules 2
+    assert len(result["rule_shapes"]) == 2
+    for rs in result["rule_shapes"]:
+        assert rs["kind"] == "milestone_rule"
+    assert len(result["milestone_shapes"]) == 2
+
+
+def test_phases_only_no_milestones(slide):
+    """3 フェーズ・マイルストーン 0 件のとき、phase rules のみ描画される.
+
+    期待値:
+      - phase_shapes: 9
+      - rule_shapes:  2 (inter-phase)
+      - milestone_shapes: 0
+    """
+    phases = [
+        TimelinePhase(label="P1", index_label="01", year_range="Y1"),
+        TimelinePhase(label="P2", index_label="02", year_range="Y2"),
+        TimelinePhase(label="P3", index_label="03", year_range="Y3"),
+    ]
+    result = add_milestone_timeline(
+        slide,
+        phases,
+        [],
+        left=0.9, top=1.15, width=11.0,
+        chart_top=2.05, chart_bottom=6.5,
+    )
+
+    assert len(result["phase_shapes"]) == 9
+    assert len(result["rule_shapes"]) == 2
+    for rs in result["rule_shapes"]:
+        assert rs["kind"] == "phase_rule"
+    assert result["milestone_shapes"] == []
+
+
+def test_invalid_x_pos_raises(slide):
+    """``x_pos`` が ``[0.0, 1.0]`` を外れたら ``INVALID_PARAMETER``."""
+    with pytest.raises(EngineError) as excinfo:
+        add_milestone_timeline(
+            slide,
+            [],
+            [TimelineMilestone(x_pos=-0.1, year="2016", label="X")],
+            left=1.0, top=1.0, width=10.0,
+            chart_top=2.0, chart_bottom=6.5,
+        )
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMETER
+    assert "x_pos" in str(excinfo.value)
+
+
+def test_invalid_chart_range_raises(slide):
+    """``chart_top >= chart_bottom`` なら ``INVALID_PARAMETER``."""
+    with pytest.raises(EngineError) as excinfo:
+        add_milestone_timeline(
+            slide,
+            [],
+            [],
+            left=1.0, top=1.0, width=10.0,
+            chart_top=5.0, chart_bottom=3.0,
+        )
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMETER
+    msg = str(excinfo.value)
+    assert "chart_top" in msg and "chart_bottom" in msg
+
+
+def test_single_phase_no_inter_phase_rule(slide):
+    """フェーズが 1 つのとき inter-phase 境界はなく、phase rules は 0 本."""
+    phases = [TimelinePhase(label="Only", index_label="01", year_range="Y")]
+    result = add_milestone_timeline(
+        slide,
+        phases,
+        [],
+        left=1.0, top=1.0, width=10.0,
+        chart_top=2.0, chart_bottom=6.5,
+    )
+
+    # 1 フェーズ分 3 shape
+    assert len(result["phase_shapes"]) == 3
+    # inter-phase rule は 0
+    assert result["rule_shapes"] == []
+
+
+def test_negative_width_raises(slide):
+    """幅が負のとき ``INVALID_PARAMETER``."""
+    with pytest.raises(EngineError) as excinfo:
+        add_milestone_timeline(
+            slide,
+            [],
+            [],
+            left=0.0, top=1.0, width=-1.0,
+            chart_top=2.0, chart_bottom=6.5,
+        )
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMETER
+
+
+def test_milestone_x_pos_positioning(slide):
+    """マイルストーン・ルールの x 座標が ``left + x_pos * width`` と一致する."""
+    milestone = TimelineMilestone(x_pos=0.5, year="2020", label="Mid")
+    result = add_milestone_timeline(
+        slide,
+        [],
+        [milestone],
+        left=2.0, top=1.0, width=10.0,
+        chart_top=2.0, chart_bottom=6.5,
+    )
+
+    rule = result["rule_shapes"][0]
+    shape = slide.shapes[rule["shape_index"]]
+    # left + 0.5 * width = 7.0; rule は 0.01" 幅で中央揃え → shape.left = 7.0 - 0.005
+    assert _in(shape.left) == pytest.approx(7.0 - 0.005, abs=1e-4)
+
+
+def test_secondary_style_uses_gray(slide):
+    """``style='secondary'`` のマイルストーンラベルはグレー文字色で描画される."""
+    milestone = TimelineMilestone(
+        x_pos=0.5, year="2020", label="Minor event", style="secondary",
+    )
+    result = add_milestone_timeline(
+        slide,
+        [],
+        [milestone],
+        left=1.0, top=1.0, width=10.0,
+        chart_top=2.0, chart_bottom=6.5,
+    )
+
+    label = result["milestone_shapes"][0]
+    shape = slide.shapes[label["shape_index"]]
+    # 文字色は最初の run の rgb で確認する。
+    run = shape.text_frame.paragraphs[0].runs[0]
+    rgb = run.font.color.rgb
+    assert str(rgb) == "666666"


### PR DESCRIPTION
## Summary
- Add `TimelinePhase` / `TimelineMilestone` dataclasses and `add_milestone_timeline` primitive (new file `src/pptx_mcp_server/engine/timeline.py`) that overlays a phase band + vertical boundary rules + year-labeled milestone annotations on an existing chart area. For IR-style growth-story slides (slide 4 of the reference IR-Deck pattern).
- Expose `pptx_add_milestone_timeline` MCP tool with strict-key validation against the dataclass fields for both `phases` and `milestones`.
- Export the new symbols from `engine/__init__.py`.

## Design decisions
- **Style handling:** `primary` uses navy (`051C2C`) + bold + 1.5" bottom margin; `secondary` uses gray (`666666`) + normal weight + 2.0" bottom margin (pulls rules up from the data area for quieter callouts).
- **Milestone rule overlap with phase boundaries:** caller responsibility. The primitive does not warn when a milestone's `x_pos` coincides with an inter-phase boundary — both rules simply stack (milestone rule is drawn after, so it wins visually only in the lower segment; the phase rule is `E0E0E0` vs milestone `C0C0C0`, so the effect is subtle).
- **Dashed lines:** out of scope per the issue. Thin solid 0.01" rectangles stand in as hairline rules — visually reads as a divider.
- **Low `chart_bottom`:** if `chart_bottom - style_margin <= rule_top`, the milestone rule is silently skipped (label still renders). The alternative (raising) would be brittle for short charts.
- **Negative width / `chart_top >= chart_bottom`:** fail-fast with `INVALID_PARAMETER`.
- **Empty `phases`:** cleanly skips the phase band and phase rules.

## Test plan
- [x] `python -m pytest tests/test_timeline.py -v` → 9 passed
- [x] Full suite → 680 passed, 1 skipped
- [x] Shape-count invariants for 3 phases × 4 milestones (9 / 6 / 4)
- [x] Empty phases with milestones-only path
- [x] Phases-only with no milestones (2 inter-phase rules, 0 milestone shapes)
- [x] Single phase → 0 inter-phase rules
- [x] x_pos positioning (`left + x_pos * width` ± rule half-width)
- [x] `style=secondary` → gray text
- [x] Validation failures: x_pos out of range, chart_top >= chart_bottom, negative width

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)