### PR TITLE
chore(release): bump to v0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pptx-mcp-server"
-version = "0.3.1"
+version = "0.4.0"
 description = "Content-aware PPTX layout engine with Japanese-aware text metrics, CSS-flex-like primitives, and structural validator for agent-generated consulting decks"
 requires-python = ">=3.11"
 license = "MIT"


### PR DESCRIPTION
Version bump for IR primitives milestone. Tag v0.4.0 after merge to trigger PyPI publish.