### PR TITLE
fix(v0.4.1): polish IR primitives — 4 bugs from Codex review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ env/
 .vscode/
 *.swp
 .DS_Store
+.claude/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pptx-mcp-server"
-version = "0.4.0"
+version = "0.4.1"
 description = "Content-aware PPTX layout engine with Japanese-aware text metrics, CSS-flex-like primitives, and structural validator for agent-generated consulting decks"
 requires-python = ">=3.11"
 license = "MIT"

--- a/src/pptx_mcp_server/engine/tables_grid.py
+++ b/src/pptx_mcp_server/engine/tables_grid.py
@@ -174,6 +174,11 @@ def add_data_table(
             ErrorCode.INVALID_PARAMETER,
             "width, row_height, header_height must all be > 0",
         )
+    if rule_thickness < 0:
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            f"rule_thickness must be >= 0; got {rule_thickness:.3f}",
+        )
 
     n_cols = len(columns)
     for ri, row in enumerate(rows):

--- a/src/pptx_mcp_server/engine/timeline.py
+++ b/src/pptx_mcp_server/engine/timeline.py
@@ -480,8 +480,9 @@ def add_milestone_timeline(
         phase_band_height=phase_band_height,
     )
 
-    # フェーズ帯の下端 = マイルストーン・ルールの上端。
-    rule_top = top + phase_band_height
+    # ルールは caller-declared chart area の上端 (chart_top) から下に引く。
+    # 旧実装は `top + phase_band_height` を使って chart_top 引数を無視していた (#119)。
+    rule_top = chart_top
 
     phase_rule_shapes = _render_phase_rules(
         slide,

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -137,7 +137,8 @@ choice, etc.) — that belongs in the calling agent's system prompt.
 
 ## Available Themes
 Pass `"theme": "<name>"` in slide specs for `build_slide` / `build_deck`.
-Available: `mckinsey` (default), `deloitte`, `neutral`. For custom palettes
+Available: `mckinsey` (default), `deloitte`, `neutral`, `ir` (Japanese IR /
+quarterly-report palette — cream + navy, HD 20"×11.25"). For custom palettes
 pass explicit `font_color` / `fill_color` hex values on elements instead.
 
 ## Response Shape (v0.3.0)
@@ -981,6 +982,12 @@ def pptx_add_data_table(
             font_name=font_name,
         )
 
+        # Envelope invariant: result must have 'message' (#120).
+        result["message"] = (
+            f"Added data table ({len(rows)} rows × {len(columns)} cols, "
+            f"consumed {result['consumed_height']:.2f}\")"
+        )
+
         # save 前に return 値構築が終わっているため、以降の save 失敗で
         # 中途半端な状態にならない (#34 と同じポリシー)。
         save_pptx(prs, file_path)
@@ -1097,6 +1104,12 @@ def pptx_add_milestone_timeline(
             milestone_font_size_pt=milestone_font_size_pt,
             milestone_year_font_size_pt=milestone_year_font_size_pt,
             theme=theme,
+        )
+
+        # Envelope invariant: result must have 'message' (#120).
+        result["message"] = (
+            f"Added milestone timeline "
+            f"({len(phases)} phases, {len(milestones)} milestones)"
         )
 
         save_pptx(prs, file_path)

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -212,3 +212,38 @@ def test_highlight_row_out_of_range_raises(slide):
             highlight_row_index=5,
         )
     assert ei.value.code == ErrorCode.INVALID_PARAMETER
+
+
+# ---------------------------------------------------------------------------
+# Issue #121 — rule_thickness validation
+# ---------------------------------------------------------------------------
+
+
+def test_negative_rule_thickness_rejected(one_slide_prs):
+    """rule_thickness < 0 must raise INVALID_PARAMETER (#121).
+
+    Pre-fix: produced negative-height rule rectangles silently.
+    """
+    slide = one_slide_prs.slides[0]
+    columns = [TableColumnSpec(header="x")]
+    with pytest.raises(EngineError) as ei:
+        add_data_table(
+            slide, [["a"]], columns,
+            left=0.5, top=1.0, width=1.0,
+            rule_thickness=-0.01,
+        )
+    assert ei.value.code == ErrorCode.INVALID_PARAMETER
+    assert "rule_thickness" in str(ei.value)
+
+
+def test_zero_rule_thickness_ok(one_slide_prs):
+    """rule_thickness=0 is valid (means no rules rendered)."""
+    slide = one_slide_prs.slides[0]
+    columns = [TableColumnSpec(header="x")]
+    # Should not raise
+    result = add_data_table(
+        slide, [["a"]], columns,
+        left=0.5, top=1.0, width=1.0,
+        rule_thickness=0.0,
+    )
+    assert result["consumed_height"] > 0

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -205,3 +205,41 @@ def test_secondary_style_uses_gray(slide):
     run = shape.text_frame.paragraphs[0].runs[0]
     rgb = run.font.color.rgb
     assert str(rgb) == "666666"
+
+
+# ---------------------------------------------------------------------------
+# Issue #119 — chart_top regression
+# ---------------------------------------------------------------------------
+
+
+def test_milestone_rules_anchor_at_chart_top(one_slide_prs: Presentation) -> None:
+    """chart_top (not top+phase_band_height) must be the rule anchor (#119).
+
+    Before the fix: milestone rules always started at `top + phase_band_height`,
+    ignoring chart_top. This test pins the corrected contract.
+    """
+    slide = one_slide_prs.slides[0]
+
+    result = add_milestone_timeline(
+        slide,
+        phases=[],
+        milestones=[
+            TimelineMilestone(x_pos=0.5, year="2020", label="Test"),
+        ],
+        left=1.0,
+        top=1.0,
+        width=10.0,
+        phase_band_height=0.5,   # top + phase_band_height = 1.5
+        chart_top=3.0,           # chart explicitly starts at y=3.0
+        chart_bottom=6.0,
+    )
+
+    emu_per_in = 914400
+    milestone_rules = [r for r in result["rule_shapes"] if r.get("kind") == "milestone_rule"]
+    assert milestone_rules, "expected at least one milestone rule shape"
+    for rule in milestone_rules:
+        shape = slide.shapes[rule["shape_index"]]
+        y_in = shape.top / emu_per_in
+        assert abs(y_in - 3.0) < 0.01, (
+            f"Milestone rule top={y_in:.3f}, expected 3.0 (chart_top)"
+        )


### PR DESCRIPTION
## Summary
Four surgical fixes addressing Codex gpt-5.4's v0.4.0 review findings. Closes #119, #120, #121, #122.

## Test plan
- [x] 703 tests passing (up from 700 baseline)
- [x] Full suite no regressions
- [x] New regression tests for chart_top anchor + rule_thickness validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)