### PR TITLE
fix(v0.5.1): timeline theme defaults to None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to `pptx-mcp-server` are documented in this file.
 
+## v0.5.1 — timeline theme default
+
+Flagged by Codex gpt-5.4 v0.5.0 review: the timeline tool
+(`pptx_add_milestone_timeline` + engine `add_milestone_timeline`) still
+defaulted to `theme="mckinsey"` instead of `None`. Omitting `theme` was
+not neutral — passing an unknown token without explicit theme silently
+resolved via mckinsey.
+
+### Fix
+
+- `add_milestone_timeline`: `theme: str = "mckinsey"` → `Optional[str] = None`
+- `pptx_add_milestone_timeline`: same
+- Both now consistent with `add_responsive_card_row` and `add_data_table`
+- Regression test pins the contract
+
+713 → 714 tests passing.
+
 ## v0.5.0 — theme-aware primitives
 
 Closes the ergonomic gaps Codex gpt-5.4 flagged in the v0.4.0 review:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pptx-mcp-server"
-version = "0.5.0"
+version = "0.5.1"
 description = "Content-aware PPTX layout engine with Japanese-aware text metrics, CSS-flex-like primitives, and structural validator for agent-generated consulting decks"
 requires-python = ">=3.11"
 license = "MIT"

--- a/src/pptx_mcp_server/engine/timeline.py
+++ b/src/pptx_mcp_server/engine/timeline.py
@@ -437,7 +437,7 @@ def add_milestone_timeline(
     milestone_rule_color: str = "C0C0C0",
     milestone_font_size_pt: float = 9,
     milestone_year_font_size_pt: float = 11,
-    theme: str = "mckinsey",
+    theme: Optional[str] = None,
 ) -> dict:
     """フェーズ帯 + 垂直ルール + マイルストーン注記を描画する.
 

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -1022,7 +1022,7 @@ def pptx_add_milestone_timeline(
     milestone_rule_color: str = "C0C0C0",
     milestone_font_size_pt: float = 9,
     milestone_year_font_size_pt: float = 11,
-    theme: str = "mckinsey",
+    theme: Optional[str] = None,
 ) -> str:
     """Overlay a phase band + vertical rules + year-labeled milestone annotations on an existing chart area.
 

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -294,3 +294,35 @@ def test_milestone_primary_style_uses_theme_primary_color_on_label(one_slide_prs
     run = label.text_frame.paragraphs[0].runs[0]
     # IR theme primary = #0A2540
     assert str(run.font.color.rgb) == "0A2540"
+
+
+# ---------------------------------------------------------------------------
+# v0.5.1: theme defaults to None (was "mckinsey" through v0.5.0)
+# ---------------------------------------------------------------------------
+
+
+def test_theme_defaults_to_none_no_auto_mckinsey_resolution(one_slide_prs):
+    """theme omitted → unknown tokens passed through as-is, not silently
+    resolved via mckinsey. Pins v0.5.1 contract (Codex gpt-5.4 v0.5.0 review
+    found that timeline tool defaulted to theme='mckinsey', breaking the
+    'theme=None preserves behavior' claim).
+    """
+    from pptx_mcp_server.engine.timeline import add_milestone_timeline, TimelinePhase
+    slide = one_slide_prs.slides[0]
+    result = add_milestone_timeline(
+        slide,
+        phases=[
+            TimelinePhase(label="A", index_label="01", year_range="2012-2016"),
+            TimelinePhase(label="B", index_label="02", year_range="2017-2020"),
+        ],
+        milestones=[],
+        left=1.0, top=1.0, width=8.0,
+        phase_band_height=0.5,
+        chart_top=2.0, chart_bottom=5.0,
+        phase_rule_color="FF00FF",  # raw hex
+        # theme omitted — must not trigger mckinsey resolution
+    )
+    phase_rules = [r for r in result["rule_shapes"] if r.get("kind") == "phase_rule"]
+    shape = slide.shapes[phase_rules[0]["shape_index"]]
+    # Raw hex should pass through unchanged
+    assert str(shape.fill.fore_color.rgb) == "FF00FF"


### PR DESCRIPTION
Closes Codex v0.5.0 residual. add_milestone_timeline default changed from 'mckinsey' to None, matching the other two primitives.