### PR TITLE
feat(v0.6.0): shadcn-for-PPTX — component layer foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,19 @@ containment. Closes #130, #131, #132, #133, #134, #135, #136.
   schema that now owns the canonical name. **The legacy tool is
   deprecated and will be removed in v0.7.0.** New callers should
   migrate to the block-component `pptx_add_kpi_row`.
+- **MCP tool tiering (#137)** — the MCP registry is now split into a
+  focused **default surface** (~20 tools: block components, high-level
+  primitives, batch build, validation / rendering, setup / inspection)
+  and an **advanced tier** (~25 tools: raw shape primitives, low-level
+  edit ops, slide-level editing, table editing primitives,
+  connectors / callouts / icons, composite helpers,
+  `pptx_add_kpi_row_legacy`). Advanced-tier tools are **hidden from
+  agents by default**; opt in via `PPTX_MCP_INCLUDE_ADVANCED=1`
+  (accepts `1` / `true` / `yes`). The advanced functions remain
+  importable for library-mode use (`from pptx_mcp_server.server
+  import pptx_add_textbox`) — only the FastMCP registration is
+  gated. Implementation lives in
+  `pptx_mcp_server._tool_registry.mcp_tool(mcp, advanced=...)`.
 
 ### Migration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,31 +2,72 @@
 
 All notable changes to `pptx-mcp-server` are documented in this file.
 
-## Unreleased / v0.6.0 — KPIRow block component (Issue #133)
+## Unreleased / v0.6.0 — shadcn-for-PPTX block-component layer
 
-Second piece of the v0.6.0 shadcn-for-PPTX component layer: a proper
-block-component KPI row that composes atomic primitives inside a
-container, replacing the v0.2.x simple-callout variant at the canonical
-`pptx_add_kpi_row` name.
+The v0.6.0 foundation: a container-scoped block-component layer that
+composes atomic primitives inside bounded rectangles and validates
+containment. Closes #130, #131, #132, #133, #134, #135, #136.
 
 ### Added
 
-- **`pptx_add_kpi_row` MCP tool (block-component variant)** — new
-  label / big-value / optional-detail layout. Each cell stacks a 9pt
-  label, a 26pt bold single-line auto-fit value, and an optional 8pt
-  detail line. Cells are evenly distributed across `width` with `gap`
-  inches between them. Supports optional `card_fill` / `card_border`
-  frames (e.g. `card_fill="highlight_row"`, `card_border="rule_subtle"`)
-  and a `theme` kwarg for theme-token resolution. Auto-tags child shapes
-  into the active container for containment validation.
-- **`engine.components.kpi_row.KPISpec`** — dataclass spec for a single
-  cell (`label`, `value`, `detail`, `value_color`, `delta_color`
-  (reserved for forward-compat)).
-- **`add_kpi_row_block` engine export** — new alias in
-  `pptx_mcp_server.engine.components`. The underlying function is
-  `engine.components.kpi_row.add_kpi_row`; it is re-exported under the
-  `add_kpi_row_block` name to avoid a name collision with the legacy
-  `engine.composites.add_kpi_row` (still exported unchanged).
+- **Container primitive (#130)** —
+  `engine.components.container.begin_container` context manager that
+  declares a bounded rectangle for a block component on a slide. Shapes
+  added inside the `with` block via the atomic primitives
+  (`_add_shape` / `_add_textbox` / `_add_image` / `add_auto_fit_textbox`)
+  are auto-tagged against the innermost active container via a
+  thread-local stack. Supports nested containers and per-container
+  `padding`. New `ContainerBounds` dataclass exposes `inner_bounds()`
+  after padding. New `check_containment(presentation, *, tolerance=0.01)`
+  validator flags any tagged child whose bbox exits its container's
+  padded bounds (`category="shape_outside_container"`,
+  `severity="error"`). `check_deck_extended` now emits a `containment`
+  key on each slide and counts findings toward `summary.errors`.
+- **Theme-aware atomic primitives (#131)** — `add_auto_fit_textbox` and
+  `_add_shape` (plus their MCP wrappers) accept an optional
+  `theme: str | None` kwarg. Color fields resolve theme tokens
+  (`"primary"`, `"text_secondary"`, `"rule_subtle"`, etc.) through the
+  central `theme.resolve_theme_color` helper. Raw hex still works and
+  `theme=None` is fully backwards-compatible.
+- **MetricCard block component (#132)** —
+  `pptx_add_metric_card_row` MCP tool + `engine.components.metric_card`
+  (`MetricCardSpec`, `MetricEntry`, `add_metric_card`,
+  `add_metric_card_row`). N bounded cards side-by-side, each stacking
+  label / title / chart slot (image or placeholder) / optional
+  metrics row. Theme-aware colors, configurable padding, and
+  auto-tagging into the active container.
+- **KPIRow block component (#133)** — block-component
+  `pptx_add_kpi_row` MCP tool with the new label / big-value /
+  optional-detail layout. Each cell stacks a 9pt label, a 26pt bold
+  single-line auto-fit value, and an optional 8pt detail line. Cells
+  are evenly distributed across `width` with `gap` inches between them.
+  Supports optional `card_fill` / `card_border` frames (e.g.
+  `card_fill="highlight_row"`, `card_border="rule_subtle"`) and a
+  `theme` kwarg for theme-token resolution. Auto-tags child shapes into
+  the active container. New `engine.components.kpi_row.KPISpec`
+  dataclass + `add_kpi_row_block` engine export (aliased to avoid a
+  name collision with the legacy `engine.composites.add_kpi_row`).
+- **NumberedList block component (#134)** —
+  `pptx_add_numbered_list` MCP tool +
+  `engine.components.numbered_list` (`NumberedItem`,
+  `add_numbered_list`). N numbered items stacked vertically inside a
+  bounded rectangle, each rendering number + caption row, bold title,
+  and wrapped body paragraph. Optional horizontal rules between items
+  (`rule_between=True` by default).
+- **PageMarker + SlideFooter block components (#135)** —
+  `pptx_add_page_marker` (top-right "section / P.XX" marker) and
+  `pptx_add_slide_footer` (bottom-edge left/right footer text) MCP
+  tools. Both use fixed conventional position and accept a `theme`
+  kwarg for default `text_secondary` color-token resolution. Engine
+  specs `PageMarkerSpec` / `SlideFooterSpec` live in
+  `engine.components.markers`.
+- **SectionHeader block component (#136)** —
+  `pptx_add_section_header` MCP tool +
+  `engine.components.section_header` (`SectionHeaderSpec`,
+  `add_section_header`). Title + optional subtitle + full-width
+  divider rule. Title/subtitle use single-line auto-fit with ellipsis
+  truncation. Returns `title_bounds`, `subtitle_bounds`,
+  `divider_bounds`, and `consumed_height` for downstream placement.
 
 ### Changed (breaking — MCP surface)
 
@@ -34,8 +75,8 @@ container, replacing the v0.2.x simple-callout variant at the canonical
   `pptx_add_kpi_row_legacy`** — callers of the 4-arg signature
   `(file_path, slide_index, kpis, y)` will fail against the new 7+ arg
   schema that now owns the canonical name. **The legacy tool is
-  deprecated and will be removed in v0.7.0.** New callers should migrate
-  to the block-component `pptx_add_kpi_row`.
+  deprecated and will be removed in v0.7.0.** New callers should
+  migrate to the block-component `pptx_add_kpi_row`.
 
 ### Migration
 
@@ -52,39 +93,13 @@ pptx_add_kpi_row_legacy(file_path, slide_index, kpis=[...], y=2.5)
 
 ### Non-breaking
 
-- `engine.composites.add_kpi_row` (library-level) is unchanged; only the
-  MCP tool name moved.
+- `engine.composites.add_kpi_row` (library-level) is unchanged; only
+  the MCP tool name moved.
 - The legacy tool's runtime behavior is identical — the rename is
   surface-only so migration is a one-line rename, not a refactor.
-
-## Unreleased — container primitive (Issue #130)
-
-Foundation for the v0.6.0 shadcn-for-PPTX component layer.
-
-### New
-
-- **`engine.components.container.begin_container`** — context manager that
-  declares a bounded rectangle for a block component on a slide. Shapes
-  added inside the `with` block via the atomic primitives
-  (`_add_shape` / `_add_textbox` / `_add_image` / `add_auto_fit_textbox`)
-  are auto-tagged against the innermost active container via a thread-local
-  stack. Supports nested containers and per-container `padding`.
-- **`ContainerBounds`** dataclass — exposes `inner_bounds()` after padding.
-- **`check_containment(presentation, *, tolerance=0.01)`** — new validator
-  that flags any tagged child whose bbox exits its container's padded
-  bounds. Findings use `category="shape_outside_container"`,
-  `severity="error"`.
-- **`check_deck_extended`** now emits a `containment` key on each slide and
-  counts findings toward `summary.errors`.
-
-### Guarantees
-
-- Atomic primitive signatures are unchanged; tagging is purely additive
-  (a no-op when no container is active).
-- Registry is validator-time metadata only — never serialized into the
-  PPTX XML.
-
-652 → 668 tests passing (+16 new).
+- Atomic primitive signatures are unchanged; container tagging is
+  purely additive (no-op when no container is active). Registry is
+  validator-time metadata only — never serialized into the PPTX XML.
 
 ## v0.5.1 — timeline theme default
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 All notable changes to `pptx-mcp-server` are documented in this file.
 
+## Unreleased / v0.6.0 — KPIRow block component (Issue #133)
+
+Second piece of the v0.6.0 shadcn-for-PPTX component layer: a proper
+block-component KPI row that composes atomic primitives inside a
+container, replacing the v0.2.x simple-callout variant at the canonical
+`pptx_add_kpi_row` name.
+
+### Added
+
+- **`pptx_add_kpi_row` MCP tool (block-component variant)** — new
+  label / big-value / optional-detail layout. Each cell stacks a 9pt
+  label, a 26pt bold single-line auto-fit value, and an optional 8pt
+  detail line. Cells are evenly distributed across `width` with `gap`
+  inches between them. Supports optional `card_fill` / `card_border`
+  frames (e.g. `card_fill="highlight_row"`, `card_border="rule_subtle"`)
+  and a `theme` kwarg for theme-token resolution. Auto-tags child shapes
+  into the active container for containment validation.
+- **`engine.components.kpi_row.KPISpec`** — dataclass spec for a single
+  cell (`label`, `value`, `detail`, `value_color`, `delta_color`
+  (reserved for forward-compat)).
+- **`add_kpi_row_block` engine export** — new alias in
+  `pptx_mcp_server.engine.components`. The underlying function is
+  `engine.components.kpi_row.add_kpi_row`; it is re-exported under the
+  `add_kpi_row_block` name to avoid a name collision with the legacy
+  `engine.composites.add_kpi_row` (still exported unchanged).
+
+### Changed (breaking — MCP surface)
+
+- **Legacy `pptx_add_kpi_row` MCP tool renamed to
+  `pptx_add_kpi_row_legacy`** — callers of the 4-arg signature
+  `(file_path, slide_index, kpis, y)` will fail against the new 7+ arg
+  schema that now owns the canonical name. **The legacy tool is
+  deprecated and will be removed in v0.7.0.** New callers should migrate
+  to the block-component `pptx_add_kpi_row`.
+
+### Migration
+
+```python
+# Before (v0.5.x legacy):
+pptx_add_kpi_row(file_path, slide_index, kpis=[...], y=2.5)
+
+# After (v0.6.0, block component):
+pptx_add_kpi_row(file_path, slide_index, kpis=[...], left=0.5, top=2.5, width=12.0)
+
+# Or, to keep the old behavior unchanged for now (removed in v0.7.0):
+pptx_add_kpi_row_legacy(file_path, slide_index, kpis=[...], y=2.5)
+```
+
+### Non-breaking
+
+- `engine.composites.add_kpi_row` (library-level) is unchanged; only the
+  MCP tool name moved.
+- The legacy tool's runtime behavior is identical — the rename is
+  surface-only so migration is a one-line rename, not a refactor.
+
 ## Unreleased — container primitive (Issue #130)
 
 Foundation for the v0.6.0 shadcn-for-PPTX component layer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to `pptx-mcp-server` are documented in this file.
 
+## Unreleased — container primitive (Issue #130)
+
+Foundation for the v0.6.0 shadcn-for-PPTX component layer.
+
+### New
+
+- **`engine.components.container.begin_container`** — context manager that
+  declares a bounded rectangle for a block component on a slide. Shapes
+  added inside the `with` block via the atomic primitives
+  (`_add_shape` / `_add_textbox` / `_add_image` / `add_auto_fit_textbox`)
+  are auto-tagged against the innermost active container via a thread-local
+  stack. Supports nested containers and per-container `padding`.
+- **`ContainerBounds`** dataclass — exposes `inner_bounds()` after padding.
+- **`check_containment(presentation, *, tolerance=0.01)`** — new validator
+  that flags any tagged child whose bbox exits its container's padded
+  bounds. Findings use `category="shape_outside_container"`,
+  `severity="error"`.
+- **`check_deck_extended`** now emits a `containment` key on each slide and
+  counts findings toward `summary.errors`.
+
+### Guarantees
+
+- Atomic primitive signatures are unchanged; tagging is purely additive
+  (a no-op when no container is active).
+- Registry is validator-time metadata only — never serialized into the
+  PPTX XML.
+
+652 → 668 tests passing (+16 new).
+
 ## v0.5.1 — timeline theme default
 
 Flagged by Codex gpt-5.4 v0.5.0 review: the timeline tool

--- a/README.md
+++ b/README.md
@@ -311,6 +311,11 @@ directly — that tool is unaffected by this gate.
 | `pptx_add_section_divider` | Add a section divider slide with dark background and accent stripes |
 | `pptx_add_kpi_row` | Add a row of N KPI cells (label / big value / optional detail) with optional card frames and theme-aware colors (block component, v0.6.0+) |
 | `pptx_add_kpi_row_legacy` | (Deprecated, removal in v0.7.0) Legacy 4-arg callout-box variant — was `pptx_add_kpi_row` prior to v0.6.0. Migrate to the block-component `pptx_add_kpi_row`. |
+| `pptx_add_metric_card_row` | N bounded cards (label/title/chart slot/metrics-row) side-by-side (block component, v0.6.0+) |
+| `pptx_add_numbered_list` | N numbered items stacked with optional rules between (block component, v0.6.0+) |
+| `pptx_add_section_header` | Title + optional subtitle + divider rule (returns `consumed_height`; block component, v0.6.0+) |
+| `pptx_add_page_marker` | Top-right "section / P.XX" marker (fixed position, v0.6.0+) |
+| `pptx_add_slide_footer` | Bottom-edge left/right footer text (fixed position, v0.6.0+) |
 | `pptx_add_bullet_block` | Add a bulleted text block with multiple items |
 | `pptx_add_responsive_card_row` | Add a row of auto-sized card shapes with title + body |
 | `pptx_add_connector` | Add a connector (straight / elbow / curve) with optional arrowheads |

--- a/README.md
+++ b/README.md
@@ -331,6 +331,54 @@ directly — that tool is unaffected by this gate.
 | `pptx_check_layout` | Validate deck layouts: overlaps, out-of-bounds, overflow, readability |
 | `pptx_render_slide` | Render slide(s) to PNG via LibreOffice for visual verification |
 
+## MCP tool tiers (v0.6.0+)
+
+The MCP surface is split into two tiers (#137) so agents see a focused,
+productive default catalog and only opt into low-level primitives when
+explicitly needed.
+
+**Default surface (~20 tools)** — always registered. Covers
+setup / inspection (`pptx_create`, `pptx_get_info`, `pptx_read_slide`,
+`pptx_add_slide`), block components
+(`pptx_add_section_header`, `pptx_add_kpi_row`,
+`pptx_add_metric_card_row`, `pptx_add_numbered_list`,
+`pptx_add_page_marker`, `pptx_add_slide_footer`), high-level primitives
+(`pptx_add_data_table`, `pptx_add_responsive_card_row`,
+`pptx_add_milestone_timeline`, `pptx_add_flex_container`,
+`pptx_add_chart`, `pptx_add_image`), batch build (`pptx_build_slide`,
+`pptx_build_deck`), and validation / rendering (`pptx_check_layout`,
+`pptx_render_slide`).
+
+**Advanced tier (~25 tools)** — hidden from the MCP catalog unless
+opted in. Covers raw shape primitives (`pptx_add_textbox`,
+`pptx_add_shape`, `pptx_add_auto_fit_textbox`), low-level edit ops
+(`pptx_edit_text`, `pptx_add_paragraph`, `pptx_delete_shape`,
+`pptx_list_shapes`, `pptx_format_shape`), slide-level editing
+(`pptx_set_dimensions`, `pptx_set_slide_background`,
+`pptx_move_slide`, `pptx_delete_slide`, `pptx_duplicate_slide`),
+table-editing primitives (`pptx_add_table`, `pptx_edit_table_cell`,
+`pptx_edit_table_cells`, `pptx_format_table`),
+connectors / callouts / icons (`pptx_add_connector`, `pptx_add_callout`,
+`pptx_add_icon`, `pptx_list_icons`), composite helpers
+(`pptx_add_section_divider`, `pptx_add_content_slide`,
+`pptx_add_bullet_block`), and the deprecated `pptx_add_kpi_row_legacy`.
+
+### Enabling the advanced tier
+
+Set the env var before starting the server:
+
+```bash
+PPTX_MCP_INCLUDE_ADVANCED=1 python -m pptx_mcp_server
+```
+
+The var accepts `1`, `true`, or `yes` (case-insensitive). It is read
+**once at import**, so restart the server after changing it.
+
+Advanced-tier tools remain importable as regular Python functions even
+when the gate is off — `from pptx_mcp_server.server import
+pptx_add_textbox` keeps working for library-mode callers and tests;
+only FastMCP registration is gated.
+
 ## Dependencies
 
 Required (installed by `pip install pptx-mcp-server`):

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Affected tools (and replaced param names):
 | `pptx_build_slide` | `spec_json: str` | `spec: dict` |
 | `pptx_build_deck` | `slides_json: str` | `slides: list[dict]` |
 | `pptx_add_chart` | `chart_json: str` | `chart: dict` |
-| `pptx_add_kpi_row` | `kpis_json: str` | `kpis: list[dict]` |
+| `pptx_add_kpi_row_legacy` (was `pptx_add_kpi_row` pre-v0.6.0; see #133) | `kpis_json: str` | `kpis: list[dict]` |
 | `pptx_add_table` | `rows_json: str` + `col_widths_json: str` | `rows: list[list]` + `col_widths: list[float] \| None` |
 | `pptx_add_bullet_block` | `items_json: str` | `bullets: list[str]` |
 | `pptx_edit_table_cells` | `edits_json: str` | `edits: list[dict]` |
@@ -233,7 +233,8 @@ Affected tools (and replaced param names):
 
 > **BREAKING CHANGE (v0.2.0).** Composite tools
 > (`pptx_add_content_slide`, `pptx_build_slide`, `pptx_build_deck`,
-> `pptx_add_kpi_row`, `pptx_add_bullet_block`, `pptx_add_section_divider`,
+> `pptx_add_kpi_row` (renamed `pptx_add_kpi_row_legacy` in v0.6.0, see #133),
+> `pptx_add_bullet_block`, `pptx_add_section_divider`,
 > `pptx_add_responsive_card_row`, `pptx_add_connector`, `pptx_add_callout`,
 > `pptx_add_chart`, `pptx_add_icon`) previously forked LibreOffice to render
 > a PNG preview after every successful edit (~1.5s, no timeout, no off-switch).
@@ -308,7 +309,8 @@ directly — that tool is unaffected by this gate.
 | `pptx_build_slide` | Build a single slide from a JSON spec |
 | `pptx_add_content_slide` | Add a content slide with action title, divider, footnote, page number |
 | `pptx_add_section_divider` | Add a section divider slide with dark background and accent stripes |
-| `pptx_add_kpi_row` | Add a row of KPI callout boxes |
+| `pptx_add_kpi_row` | Add a row of N KPI cells (label / big value / optional detail) with optional card frames and theme-aware colors (block component, v0.6.0+) |
+| `pptx_add_kpi_row_legacy` | (Deprecated, removal in v0.7.0) Legacy 4-arg callout-box variant — was `pptx_add_kpi_row` prior to v0.6.0. Migrate to the block-component `pptx_add_kpi_row`. |
 | `pptx_add_bullet_block` | Add a bulleted text block with multiple items |
 | `pptx_add_responsive_card_row` | Add a row of auto-sized card shapes with title + body |
 | `pptx_add_connector` | Add a connector (straight / elbow / curve) with optional arrowheads |

--- a/src/pptx_mcp_server/_tool_registry.py
+++ b/src/pptx_mcp_server/_tool_registry.py
@@ -1,0 +1,78 @@
+"""Tool-tier gating for FastMCP registration (v0.6.0, #137).
+
+FastMCP doesn't natively support tool tiering. This module provides a
+custom :func:`mcp_tool` decorator that gates registration by env var,
+keeping the default agent-facing surface focused on the productive
+block-component + batch layer while hiding atomic raw-shape primitives
+behind ``PPTX_MCP_INCLUDE_ADVANCED=1``.
+
+Design notes
+------------
+* Advanced tools still exist as callable Python functions even when the
+  env var is unset — the decorator simply skips FastMCP registration in
+  that case. Existing library-mode tests that import tool functions
+  directly (``from pptx_mcp_server.server import pptx_add_textbox``)
+  keep working untouched.
+* The env var is read **once at module import**. Tests that flip the
+  gate mid-run must ``importlib.reload`` this module *and* ``server``
+  so the registration decisions are re-evaluated.
+* Classification is tracked in a module-level set so tests can assert
+  exhaustiveness / count stability.
+"""
+
+from __future__ import annotations
+
+import os
+
+__all__ = [
+    "mcp_tool",
+    "is_advanced_enabled",
+    "advanced_tool_names",
+]
+
+_ADVANCED_TOOLS: set[str] = set()
+_INCLUDE_ADVANCED: bool = (
+    os.environ.get("PPTX_MCP_INCLUDE_ADVANCED", "").strip().lower()
+    in {"1", "true", "yes"}
+)
+
+
+def is_advanced_enabled() -> bool:
+    """Return True when ``PPTX_MCP_INCLUDE_ADVANCED`` is set to a truthy
+    value at import time (``"1"``, ``"true"``, ``"yes"`` — any casing)."""
+    return _INCLUDE_ADVANCED
+
+
+def mcp_tool(mcp, *, advanced: bool = False):
+    """Register a FastMCP tool with tier classification.
+
+    Usage mirrors :meth:`FastMCP.tool`::
+
+        @mcp_tool(mcp)
+        def pptx_foo(...): ...
+
+        @mcp_tool(mcp, advanced=True)
+        def pptx_bar(...): ...
+
+    When ``advanced=True`` and :envvar:`PPTX_MCP_INCLUDE_ADVANCED` is
+    unset, the tool is **not** registered with the MCP server (agents
+    won't see it) but the Python function remains importable for
+    library-mode callers and tests. When ``advanced=False`` the tool is
+    always registered.
+    """
+
+    def decorator(fn):
+        if advanced:
+            _ADVANCED_TOOLS.add(fn.__name__)
+            if not _INCLUDE_ADVANCED:
+                # Not registered with FastMCP; still importable.
+                return fn
+        return mcp.tool()(fn)
+
+    return decorator
+
+
+def advanced_tool_names() -> frozenset[str]:
+    """Return the set of tools classified as advanced (registered or
+    not). Useful for introspection and for the exhaustiveness test."""
+    return frozenset(_ADVANCED_TOOLS)

--- a/src/pptx_mcp_server/engine/__init__.py
+++ b/src/pptx_mcp_server/engine/__init__.py
@@ -81,6 +81,12 @@ from .components.container import (
     ContainerBounds,
     begin_container,
 )
+from .components.metric_card import (
+    MetricEntry,
+    MetricCardSpec,
+    add_metric_card,
+    add_metric_card_row,
+)
 from .connectors import (
     add_connector,
     add_callout,
@@ -152,6 +158,7 @@ __all__ = [
     "ValidationFinding",
     # Components
     "ContainerBounds", "begin_container",
+    "MetricEntry", "MetricCardSpec", "add_metric_card", "add_metric_card_row",
     # Composites
     "add_content_slide", "add_section_divider", "add_kpi_row", "add_bullet_block",
     "build_slide", "build_deck",

--- a/src/pptx_mcp_server/engine/__init__.py
+++ b/src/pptx_mcp_server/engine/__init__.py
@@ -81,6 +81,10 @@ from .components.container import (
     ContainerBounds,
     begin_container,
 )
+from .components.numbered_list import (
+    NumberedItem,
+    add_numbered_list,
+)
 from .connectors import (
     add_connector,
     add_callout,
@@ -152,6 +156,7 @@ __all__ = [
     "ValidationFinding",
     # Components
     "ContainerBounds", "begin_container",
+    "NumberedItem", "add_numbered_list",
     # Composites
     "add_content_slide", "add_section_divider", "add_kpi_row", "add_bullet_block",
     "build_slide", "build_deck",

--- a/src/pptx_mcp_server/engine/__init__.py
+++ b/src/pptx_mcp_server/engine/__init__.py
@@ -81,6 +81,10 @@ from .components.container import (
     ContainerBounds,
     begin_container,
 )
+from .components.kpi_row import (
+    KPISpec,
+    add_kpi_row as add_kpi_row_block,
+)
 from .connectors import (
     add_connector,
     add_callout,
@@ -152,6 +156,7 @@ __all__ = [
     "ValidationFinding",
     # Components
     "ContainerBounds", "begin_container",
+    "KPISpec", "add_kpi_row_block",
     # Composites
     "add_content_slide", "add_section_divider", "add_kpi_row", "add_bullet_block",
     "build_slide", "build_deck",

--- a/src/pptx_mcp_server/engine/__init__.py
+++ b/src/pptx_mcp_server/engine/__init__.py
@@ -74,7 +74,12 @@ from .validation import (
     check_unreadable_text,
     check_divider_collision,
     check_inconsistent_gaps,
+    check_containment,
     ValidationFinding,
+)
+from .components.container import (
+    ContainerBounds,
+    begin_container,
 )
 from .connectors import (
     add_connector,
@@ -143,7 +148,10 @@ __all__ = [
     "check_deck_overlaps", "check_slide_overlaps", "check_deck_extended",
     "check_text_overflow", "check_unreadable_text",
     "check_divider_collision", "check_inconsistent_gaps",
+    "check_containment",
     "ValidationFinding",
+    # Components
+    "ContainerBounds", "begin_container",
     # Composites
     "add_content_slide", "add_section_divider", "add_kpi_row", "add_bullet_block",
     "build_slide", "build_deck",

--- a/src/pptx_mcp_server/engine/__init__.py
+++ b/src/pptx_mcp_server/engine/__init__.py
@@ -81,6 +81,10 @@ from .components.container import (
     ContainerBounds,
     begin_container,
 )
+from .components.section_header import (
+    SectionHeaderSpec,
+    add_section_header,
+)
 from .connectors import (
     add_connector,
     add_callout,
@@ -152,6 +156,7 @@ __all__ = [
     "ValidationFinding",
     # Components
     "ContainerBounds", "begin_container",
+    "SectionHeaderSpec", "add_section_header",
     # Composites
     "add_content_slide", "add_section_divider", "add_kpi_row", "add_bullet_block",
     "build_slide", "build_deck",

--- a/src/pptx_mcp_server/engine/__init__.py
+++ b/src/pptx_mcp_server/engine/__init__.py
@@ -81,6 +81,12 @@ from .components.container import (
     ContainerBounds,
     begin_container,
 )
+from .components.markers import (
+    PageMarkerSpec,
+    SlideFooterSpec,
+    add_page_marker,
+    add_slide_footer,
+)
 from .connectors import (
     add_connector,
     add_callout,
@@ -152,6 +158,8 @@ __all__ = [
     "ValidationFinding",
     # Components
     "ContainerBounds", "begin_container",
+    "PageMarkerSpec", "SlideFooterSpec",
+    "add_page_marker", "add_slide_footer",
     # Composites
     "add_content_slide", "add_section_divider", "add_kpi_row", "add_bullet_block",
     "build_slide", "build_deck",

--- a/src/pptx_mcp_server/engine/components/__init__.py
+++ b/src/pptx_mcp_server/engine/components/__init__.py
@@ -1,0 +1,17 @@
+"""Component-layer primitives for pptx-mcp-server (v0.6.0+).
+
+This sub-package hosts higher-level "block" components (cards, containers,
+etc.) that compose atomic primitives from the engine into reusable layout
+units. The atomic primitive API (``engine.shapes`` etc.) is intentionally
+kept unchanged — components live here so v0.5.x users are not affected.
+"""
+
+from .container import (
+    ContainerBounds,
+    begin_container,
+)
+
+__all__ = [
+    "ContainerBounds",
+    "begin_container",
+]

--- a/src/pptx_mcp_server/engine/components/__init__.py
+++ b/src/pptx_mcp_server/engine/components/__init__.py
@@ -13,6 +13,7 @@ from .container import (
 )
 from .kpi_row import (
     KPISpec,
+    # Aliased to avoid collision with legacy `engine.composites.add_kpi_row`.
     add_kpi_row as add_kpi_row_block,
 )
 

--- a/src/pptx_mcp_server/engine/components/__init__.py
+++ b/src/pptx_mcp_server/engine/components/__init__.py
@@ -11,9 +11,15 @@ from .container import (
     begin_container,
     clear_slide_containers,
 )
+from .kpi_row import (
+    KPISpec,
+    add_kpi_row as add_kpi_row_block,
+)
 
 __all__ = [
     "ContainerBounds",
     "begin_container",
     "clear_slide_containers",
+    "KPISpec",
+    "add_kpi_row_block",
 ]

--- a/src/pptx_mcp_server/engine/components/__init__.py
+++ b/src/pptx_mcp_server/engine/components/__init__.py
@@ -9,9 +9,11 @@ kept unchanged — components live here so v0.5.x users are not affected.
 from .container import (
     ContainerBounds,
     begin_container,
+    clear_slide_containers,
 )
 
 __all__ = [
     "ContainerBounds",
     "begin_container",
+    "clear_slide_containers",
 ]

--- a/src/pptx_mcp_server/engine/components/__init__.py
+++ b/src/pptx_mcp_server/engine/components/__init__.py
@@ -11,9 +11,19 @@ from .container import (
     begin_container,
     clear_slide_containers,
 )
+from .markers import (
+    PageMarkerSpec,
+    SlideFooterSpec,
+    add_page_marker,
+    add_slide_footer,
+)
 
 __all__ = [
     "ContainerBounds",
     "begin_container",
     "clear_slide_containers",
+    "PageMarkerSpec",
+    "SlideFooterSpec",
+    "add_page_marker",
+    "add_slide_footer",
 ]

--- a/src/pptx_mcp_server/engine/components/__init__.py
+++ b/src/pptx_mcp_server/engine/components/__init__.py
@@ -11,9 +11,15 @@ from .container import (
     begin_container,
     clear_slide_containers,
 )
+from .section_header import (
+    SectionHeaderSpec,
+    add_section_header,
+)
 
 __all__ = [
     "ContainerBounds",
     "begin_container",
     "clear_slide_containers",
+    "SectionHeaderSpec",
+    "add_section_header",
 ]

--- a/src/pptx_mcp_server/engine/components/__init__.py
+++ b/src/pptx_mcp_server/engine/components/__init__.py
@@ -11,9 +11,19 @@ from .container import (
     begin_container,
     clear_slide_containers,
 )
+from .metric_card import (
+    MetricEntry,
+    MetricCardSpec,
+    add_metric_card,
+    add_metric_card_row,
+)
 
 __all__ = [
     "ContainerBounds",
     "begin_container",
     "clear_slide_containers",
+    "MetricEntry",
+    "MetricCardSpec",
+    "add_metric_card",
+    "add_metric_card_row",
 ]

--- a/src/pptx_mcp_server/engine/components/__init__.py
+++ b/src/pptx_mcp_server/engine/components/__init__.py
@@ -11,9 +11,15 @@ from .container import (
     begin_container,
     clear_slide_containers,
 )
+from .numbered_list import (
+    NumberedItem,
+    add_numbered_list,
+)
 
 __all__ = [
     "ContainerBounds",
     "begin_container",
     "clear_slide_containers",
+    "NumberedItem",
+    "add_numbered_list",
 ]

--- a/src/pptx_mcp_server/engine/components/_util.py
+++ b/src/pptx_mcp_server/engine/components/_util.py
@@ -1,0 +1,39 @@
+"""Shared helpers for v0.6.0+ block components."""
+
+from __future__ import annotations
+
+# Canonical fallback palette used when no ``theme`` is supplied.
+# Mirrors the MCKINSEY theme for the 4 tokens that block components use
+# as defaults. Keep in sync with engine.theme.MCKINSEY.
+_FALLBACK_TOKENS: dict[str, str] = {
+    "primary": "051C2C",
+    "text_secondary": "666666",
+    "rule_subtle": "E0E0E0",
+    "highlight_row": "F8F9F5",
+}
+
+
+def resolve_component_color(token_or_hex: str, theme: str | None) -> str:
+    """Resolve a component color token to a raw 6-hex string.
+
+    Behavior:
+    - Empty / None input → return as-is (empty means "disable fill" etc.)
+    - If ``theme`` is a non-empty string → delegate to ``resolve_theme_color``
+      (centralised engine/theme.py helper; same behavior as v0.5.0
+      atomic primitives).
+    - Else (theme is None): look up in ``_FALLBACK_TOKENS``; if not a known
+      token, strip any leading ``#`` and return the input unchanged (treat
+      as raw hex; downstream ``_parse_color`` will validate).
+
+    This replaces 5 per-component ``_resolve_color`` helpers that had crept
+    into subtle behavior drift. All block components must use this helper.
+    """
+    if not token_or_hex:
+        return token_or_hex
+    if theme:
+        from ...theme import resolve_theme_color
+        return resolve_theme_color(token_or_hex, theme)
+    token = _FALLBACK_TOKENS.get(token_or_hex)
+    if token is not None:
+        return token
+    return token_or_hex.lstrip("#")

--- a/src/pptx_mcp_server/engine/components/container.py
+++ b/src/pptx_mcp_server/engine/components/container.py
@@ -1,0 +1,244 @@
+"""Container primitive — declare a bounded rectangle for child shapes.
+
+``begin_container`` is a context manager that declares a logical bounding box
+on a slide. Shapes added by atomic primitives (``_add_shape``, ``_add_textbox``,
+``_add_image``, ``add_auto_fit_textbox``) inside the ``with`` block are auto-
+registered against the innermost active container via a thread-local stack.
+The registry is validator-time metadata only — it is **not** serialized into
+the PPTX file (see Issue #130).
+
+Two data structures back this feature:
+
+1. ``_CONTAINER_STACK`` — a ``threading.local`` list used during ``with``
+   blocks to route newly created shapes to the innermost open container.
+2. ``_SLIDE_REGISTRY`` — a module-level ``dict`` keyed by ``id(slide)`` that
+   persists container declarations beyond the ``with`` block so the
+   validator (``check_containment``) can inspect them later.
+
+The validator key is ``id(slide)`` which is stable for the lifetime of the
+Python slide object (that is all we need; containment is checked before the
+slide is garbage collected). For shape identity we store the shape's XML
+``name`` plus its bbox at tag time — python-pptx rebuilds shape wrappers on
+each access, so ``id(shape)`` is unreliable, but the name survives round-
+trips within a single in-memory session.
+"""
+
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Dict, Iterator, List, Optional, Tuple
+
+
+@dataclass
+class ShapeRef:
+    """Lightweight handle to a shape tagged inside a container.
+
+    Holds the shape's ``name`` (as assigned by python-pptx on creation) plus
+    its bbox at tag time. ``check_containment`` re-resolves the live shape
+    by walking ``slide.shapes`` and matching on ``name`` — falling back to
+    the cached bbox if the name cannot be found.
+    """
+
+    name: str
+    left: float
+    top: float
+    width: float
+    height: float
+
+
+@dataclass
+class ContainerBounds:
+    """Declared bounding rectangle for a logical component on a slide.
+
+    Attributes:
+        name: Semantic label (e.g. ``"metric_card_0"``). Used in validator
+            findings so the author can quickly locate the offending
+            container in their code.
+        left, top, width, height: Outer bbox in inches.
+        padding: Inset (inches) subtracted equally from each side when
+            computing the effective bounds children must fit inside.
+            Default 0 (bounds == outer bbox).
+        children: Shapes registered while this container was the innermost
+            active entry on the thread-local stack. Populated by
+            ``_register_with_active_container``.
+    """
+
+    name: str
+    left: float
+    top: float
+    width: float
+    height: float
+    padding: float = 0.0
+    children: List[ShapeRef] = field(default_factory=list)
+
+    def inner_bounds(self) -> Tuple[float, float, float, float]:
+        """Return ``(left, top, right, bottom)`` after applying ``padding``."""
+        pad = self.padding
+        return (
+            self.left + pad,
+            self.top + pad,
+            self.left + self.width - pad,
+            self.top + self.height - pad,
+        )
+
+
+# Thread-local stack of (slide_id, ContainerBounds) tuples. Innermost container
+# is at the end of the list. Only the innermost matching-slide entry receives
+# the new shape on registration.
+_thread_local = threading.local()
+
+
+def _get_stack() -> List[Tuple[int, ContainerBounds]]:
+    """Return this thread's container stack, lazily initializing it."""
+    stack = getattr(_thread_local, "stack", None)
+    if stack is None:
+        stack = []
+        _thread_local.stack = stack
+    return stack
+
+
+# Persistent per-slide registry: ``id(slide) -> list[ContainerBounds]``.
+# Entries live until ``clear_container_registry`` is called (tests) or the
+# slide object is replaced. This is validator-time metadata — never
+# serialized into the PPTX XML.
+_SLIDE_REGISTRY: Dict[int, List[ContainerBounds]] = {}
+
+
+def _get_slide_containers(slide) -> List[ContainerBounds]:
+    """Return the list of declared containers for ``slide`` (may be empty)."""
+    return _SLIDE_REGISTRY.get(id(slide), [])
+
+
+def iter_slide_containers(slide) -> Iterator[ContainerBounds]:
+    """Iterate declared containers for ``slide`` (validator consumption)."""
+    for bounds in _get_slide_containers(slide):
+        yield bounds
+
+
+def clear_container_registry() -> None:
+    """Drop all registered containers. Primarily for test isolation."""
+    _SLIDE_REGISTRY.clear()
+    # Also clear the thread-local stack for safety; tests that interleave
+    # with un-matched begin_container/exit flows should not leak state.
+    stack = getattr(_thread_local, "stack", None)
+    if stack is not None:
+        stack.clear()
+
+
+@contextmanager
+def begin_container(
+    slide,
+    *,
+    name: str,
+    left: float,
+    top: float,
+    width: float,
+    height: float,
+    padding: float = 0.0,
+):
+    """Declare a bounded container on ``slide``.
+
+    Children added while this context is active are tagged against this
+    container via a thread-local stack and — after the block exits — can be
+    inspected by ``check_containment`` to flag any child whose bbox escapes
+    the declared bounds.
+
+    Nested containers are supported: a ``begin_container`` call inside
+    another ``begin_container`` pushes onto the same thread-local stack, and
+    newly added shapes are registered against the innermost entry only.
+
+    Args:
+        slide: The python-pptx slide object children will be added to.
+        name: Semantic label for validator messages.
+        left, top, width, height: Outer bbox in inches.
+        padding: Inner inset in inches (default 0). ``check_containment``
+            enforces ``child.bbox ⊆ (outer shrunk by padding)``.
+
+    Yields:
+        The ``ContainerBounds`` instance. Callers may use it to read back
+        the bounds they declared (e.g. for relative-positioning math).
+    """
+    bounds = ContainerBounds(
+        name=name,
+        left=float(left),
+        top=float(top),
+        width=float(width),
+        height=float(height),
+        padding=float(padding),
+    )
+
+    # Persistent registry for the validator.
+    _SLIDE_REGISTRY.setdefault(id(slide), []).append(bounds)
+
+    # Thread-local stack for auto-tagging new shapes.
+    stack = _get_stack()
+    stack.append((id(slide), bounds))
+    try:
+        yield bounds
+    finally:
+        # Pop our entry. Find from the top in case an inner block forgot to
+        # pop (defensive; normally stack top IS our entry).
+        for i in range(len(stack) - 1, -1, -1):
+            if stack[i][1] is bounds:
+                del stack[i]
+                break
+
+
+def _register_with_active_container(
+    slide,
+    shape,
+    left: float,
+    top: float,
+    width: float,
+    height: float,
+) -> None:
+    """If a matching container is active on this thread, register ``shape``.
+
+    Called by atomic primitives (``_add_shape``, ``_add_textbox``,
+    ``_add_image``, ``add_auto_fit_textbox``) after the shape has been
+    created. Silently no-ops if:
+
+    - No container is active on this thread.
+    - The innermost container's slide does not match (e.g. the caller
+      switched slides inside the ``with`` block).
+    - ``shape`` has no ``.name`` attribute (e.g. a stubbed slide used in
+      unit tests that pass a mock — don't crash).
+
+    Only the innermost matching container receives the ShapeRef. Outer
+    containers implicitly "see" the shape too via the nesting relationship
+    (inner bounds are expected to lie inside outer bounds); this matches
+    how CSS / DOM containment is typically reasoned about and keeps the
+    registration cheap.
+    """
+    stack = _get_stack()
+    if not stack:
+        return
+    slide_id = id(slide)
+    # Innermost matching slide only.
+    for i in range(len(stack) - 1, -1, -1):
+        entry_slide_id, bounds = stack[i]
+        if entry_slide_id == slide_id:
+            shape_name = _safe_shape_name(shape)
+            bounds.children.append(
+                ShapeRef(
+                    name=shape_name,
+                    left=float(left),
+                    top=float(top),
+                    width=float(width),
+                    height=float(height),
+                )
+            )
+            return
+
+
+def _safe_shape_name(shape) -> str:
+    """Best-effort extraction of ``shape.name`` for registry lookups."""
+    try:
+        n = shape.name
+    except Exception:  # pragma: no cover - defensive
+        n = None
+    if not n:
+        return ""
+    return str(n)

--- a/src/pptx_mcp_server/engine/components/container.py
+++ b/src/pptx_mcp_server/engine/components/container.py
@@ -127,6 +127,16 @@ def clear_container_registry() -> None:
         stack.clear()
 
 
+def clear_slide_containers(slide) -> None:
+    """Remove any container entries registered against this slide.
+
+    Called at the end of a validation pass so long-running processes
+    don't leak memory, and so ``id(slide)`` reuse can't bleed stale
+    bounds into a freshly-loaded slide.
+    """
+    _SLIDE_REGISTRY.pop(id(slide), None)
+
+
 @contextmanager
 def begin_container(
     slide,

--- a/src/pptx_mcp_server/engine/components/kpi_row.py
+++ b/src/pptx_mcp_server/engine/components/kpi_row.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from ._util import resolve_component_color as _resolve_color
+
 
 __all__ = ["KPISpec", "add_kpi_row"]
 
@@ -52,39 +54,10 @@ class KPISpec:
     delta_color: str = "primary"  # reserved; unused in MVP
 
 
-# Theme-token fallback map: used when ``theme=None`` so hardcoded token names
-# inside the renderer still resolve to reasonable hex colors without a theme
-# registry lookup. Keys mirror the v0.6.0 standard tokens (primary,
-# text_secondary, highlight_row, rule_subtle). Values are ``#``-less 6-hex.
-_FALLBACK_TOKENS = {
-    "primary": "051C2C",
-    "text_secondary": "666666",
-    "highlight_row": "F8F9F5",  # cream
-    "rule_subtle": "E0E0E0",
-}
-
-
-def _resolve_color(token_or_hex: str, theme: Optional[str]) -> str:
-    """Resolve a theme token / raw hex to ``#``-less 6-hex.
-
-    If ``theme`` is provided, delegate to the shared
-    ``pptx_mcp_server.theme.resolve_theme_color`` so the caller's chosen
-    palette is honored. Otherwise fall back to the built-in token map
-    (primary, text_secondary, highlight_row, rule_subtle) so a no-theme
-    caller still gets sensible defaults. Raw hex inputs pass through
-    unchanged.
-
-    The helper is defined locally (rather than pulled from theme.py) so
-    the component's fallback behavior stays unit-test-stable even as the
-    shared theme module evolves.
-    """
-    if theme:
-        # Imported lazily to keep component-level import cost low and avoid
-        # any theory-of-circularity issues during engine init.
-        from pptx_mcp_server.theme import resolve_theme_color
-
-        return resolve_theme_color(token_or_hex, theme)
-    return _FALLBACK_TOKENS.get(token_or_hex, token_or_hex)
+# Theme-token resolution is delegated to the shared
+# ``engine.components._util.resolve_component_color`` helper (imported above
+# as ``_resolve_color``). Fallback palette covers the 4 v0.6.0 standard
+# tokens (primary, text_secondary, highlight_row, rule_subtle).
 
 
 # Layout constants (inches) — tuned for a 0.95" cell height default. Y
@@ -130,7 +103,7 @@ def add_kpi_row(
         gap: horizontal spacing between cells in inches.
         theme: optional theme-registry key (``"ir"``, ``"mckinsey"``, …).
             When ``None``, hardcoded fallback colors are used (see
-            ``_FALLBACK_TOKENS``).
+            ``engine.components._util._FALLBACK_TOKENS``).
         card_fill: optional theme token / hex for a per-cell rectangle
             fill. ``None`` means no fill. Typical value: ``"highlight_row"``.
         card_border: optional theme token / hex for a per-cell rectangle

--- a/src/pptx_mcp_server/engine/components/kpi_row.py
+++ b/src/pptx_mcp_server/engine/components/kpi_row.py
@@ -1,0 +1,282 @@
+"""KPIRow block component (Issue #133, v0.6.0).
+
+Renders N KPI cells evenly distributed across a horizontal ``width`` with a
+fixed ``gap`` between cells. Each cell stacks a short label (9pt), a large
+value (26pt, bold, wrap=False auto-fit) and an optional detail line (8pt).
+
+Typical consulting / IR use:
+
+    with begin_container(slide, name="kpi_row", left=L, top=T, width=W, height=H):
+        add_kpi_row(slide, kpis, left=L, top=T, width=W, height=H, theme="ir")
+
+The component wraps its own ``begin_container(name="kpi_row")`` so child
+shapes are validator-visible via ``check_containment``.
+
+Theme tokens are resolved via a thin local helper so a caller passing
+``theme=None`` still gets sensible defaults (matches the v0.6.0 atomic-
+primitive convention established in #131).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+__all__ = ["KPISpec", "add_kpi_row"]
+
+
+@dataclass
+class KPISpec:
+    """Specification for a single KPI cell in a KPIRow.
+
+    Attributes:
+        label: Short descriptor above the value (e.g. ``"Revenue"``).
+        value: Large-format numeric / text value (e.g. ``"107.8M"``,
+            ``"+12.3%"``, ``"プレミアムモルツ +156%"``). Single-line with
+            auto-fit shrink + ellipsis fallback.
+        detail: Optional smaller caption below the value (e.g.
+            ``"+12% QoQ"``). When empty, the detail textbox is not created
+            and no vertical space is reclaimed — cells remain uniform.
+        value_color: Theme token (e.g. ``"primary"``, ``"positive"``) or
+            hex (e.g. ``"051C2C"``) for the value text.
+        delta_color: Reserved for a future delta / arrow variant. Not
+            consumed by the MVP renderer; kept on the dataclass so callers
+            can pre-wire it without breaking a later minor bump.
+    """
+
+    label: str
+    value: str
+    detail: str = ""
+    value_color: str = "primary"
+    delta_color: str = "primary"  # reserved; unused in MVP
+
+
+# Theme-token fallback map: used when ``theme=None`` so hardcoded token names
+# inside the renderer still resolve to reasonable hex colors without a theme
+# registry lookup. Keys mirror the v0.6.0 standard tokens (primary,
+# text_secondary, highlight_row, rule_subtle). Values are ``#``-less 6-hex.
+_FALLBACK_TOKENS = {
+    "primary": "051C2C",
+    "text_secondary": "666666",
+    "highlight_row": "F8F9F5",  # cream
+    "rule_subtle": "E0E0E0",
+}
+
+
+def _resolve_color(token_or_hex: str, theme: Optional[str]) -> str:
+    """Resolve a theme token / raw hex to ``#``-less 6-hex.
+
+    If ``theme`` is provided, delegate to the shared
+    ``pptx_mcp_server.theme.resolve_theme_color`` so the caller's chosen
+    palette is honored. Otherwise fall back to the built-in token map
+    (primary, text_secondary, highlight_row, rule_subtle) so a no-theme
+    caller still gets sensible defaults. Raw hex inputs pass through
+    unchanged.
+
+    The helper is defined locally (rather than pulled from theme.py) so
+    the component's fallback behavior stays unit-test-stable even as the
+    shared theme module evolves.
+    """
+    if theme:
+        # Imported lazily to keep component-level import cost low and avoid
+        # any theory-of-circularity issues during engine init.
+        from pptx_mcp_server.theme import resolve_theme_color
+
+        return resolve_theme_color(token_or_hex, theme)
+    return _FALLBACK_TOKENS.get(token_or_hex, token_or_hex)
+
+
+# Layout constants (inches) — tuned for a 0.95" cell height default. Y
+# offsets inside a cell:
+#
+#   label  : [0.00 .. 0.22)     9pt  text_secondary   wrap=True
+#   (gap)  : [0.22 .. 0.24)     (2 pt visual breathing room)
+#   value  : [0.24 .. 0.74)     26pt bold value_color wrap=False auto-fit
+#   detail : [0.76 .. 0.94)     8pt  text_secondary   wrap=True (optional)
+#
+# If the caller passes a taller ``height``, the stacked blocks sit at the
+# top of the cell and the extra room appears below the detail line. This
+# mirrors how existing card_row components behave (top-aligned stack).
+_LABEL_H = 0.22
+_LABEL_VALUE_GAP = 0.02
+_VALUE_H = 0.50
+_DETAIL_TOP_OFFSET = 0.76
+_DETAIL_H = 0.18
+
+
+def add_kpi_row(
+    slide,
+    kpis: List[KPISpec],
+    *,
+    left: float,
+    top: float,
+    width: float,
+    height: float = 0.95,
+    gap: float = 0.15,
+    theme: Optional[str] = None,
+    card_fill: Optional[str] = None,
+    card_border: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Render ``kpis`` as a horizontal row of N evenly distributed cells.
+
+    Each cell width is ``(width - (n-1) * gap) / n``. When ``n == 1`` the
+    single cell consumes the full ``width`` and ``gap`` is ignored.
+
+    Args:
+        slide: python-pptx slide object.
+        kpis: list of ``KPISpec`` instances. Must be non-empty.
+        left, top, width, height: cell-row bbox in inches.
+        gap: horizontal spacing between cells in inches.
+        theme: optional theme-registry key (``"ir"``, ``"mckinsey"``, …).
+            When ``None``, hardcoded fallback colors are used (see
+            ``_FALLBACK_TOKENS``).
+        card_fill: optional theme token / hex for a per-cell rectangle
+            fill. ``None`` means no fill. Typical value: ``"highlight_row"``.
+        card_border: optional theme token / hex for a per-cell rectangle
+            border. ``None`` means no border. Typical value: ``"rule_subtle"``.
+
+    Returns:
+        dict with keys:
+            - ``cells``: per-cell dicts with ``bounds``, ``label_shape``,
+              ``value_shape``, ``detail_shape`` (or ``None``),
+              ``card_shape`` (or ``None``), and ``value_actual_font_size``
+              (float; < 26 when auto-fit shrank the value).
+            - ``consumed_height`` / ``consumed_width``: mirrors the input
+              so callers composing vertical stacks know how much space
+              the row consumed.
+
+    Notes:
+        The function wraps its children in ``begin_container(name="kpi_row")``
+        so ``check_containment`` can verify nothing escapes the row bbox.
+        All atomic-primitive shape calls pass ``theme=None`` because color
+        tokens have already been resolved by ``_resolve_color``; letting
+        the primitive resolve again would either double-resolve or fail.
+    """
+    # 循環 import 回避: components/ 配下は engine.shapes を lazy import する
+    # (#135/#136 で確立した pattern を踏襲)。engine/__init__ の読み込み順に
+    # 対する defensive measure で、直接的な循環は現状発生しないが、将来の
+    # components/ 内相互依存 (#134 など) で顕在化しうるため予防する。
+    from ..shapes import _add_shape, add_auto_fit_textbox
+    from .container import begin_container
+
+    n = len(kpis)
+    if n <= 0:
+        # Empty input: container still declared so container-aware callers
+        # don't blow up, but no cells are rendered.
+        with begin_container(
+            slide, name="kpi_row",
+            left=left, top=top, width=width, height=height,
+        ):
+            pass
+        return {"cells": [], "consumed_height": height, "consumed_width": width}
+
+    if n == 1:
+        cell_w = width
+    else:
+        cell_w = (width - (n - 1) * gap) / n
+
+    # Pre-resolve frame colors once; they're identical across cells.
+    card_fill_hex = _resolve_color(card_fill, theme) if card_fill else None
+    card_border_hex = _resolve_color(card_border, theme) if card_border else None
+
+    cells: List[Dict[str, Any]] = []
+
+    with begin_container(
+        slide, name="kpi_row",
+        left=left, top=top, width=width, height=height,
+    ):
+        for i, spec in enumerate(kpis):
+            cell_x = left + i * (cell_w + gap) if n > 1 else left
+
+            # 1) Card rectangle first, so text sits above it in z-order.
+            card_shape = None
+            if card_fill_hex or card_border_hex:
+                idx = _add_shape(
+                    slide,
+                    "rectangle",
+                    cell_x,
+                    top,
+                    cell_w,
+                    height,
+                    fill_color=card_fill_hex,
+                    line_color=card_border_hex,
+                    no_line=(card_border_hex is None),
+                    # テーマは既に local _resolve_color で解決済み。ここで
+                    # 再度 theme を渡すと resolve_theme_color が二重に走って
+                    # hex をトークンとして誤解釈するリスクがあるため None.
+                    theme=None,
+                )
+                card_shape = slide.shapes[idx]
+
+            # 2) Label (9pt, text_secondary).
+            label_shape, _ = add_auto_fit_textbox(
+                slide,
+                spec.label,
+                cell_x,
+                top,
+                cell_w,
+                _LABEL_H,
+                font_size_pt=9,
+                min_size_pt=7,
+                color_hex=_resolve_color("text_secondary", theme),
+                align="left",
+                wrap=True,
+                theme=None,
+            )
+
+            # 3) Value (26pt bold; single-line auto-fit via wrap=False).
+            value_top = top + _LABEL_H + _LABEL_VALUE_GAP
+            value_shape, value_size = add_auto_fit_textbox(
+                slide,
+                spec.value,
+                cell_x,
+                value_top,
+                cell_w,
+                _VALUE_H,
+                font_size_pt=26,
+                min_size_pt=14,
+                bold=True,
+                color_hex=_resolve_color(spec.value_color, theme),
+                align="left",
+                wrap=False,
+                theme=None,
+            )
+
+            # 4) Detail (optional, 8pt).
+            detail_shape = None
+            if spec.detail:
+                detail_shape, _ = add_auto_fit_textbox(
+                    slide,
+                    spec.detail,
+                    cell_x,
+                    top + _DETAIL_TOP_OFFSET,
+                    cell_w,
+                    _DETAIL_H,
+                    font_size_pt=8,
+                    min_size_pt=6,
+                    color_hex=_resolve_color("text_secondary", theme),
+                    align="left",
+                    wrap=True,
+                    theme=None,
+                )
+
+            cells.append({
+                "bounds": {
+                    "left": cell_x,
+                    "top": top,
+                    "width": cell_w,
+                    "height": height,
+                },
+                "label_shape": label_shape,
+                "value_shape": value_shape,
+                "detail_shape": detail_shape,
+                "card_shape": card_shape,
+                "value_actual_font_size": float(value_size),
+            })
+
+    return {
+        "cells": cells,
+        "consumed_height": height,
+        "consumed_width": width,
+    }

--- a/src/pptx_mcp_server/engine/components/markers.py
+++ b/src/pptx_mcp_server/engine/components/markers.py
@@ -38,6 +38,37 @@ from typing import Optional
 # スライド左右端からの水平マージン。
 _MARGIN: float = 0.5
 
+# ---------------------------------------------------------------------------
+# theme=None fallback for well-known color tokens.
+#
+# ``add_auto_fit_textbox`` は ``color_hex`` が hex でない場合に
+# ``#<token>`` として parse しようとして落ちる。呼び出し側が theme を
+# 指定していれば ``resolve_theme_color`` がトークンを hex に変換するが、
+# MCP ツール経由では既定が ``theme=None`` のため、デフォルト
+# ``"text_secondary"`` だけで EngineError が出てしまう (#135 CQ review)。
+# ここでは timeline.py / MCKINSEY / IR と整合する最小の hex 代替を持ち、
+# ``theme`` 未指定時のみ差し替える。テーマが指定されていれば一切介入
+# しない (二重解決回避)。
+# ---------------------------------------------------------------------------
+_TOKEN_FALLBACK_HEX: dict[str, str] = {
+    "text_secondary": "666666",
+    "primary": "051C2C",
+    "rule_subtle": "E0E0E0",
+}
+
+
+def _resolve_color(token_or_hex: str, theme: Optional[str]) -> str:
+    """``theme`` 未指定時に既知のトークンを hex にフォールバックする.
+
+    ``theme`` が与えられていれば入力はそのまま返し、下流の
+    ``add_auto_fit_textbox`` が ``resolve_theme_color`` で解決する。
+    ``theme is None`` で入力が ``_TOKEN_FALLBACK_HEX`` のキーなら hex を
+    返す (MCKINSEY 系パレット)。未知の文字列はパススルー (hex と仮定)。
+    """
+    if theme:
+        return token_or_hex
+    return _TOKEN_FALLBACK_HEX.get(token_or_hex, token_or_hex)
+
 # Page marker (top-right)
 _PAGE_MARKER_TOP: float = 0.35           # 1 行目の top
 _PAGE_MARKER_TEXTBOX_W: float = 2.5      # 各行のテキストボックス幅
@@ -124,6 +155,7 @@ def add_page_marker(
     left = slide_width - _MARGIN - _PAGE_MARKER_TEXTBOX_W
     top1 = _PAGE_MARKER_TOP
     top2 = _PAGE_MARKER_TOP + _PAGE_MARKER_LINE_H
+    color = _resolve_color(spec.color, theme)
 
     section_shape, _ = add_auto_fit_textbox(
         slide,
@@ -133,7 +165,7 @@ def add_page_marker(
         width=_PAGE_MARKER_TEXTBOX_W,
         height=_PAGE_MARKER_LINE_H,
         font_size_pt=spec.font_size_pt,
-        color_hex=spec.color,
+        color_hex=color,
         align="right",
         wrap=False,
         theme=theme,
@@ -146,7 +178,7 @@ def add_page_marker(
         width=_PAGE_MARKER_TEXTBOX_W,
         height=_PAGE_MARKER_LINE_H,
         font_size_pt=spec.font_size_pt,
-        color_hex=spec.color,
+        color_hex=color,
         align="right",
         wrap=False,
         theme=theme,
@@ -195,6 +227,7 @@ def add_slide_footer(
     from ..shapes import add_auto_fit_textbox  # lazy: avoid circular import
 
     top = slide_height - _FOOTER_BOTTOM_OFFSET
+    color = _resolve_color(spec.color, theme)
 
     left_shape, _ = add_auto_fit_textbox(
         slide,
@@ -204,7 +237,7 @@ def add_slide_footer(
         width=_FOOTER_LEFT_W,
         height=_FOOTER_HEIGHT,
         font_size_pt=spec.font_size_pt,
-        color_hex=spec.color,
+        color_hex=color,
         align="left",
         wrap=False,
         theme=theme,
@@ -220,7 +253,7 @@ def add_slide_footer(
             width=_FOOTER_RIGHT_W,
             height=_FOOTER_HEIGHT,
             font_size_pt=spec.font_size_pt,
-            color_hex=spec.color,
+            color_hex=color,
             align="right",
             wrap=False,
             theme=theme,

--- a/src/pptx_mcp_server/engine/components/markers.py
+++ b/src/pptx_mcp_server/engine/components/markers.py
@@ -1,0 +1,238 @@
+"""Page marker / slide footer block components (v0.6.0, closes #135).
+
+2 つの軽量ブロックコンポーネントを提供する:
+
+* ``add_page_marker`` - スライド右上に 2 行 (section / page) の小さな
+  テキストマーカーを描画する。IR や四半期レポート系の定型フォーマットで
+  各ページ上部に "FINANCIAL SUMMARY" / "P.05 ／ FY Q3" のように表示する
+  慣習的な位置専用の薄いヘルパ。
+* ``add_slide_footer`` - スライド下部に左右 2 テキストのフッタを描画する。
+  右側テキストが空文字の場合は右テキストボックスを作らない。
+
+どちらも位置・サイズは固定のオフセット定数 (モジュール冒頭で定義) を
+使う。「慣習的な位置」専用であり、任意位置指定は呼び出し側が
+``add_auto_fit_textbox`` を直接使えば足りる。
+
+どちらの関数も背後では ``add_auto_fit_textbox`` のみを使い、theme 解決
+(``"text_secondary"`` など) はそちらに委ねる (#131 の二重解決を避ける)。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+# ``engine.shapes`` imports ``components.container`` at module load time —
+# if we import ``add_auto_fit_textbox`` at module top here, ``shapes.py``
+# and ``components/__init__.py`` deadlock during partial init (shapes
+# triggers components init → markers import → shapes re-entry). Defer the
+# import to call time; it is cheap after first load.
+
+
+# ---------------------------------------------------------------------------
+# Fixed offsets (inches). 本モジュールは "慣習的な位置" 専用であり、可変化
+# しない。呼び出し側が別座標を使いたい場合は add_auto_fit_textbox を直接
+# 使うべき、というのが設計上の境界 (issue #135)。
+# ---------------------------------------------------------------------------
+
+# スライド左右端からの水平マージン。
+_MARGIN: float = 0.5
+
+# Page marker (top-right)
+_PAGE_MARKER_TOP: float = 0.35           # 1 行目の top
+_PAGE_MARKER_TEXTBOX_W: float = 2.5      # 各行のテキストボックス幅
+_PAGE_MARKER_LINE_H: float = 0.25        # 各行のテキストボックス高さ
+
+# Slide footer (bottom)
+_FOOTER_HEIGHT: float = 0.3              # フッタテキストボックス高さ
+_FOOTER_BOTTOM_OFFSET: float = 0.4       # スライド下端からの top オフセット
+_FOOTER_LEFT_W: float = 4.0              # 左テキストボックス幅
+_FOOTER_RIGHT_W: float = 6.0             # 右テキストボックス幅
+
+
+@dataclass
+class PageMarkerSpec:
+    """右上ページマーカーの内容定義.
+
+    Attributes:
+        section: 1 行目。セクション名 (e.g. ``"FINANCIAL SUMMARY"``)。
+            呼び出し側で uppercase にすることを想定するが強制はしない。
+        page: 2 行目。ページ表記 (e.g. ``"P.05 ／ FY Q3"``)。
+        font_size_pt: 両行に適用する font size (pt)。
+        color: 文字色トークン or hex (``#`` なし)。``theme`` 指定時は
+            ``resolve_theme_color`` 経由で解決される。既定は
+            ``"text_secondary"``。
+    """
+
+    section: str
+    page: str
+    font_size_pt: float = 10
+    color: str = "text_secondary"
+
+
+@dataclass
+class SlideFooterSpec:
+    """スライド下部フッタの内容定義.
+
+    Attributes:
+        left_text: 左側フッタテキスト。
+        right_text: 右側フッタテキスト。空文字列のときは右テキストボックス
+            を描画しない (``add_slide_footer`` の ``right_shape`` は
+            ``None``)。
+        font_size_pt: 両側に適用する font size (pt)。
+        color: 文字色トークン or hex (``#`` なし)。``theme`` 指定時は
+            ``resolve_theme_color`` 経由で解決される。既定は
+            ``"text_secondary"``。
+    """
+
+    left_text: str = "IR Presentation · FY Q3"
+    right_text: str = ""
+    font_size_pt: float = 10
+    color: str = "text_secondary"
+
+
+def add_page_marker(
+    slide,
+    spec: PageMarkerSpec,
+    *,
+    slide_width: float,
+    slide_height: float,  # noqa: ARG001 - API consistency; not used for top placement
+    theme: Optional[str] = None,
+) -> dict:
+    """スライド右上に 2 行のページマーカーを描画する.
+
+    配置は固定で、右端が ``slide_width - _MARGIN`` (= 0.5" マージン)、
+    1 行目の top が ``_PAGE_MARKER_TOP`` (= 0.35")、2 行目はその直下
+    (``_PAGE_MARKER_LINE_H`` = 0.25" オフセット)。どちらの行も右寄せ、
+    折り返しなし (``wrap=False``) で描画する。
+
+    Args:
+        slide: python-pptx の Slide オブジェクト。
+        spec: :class:`PageMarkerSpec` — 内容とスタイル。
+        slide_width: スライド幅 (inches)。右端座標の計算に使う。
+        slide_height: スライド高さ (inches)。API 一貫性のため受け取るが
+            top-right マーカーでは未使用。
+        theme: テーマ名 (e.g. ``"ir"``)。``spec.color`` がトークンのとき
+            解決に使う。
+
+    Returns:
+        ``{"section_shape": ..., "page_shape": ..., "bounds": {...}}``。
+        ``bounds`` は 2 行全体の外接矩形 (inches)。
+    """
+    from ..shapes import add_auto_fit_textbox  # lazy: avoid circular import
+
+    left = slide_width - _MARGIN - _PAGE_MARKER_TEXTBOX_W
+    top1 = _PAGE_MARKER_TOP
+    top2 = _PAGE_MARKER_TOP + _PAGE_MARKER_LINE_H
+
+    section_shape, _ = add_auto_fit_textbox(
+        slide,
+        spec.section,
+        left=left,
+        top=top1,
+        width=_PAGE_MARKER_TEXTBOX_W,
+        height=_PAGE_MARKER_LINE_H,
+        font_size_pt=spec.font_size_pt,
+        color_hex=spec.color,
+        align="right",
+        wrap=False,
+        theme=theme,
+    )
+    page_shape, _ = add_auto_fit_textbox(
+        slide,
+        spec.page,
+        left=left,
+        top=top2,
+        width=_PAGE_MARKER_TEXTBOX_W,
+        height=_PAGE_MARKER_LINE_H,
+        font_size_pt=spec.font_size_pt,
+        color_hex=spec.color,
+        align="right",
+        wrap=False,
+        theme=theme,
+    )
+
+    return {
+        "section_shape": section_shape,
+        "page_shape": page_shape,
+        "bounds": {
+            "left": left,
+            "top": top1,
+            "width": _PAGE_MARKER_TEXTBOX_W,
+            "height": _PAGE_MARKER_LINE_H * 2,
+        },
+    }
+
+
+def add_slide_footer(
+    slide,
+    spec: SlideFooterSpec,
+    *,
+    slide_width: float,
+    slide_height: float,
+    theme: Optional[str] = None,
+) -> dict:
+    """スライド下部に左右 2 テキストのフッタを描画する.
+
+    配置は固定で、top は ``slide_height - _FOOTER_BOTTOM_OFFSET``、
+    左側は ``left=_MARGIN`` の左寄せテキスト、右側は
+    ``left=slide_width - _MARGIN - _FOOTER_RIGHT_W`` の右寄せテキスト。
+    右側は ``spec.right_text`` が空文字のとき描画をスキップする (戻り値の
+    ``right_shape`` が ``None``)。
+
+    Args:
+        slide: python-pptx の Slide オブジェクト。
+        spec: :class:`SlideFooterSpec` — 内容とスタイル。
+        slide_width: スライド幅 (inches)。
+        slide_height: スライド高さ (inches)。top の計算に使う。
+        theme: テーマ名。``spec.color`` がトークンのとき解決に使う。
+
+    Returns:
+        ``{"left_shape": ..., "right_shape": ... or None, "bounds": {...}}``。
+        ``bounds`` は左右両端を含む外接矩形 (inches、右側未描画でも幅は
+        ``slide_width - 2*_MARGIN``)。
+    """
+    from ..shapes import add_auto_fit_textbox  # lazy: avoid circular import
+
+    top = slide_height - _FOOTER_BOTTOM_OFFSET
+
+    left_shape, _ = add_auto_fit_textbox(
+        slide,
+        spec.left_text,
+        left=_MARGIN,
+        top=top,
+        width=_FOOTER_LEFT_W,
+        height=_FOOTER_HEIGHT,
+        font_size_pt=spec.font_size_pt,
+        color_hex=spec.color,
+        align="left",
+        wrap=False,
+        theme=theme,
+    )
+
+    right_shape = None
+    if spec.right_text:
+        right_shape, _ = add_auto_fit_textbox(
+            slide,
+            spec.right_text,
+            left=slide_width - _MARGIN - _FOOTER_RIGHT_W,
+            top=top,
+            width=_FOOTER_RIGHT_W,
+            height=_FOOTER_HEIGHT,
+            font_size_pt=spec.font_size_pt,
+            color_hex=spec.color,
+            align="right",
+            wrap=False,
+            theme=theme,
+        )
+
+    return {
+        "left_shape": left_shape,
+        "right_shape": right_shape,
+        "bounds": {
+            "left": _MARGIN,
+            "top": top,
+            "width": slide_width - 2 * _MARGIN,
+            "height": _FOOTER_HEIGHT,
+        },
+    }

--- a/src/pptx_mcp_server/engine/components/markers.py
+++ b/src/pptx_mcp_server/engine/components/markers.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
+from ._util import resolve_component_color as _resolve_color
+
 # ``engine.shapes`` imports ``components.container`` at module load time —
 # if we import ``add_auto_fit_textbox`` at module top here, ``shapes.py``
 # and ``components/__init__.py`` deadlock during partial init (shapes
@@ -37,37 +39,6 @@ from typing import Optional
 
 # スライド左右端からの水平マージン。
 _MARGIN: float = 0.5
-
-# ---------------------------------------------------------------------------
-# theme=None fallback for well-known color tokens.
-#
-# ``add_auto_fit_textbox`` は ``color_hex`` が hex でない場合に
-# ``#<token>`` として parse しようとして落ちる。呼び出し側が theme を
-# 指定していれば ``resolve_theme_color`` がトークンを hex に変換するが、
-# MCP ツール経由では既定が ``theme=None`` のため、デフォルト
-# ``"text_secondary"`` だけで EngineError が出てしまう (#135 CQ review)。
-# ここでは timeline.py / MCKINSEY / IR と整合する最小の hex 代替を持ち、
-# ``theme`` 未指定時のみ差し替える。テーマが指定されていれば一切介入
-# しない (二重解決回避)。
-# ---------------------------------------------------------------------------
-_TOKEN_FALLBACK_HEX: dict[str, str] = {
-    "text_secondary": "666666",
-    "primary": "051C2C",
-    "rule_subtle": "E0E0E0",
-}
-
-
-def _resolve_color(token_or_hex: str, theme: Optional[str]) -> str:
-    """``theme`` 未指定時に既知のトークンを hex にフォールバックする.
-
-    ``theme`` が与えられていれば入力はそのまま返し、下流の
-    ``add_auto_fit_textbox`` が ``resolve_theme_color`` で解決する。
-    ``theme is None`` で入力が ``_TOKEN_FALLBACK_HEX`` のキーなら hex を
-    返す (MCKINSEY 系パレット)。未知の文字列はパススルー (hex と仮定)。
-    """
-    if theme:
-        return token_or_hex
-    return _TOKEN_FALLBACK_HEX.get(token_or_hex, token_or_hex)
 
 # Page marker (top-right)
 _PAGE_MARKER_TOP: float = 0.35           # 1 行目の top

--- a/src/pptx_mcp_server/engine/components/metric_card.py
+++ b/src/pptx_mcp_server/engine/components/metric_card.py
@@ -16,10 +16,10 @@ Design notes
   by sibling components landing on the same foundation branch.
 - Color fields on :class:`MetricCardSpec` default to theme tokens
   (``"primary"``, ``"text_secondary"``, ``"rule_subtle"``). When the caller
-  passes ``theme=None``, the module-local :func:`_resolve_color` falls back
+  passes ``theme=None``, the shared
+  :func:`engine.components._util.resolve_component_color` helper falls back
   to MCKINSEY-equivalent hexes so token defaults never reach the paint
-  layer unresolved (mirror of ``engine/timeline.py:_style_color`` /
-  ``engine/components/section_header.py:_resolve_color``).
+  layer unresolved (shared across all v0.6.0 block components).
 - Metric value textboxes use ``wrap=False`` so large numbers scale by width
   rather than wrapping mid-figure.
 """
@@ -30,6 +30,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from ..pptx_io import EngineError, ErrorCode
+from ._util import resolve_component_color as _resolve_color
 from .container import begin_container
 
 # Vertical allocation inside the inner (padded) box.
@@ -44,14 +45,10 @@ _METRIC_VALUE_CELL_H: float = 0.50
 _MIN_CHART_H: float = 0.5
 
 
-# Hardcoded fallbacks for the default theme tokens used by this component.
-# Covers every token appearing in MetricCardSpec defaults + the background
-# hex used as chart-placeholder fill.
-_FALLBACK_COLORS = {
-    "primary": "051C2C",
-    "text_secondary": "666666",
-    "rule_subtle": "E0E0E0",
-}
+# Theme-token resolution is delegated to the shared
+# ``engine.components._util.resolve_component_color`` helper (imported above
+# as ``_resolve_color``); see ``_util._FALLBACK_TOKENS`` for the canonical
+# no-theme fallback palette.
 
 
 @dataclass
@@ -103,26 +100,6 @@ class MetricCardSpec:
     label_size_pt: float = 9
     metric_label_size_pt: float = 10
     metric_value_size_pt: float = 22
-
-
-def _resolve_color(token_or_hex: str, theme: str | None) -> str:
-    """Resolve a token/hex to 6-hex (no ``#``) even when ``theme`` is None.
-
-    When a theme is provided, delegates to :func:`resolve_theme_color`.
-    Otherwise maps the well-known default tokens to hardcoded MCKINSEY hex
-    equivalents; raw hex passes through (with an optional leading ``#``
-    stripped).
-    """
-    if not token_or_hex:
-        return ""
-    if theme:
-        from ...theme import resolve_theme_color
-
-        return resolve_theme_color(token_or_hex, theme)
-    if token_or_hex in _FALLBACK_COLORS:
-        return _FALLBACK_COLORS[token_or_hex]
-    # Raw hex passthrough (strip optional ``#``).
-    return token_or_hex.lstrip("#")
 
 
 def add_metric_card(

--- a/src/pptx_mcp_server/engine/components/metric_card.py
+++ b/src/pptx_mcp_server/engine/components/metric_card.py
@@ -134,6 +134,7 @@ def add_metric_card(
     width: float,
     height: float,
     theme: str | None = None,
+    container_name: str = "metric_card",
 ) -> dict:
     """Render a single metric card inside ``(left, top, width, height)``.
 
@@ -142,8 +143,8 @@ def add_metric_card(
 
     Returns:
         Dict with the rendered bounds and each child shape:
-        ``{"bounds": {...}, "label_shape", "title_shape", "chart_shape",
-        "metric_shapes": [(label_shape, value_shape), ...]}``.
+        ``{"bounds": {...}, "frame_shape", "label_shape", "title_shape",
+        "chart_shape", "metric_shapes": [(label_shape, value_shape), ...]}``.
 
     Raises:
         EngineError: ``INVALID_PARAMETER`` when the inner height is too
@@ -152,6 +153,17 @@ def add_metric_card(
     # Deferred imports to avoid circular import with ``engine.shapes``
     # (which imports ``components.container``).
     from ..shapes import _add_image, _add_shape, add_auto_fit_textbox
+
+    # Validate optional chart image path up front so a missing file fails
+    # before any shapes are appended (avoids partial-card leaks on error).
+    if spec.chart_image_path is not None:
+        import os
+
+        if not os.path.isfile(spec.chart_image_path):
+            raise EngineError(
+                ErrorCode.INVALID_PARAMETER,
+                f"MetricCard chart_image_path does not exist: {spec.chart_image_path!r}",
+            )
 
     # Resolve colors once at entry. Raw hex / theme tokens both normalize
     # to 6-hex (no ``#``) so downstream primitives receive uniform input.
@@ -191,7 +203,7 @@ def add_metric_card(
 
     with begin_container(
         slide,
-        name="metric_card",
+        name=container_name,
         left=float(left),
         top=float(top),
         width=float(width),
@@ -209,8 +221,6 @@ def add_metric_card(
             line_color=border_color,
             line_width=float(spec.border_width),
         )
-        # Note: the frame shape is not returned explicitly — the validator
-        # sees it via container registration.
 
         # 2) Inner layout cursor.
         inner_left = float(left) + pad
@@ -305,7 +315,7 @@ def add_metric_card(
                     width=cell_w,
                     height=_METRIC_VALUE_CELL_H,
                     font_size_pt=float(spec.metric_value_size_pt),
-                    min_size_pt=max(float(spec.metric_value_size_pt) - 6, 10),
+                    min_size_pt=max(float(spec.metric_value_size_pt) - 12, 10),
                     bold=True,
                     color_hex=metric_value_color,
                     align="left",
@@ -373,6 +383,7 @@ def add_metric_card_row(
             width=card_w,
             height=height,
             theme=theme,
+            container_name=f"metric_card_{i}",
         )
         placements.append(result["bounds"])
 

--- a/src/pptx_mcp_server/engine/components/metric_card.py
+++ b/src/pptx_mcp_server/engine/components/metric_card.py
@@ -1,0 +1,383 @@
+"""MetricCard block component (Issue #132).
+
+A single metric card renders, top-to-bottom, a small uppercase ``label``,
+a ``title``, a chart (image or placeholder rectangle), and an optional row
+of ``(metric.label, metric.value)`` cells. Sibling cards of equal height
+can be laid out horizontally with :func:`add_metric_card_row`.
+
+Design notes
+------------
+- Uses :func:`begin_container` to declare a validator-checkable bounding box
+  per card. Child shapes auto-register via the thread-local stack maintained
+  by the atomic primitives.
+- Deferred imports are used for :mod:`..shapes` symbols to avoid circular
+  imports: ``engine.shapes`` already imports ``components.container``, and
+  ``components/__init__`` re-exports this module. Mirrors the pattern used
+  by sibling components landing on the same foundation branch.
+- Color fields on :class:`MetricCardSpec` default to theme tokens
+  (``"primary"``, ``"text_secondary"``, ``"rule_subtle"``). When the caller
+  passes ``theme=None``, the module-local :func:`_resolve_color` falls back
+  to MCKINSEY-equivalent hexes so token defaults never reach the paint
+  layer unresolved (mirror of ``engine/timeline.py:_style_color`` /
+  ``engine/components/section_header.py:_resolve_color``).
+- Metric value textboxes use ``wrap=False`` so large numbers scale by width
+  rather than wrapping mid-figure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from ..pptx_io import EngineError, ErrorCode
+from .container import begin_container
+
+# Vertical allocation inside the inner (padded) box.
+_LABEL_H: float = 0.25
+_LABEL_TITLE_GAP: float = 0.05
+_TITLE_H: float = 0.40
+_TITLE_CHART_GAP: float = 0.20
+_CHART_METRICS_GAP: float = 0.20
+_METRICS_ROW_H: float = 0.80
+_METRIC_LABEL_CELL_H: float = 0.30
+_METRIC_VALUE_CELL_H: float = 0.50
+_MIN_CHART_H: float = 0.5
+
+
+# Hardcoded fallbacks for the default theme tokens used by this component.
+# Covers every token appearing in MetricCardSpec defaults + the background
+# hex used as chart-placeholder fill.
+_FALLBACK_COLORS = {
+    "primary": "051C2C",
+    "text_secondary": "666666",
+    "rule_subtle": "E0E0E0",
+}
+
+
+@dataclass
+class MetricEntry:
+    """A single (label, value) cell in the metrics row."""
+
+    label: str
+    value: str
+
+
+@dataclass
+class MetricCardSpec:
+    """Content + style definition for one metric card.
+
+    Attributes:
+        label: Small uppercase caption above the title (e.g. "KPI").
+        title: Main heading text for the card.
+        chart_image_path: Optional path to a chart PNG; when ``None``, a
+            blank placeholder rectangle fills the chart area.
+        metrics: Optional list of :class:`MetricEntry` for the bottom row.
+            Empty list → chart area expands to fill the remaining height.
+        fill_color: Card background fill (hex or theme token).
+        border_color: Card stroke color (hex or theme token).
+        border_width: Card stroke width in points.
+        label_color: Color for the ``label`` text.
+        title_color: Color for the ``title`` text.
+        metric_label_color: Color for per-metric labels.
+        metric_value_color: Color for per-metric values.
+        padding: Inner inset (inches) applied equally to all 4 sides.
+        title_size_pt: Font size for the title.
+        label_size_pt: Font size for the label.
+        metric_label_size_pt: Font size for per-metric labels.
+        metric_value_size_pt: Font size for per-metric values.
+    """
+
+    label: str = ""
+    title: str = ""
+    chart_image_path: Optional[str] = None
+    metrics: list[MetricEntry] = field(default_factory=list)
+    fill_color: str = "F8F9F5"
+    border_color: str = "rule_subtle"
+    border_width: float = 0.012
+    label_color: str = "text_secondary"
+    title_color: str = "primary"
+    metric_label_color: str = "text_secondary"
+    metric_value_color: str = "primary"
+    padding: float = 0.3
+    title_size_pt: float = 14
+    label_size_pt: float = 9
+    metric_label_size_pt: float = 10
+    metric_value_size_pt: float = 22
+
+
+def _resolve_color(token_or_hex: str, theme: str | None) -> str:
+    """Resolve a token/hex to 6-hex (no ``#``) even when ``theme`` is None.
+
+    When a theme is provided, delegates to :func:`resolve_theme_color`.
+    Otherwise maps the well-known default tokens to hardcoded MCKINSEY hex
+    equivalents; raw hex passes through (with an optional leading ``#``
+    stripped).
+    """
+    if not token_or_hex:
+        return ""
+    if theme:
+        from ...theme import resolve_theme_color
+
+        return resolve_theme_color(token_or_hex, theme)
+    if token_or_hex in _FALLBACK_COLORS:
+        return _FALLBACK_COLORS[token_or_hex]
+    # Raw hex passthrough (strip optional ``#``).
+    return token_or_hex.lstrip("#")
+
+
+def add_metric_card(
+    slide,
+    spec: MetricCardSpec,
+    *,
+    left: float,
+    top: float,
+    width: float,
+    height: float,
+    theme: str | None = None,
+) -> dict:
+    """Render a single metric card inside ``(left, top, width, height)``.
+
+    Lays out (top-to-bottom) label → title → chart → metrics row inside an
+    inner box shrunk by :attr:`MetricCardSpec.padding` on all sides.
+
+    Returns:
+        Dict with the rendered bounds and each child shape:
+        ``{"bounds": {...}, "label_shape", "title_shape", "chart_shape",
+        "metric_shapes": [(label_shape, value_shape), ...]}``.
+
+    Raises:
+        EngineError: ``INVALID_PARAMETER`` when the inner height is too
+            small to satisfy the label/title/chart/metrics allocation.
+    """
+    # Deferred imports to avoid circular import with ``engine.shapes``
+    # (which imports ``components.container``).
+    from ..shapes import _add_image, _add_shape, add_auto_fit_textbox
+
+    # Resolve colors once at entry. Raw hex / theme tokens both normalize
+    # to 6-hex (no ``#``) so downstream primitives receive uniform input.
+    fill_color = _resolve_color(spec.fill_color, theme) or "F8F9F5"
+    border_color = _resolve_color(spec.border_color, theme) or "E0E0E0"
+    label_color = _resolve_color(spec.label_color, theme) or "666666"
+    title_color = _resolve_color(spec.title_color, theme) or "051C2C"
+    metric_label_color = _resolve_color(spec.metric_label_color, theme) or "666666"
+    metric_value_color = _resolve_color(spec.metric_value_color, theme) or "051C2C"
+
+    pad = float(spec.padding)
+    inner_w = width - 2 * pad
+    inner_h = height - 2 * pad
+
+    has_metrics = bool(spec.metrics)
+    metrics_row_h = _METRICS_ROW_H if has_metrics else 0.0
+    metrics_gap = _CHART_METRICS_GAP if has_metrics else 0.0
+
+    required = (
+        _LABEL_H
+        + _LABEL_TITLE_GAP
+        + _TITLE_H
+        + _TITLE_CHART_GAP
+        + _MIN_CHART_H
+        + metrics_gap
+        + metrics_row_h
+    )
+    if inner_h < required:
+        raise EngineError(
+            ErrorCode.INVALID_PARAMETER,
+            (
+                "MetricCard height too small: need >= "
+                f"{required + 2 * pad:.2f}\" "
+                f"for padding/label/title/chart/metrics; got {height:.2f}\"."
+            ),
+        )
+
+    with begin_container(
+        slide,
+        name="metric_card",
+        left=float(left),
+        top=float(top),
+        width=float(width),
+        height=float(height),
+    ):
+        # 1) Card background + border frame.
+        bg_idx = _add_shape(
+            slide,
+            "rectangle",
+            float(left),
+            float(top),
+            float(width),
+            float(height),
+            fill_color=fill_color,
+            line_color=border_color,
+            line_width=float(spec.border_width),
+        )
+        # Note: the frame shape is not returned explicitly — the validator
+        # sees it via container registration.
+
+        # 2) Inner layout cursor.
+        inner_left = float(left) + pad
+        cursor_y = float(top) + pad
+
+        # 3) Label row.
+        label_shape, _ = add_auto_fit_textbox(
+            slide,
+            spec.label,
+            left=inner_left,
+            top=cursor_y,
+            width=inner_w,
+            height=_LABEL_H,
+            font_size_pt=float(spec.label_size_pt),
+            min_size_pt=max(float(spec.label_size_pt) - 2, 6),
+            color_hex=label_color,
+            align="left",
+            vertical_anchor="top",
+        )
+        cursor_y += _LABEL_H + _LABEL_TITLE_GAP
+
+        # 4) Title row.
+        title_shape, _ = add_auto_fit_textbox(
+            slide,
+            spec.title,
+            left=inner_left,
+            top=cursor_y,
+            width=inner_w,
+            height=_TITLE_H,
+            font_size_pt=float(spec.title_size_pt),
+            min_size_pt=max(float(spec.title_size_pt) - 4, 8),
+            bold=True,
+            color_hex=title_color,
+            align="left",
+            vertical_anchor="top",
+        )
+        cursor_y += _TITLE_H + _TITLE_CHART_GAP
+
+        # 5) Chart area: fills remaining space above the metrics row.
+        chart_bottom = float(top) + pad + inner_h - metrics_row_h - metrics_gap
+        chart_h = chart_bottom - cursor_y
+
+        if spec.chart_image_path:
+            chart_idx = _add_image(
+                slide,
+                spec.chart_image_path,
+                left=inner_left,
+                top=cursor_y,
+                width=inner_w,
+                height=chart_h,
+            )
+        else:
+            chart_idx = _add_shape(
+                slide,
+                "rectangle",
+                inner_left,
+                cursor_y,
+                inner_w,
+                chart_h,
+                fill_color=fill_color,
+                line_color=None,
+                no_line=True,
+            )
+        chart_shape = slide.shapes[chart_idx]
+
+        # 6) Metrics row: N cells split evenly across inner width.
+        metric_shapes: list[tuple[object, object]] = []
+        if has_metrics:
+            metrics_top = cursor_y + chart_h + metrics_gap
+            n = len(spec.metrics)
+            cell_w = inner_w / n
+            for i, metric in enumerate(spec.metrics):
+                cell_x = inner_left + i * cell_w
+                m_label_shape, _ = add_auto_fit_textbox(
+                    slide,
+                    metric.label,
+                    left=cell_x,
+                    top=metrics_top,
+                    width=cell_w,
+                    height=_METRIC_LABEL_CELL_H,
+                    font_size_pt=float(spec.metric_label_size_pt),
+                    min_size_pt=max(float(spec.metric_label_size_pt) - 2, 6),
+                    color_hex=metric_label_color,
+                    align="left",
+                    vertical_anchor="top",
+                )
+                m_value_shape, _ = add_auto_fit_textbox(
+                    slide,
+                    metric.value,
+                    left=cell_x,
+                    top=metrics_top + _METRIC_LABEL_CELL_H,
+                    width=cell_w,
+                    height=_METRIC_VALUE_CELL_H,
+                    font_size_pt=float(spec.metric_value_size_pt),
+                    min_size_pt=max(float(spec.metric_value_size_pt) - 6, 10),
+                    bold=True,
+                    color_hex=metric_value_color,
+                    align="left",
+                    vertical_anchor="top",
+                    wrap=False,
+                )
+                metric_shapes.append((m_label_shape, m_value_shape))
+
+    # The background rectangle index captured pre-children; re-resolve to
+    # a live shape reference for the return payload. (Additional shapes
+    # were added after it, but `bg_idx` remains valid because indexes are
+    # append-only for in-memory slides.)
+    bg_shape = slide.shapes[bg_idx]
+
+    return {
+        "bounds": {
+            "left": float(left),
+            "top": float(top),
+            "width": float(width),
+            "height": float(height),
+        },
+        "frame_shape": bg_shape,
+        "label_shape": label_shape,
+        "title_shape": title_shape,
+        "chart_shape": chart_shape,
+        "metric_shapes": metric_shapes,
+    }
+
+
+def add_metric_card_row(
+    slide,
+    specs: list[MetricCardSpec],
+    *,
+    left: float,
+    top: float,
+    width: float,
+    height: float,
+    gap: float = 0.3,
+    theme: str | None = None,
+) -> dict:
+    """Render N metric cards side-by-side with equal widths.
+
+    Each card occupies ``(width - (n - 1) * gap) / n`` inches of horizontal
+    space and the full ``height``. Single-card rows ignore ``gap``.
+
+    Returns:
+        ``{"cards": [bounds_dict, ...], "consumed_height": height,
+        "consumed_width": width}``.
+    """
+    n = len(specs)
+    if n == 0:
+        return {"cards": [], "consumed_height": 0.0, "consumed_width": 0.0}
+
+    effective_gap = gap if n > 1 else 0.0
+    card_w = (width - effective_gap * (n - 1)) / n
+
+    placements: list[dict] = []
+    for i, spec in enumerate(specs):
+        x = left + i * (card_w + effective_gap)
+        result = add_metric_card(
+            slide,
+            spec,
+            left=x,
+            top=top,
+            width=card_w,
+            height=height,
+            theme=theme,
+        )
+        placements.append(result["bounds"])
+
+    return {
+        "cards": placements,
+        "consumed_height": float(height),
+        "consumed_width": float(width),
+    }

--- a/src/pptx_mcp_server/engine/components/numbered_list.py
+++ b/src/pptx_mcp_server/engine/components/numbered_list.py
@@ -15,9 +15,9 @@ Rendering is wrapped in a ``begin_container`` so ``check_containment`` can
 validate all children stay inside the bounds.
 
 Color tokens (``rule_subtle``, ``primary``, ``text_secondary``) resolve via
-the theme registry when ``theme`` is supplied; otherwise a small
-``_TOKEN_FALLBACK_HEX`` table provides sensible neutral defaults so the
-component renders cleanly without a theme.
+the theme registry when ``theme`` is supplied; otherwise the shared
+``engine.components._util._FALLBACK_TOKENS`` table provides sensible
+neutral defaults so the component renders cleanly without a theme.
 
 Layout (per item, top to bottom):
 
@@ -38,6 +38,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import List, Optional
+
+from ._util import resolve_component_color as _resolve_color
 
 
 # --------------------------------------------------------------------------
@@ -69,32 +71,10 @@ class NumberedItem:
     body: str
 
 
-# --------------------------------------------------------------------------
-# Theme-token fallbacks (no-theme defaults)
-# --------------------------------------------------------------------------
-
-# When ``theme is None`` we still want neutral, readable colors for common
-# semantic tokens. Raw hex input is passed through unchanged by
-# ``_resolve_color``.
-_TOKEN_FALLBACK_HEX = {
-    "primary": "051C2C",
-    "text_secondary": "666666",
-    "rule_subtle": "E0E0E0",
-}
-
-
-def _resolve_color(token_or_hex: str, theme: Optional[str]) -> str:
-    """Resolve a theme token or raw hex to a 6-char hex (no ``#``).
-
-    Mirrors the lightweight pattern used by #135/#136/#132/#133: when a
-    theme name is given, delegate to ``resolve_theme_color``; otherwise
-    look the token up in ``_TOKEN_FALLBACK_HEX`` and return raw-hex input
-    unchanged if it isn't a known token.
-    """
-    if theme:
-        from pptx_mcp_server.theme import resolve_theme_color
-        return resolve_theme_color(token_or_hex, theme)
-    return _TOKEN_FALLBACK_HEX.get(token_or_hex, token_or_hex)
+# Theme-token resolution is delegated to the shared
+# ``engine.components._util.resolve_component_color`` helper (imported above
+# as ``_resolve_color``) to keep every block component's fallback palette
+# and precedence rules identical (Task D, v0.6.0 consolidation).
 
 
 # --------------------------------------------------------------------------
@@ -156,7 +136,7 @@ def add_numbered_list(
             Font sizes in points. Body/title use auto-fit ellipsis if the
             content is too long for the allocated space.
         theme: Optional theme name for token resolution. ``None`` → use
-            ``_TOKEN_FALLBACK_HEX`` defaults.
+            ``engine.components._util._FALLBACK_TOKENS`` defaults.
 
     Returns:
         A dict with::

--- a/src/pptx_mcp_server/engine/components/numbered_list.py
+++ b/src/pptx_mcp_server/engine/components/numbered_list.py
@@ -1,0 +1,346 @@
+"""NumberedList block component — stacked numbered items with rules (Issue #134).
+
+Renders N numbered items vertically inside a declared container. Each item
+displays:
+
+1. A number + caption row (e.g. ``01 ／ 主要ターゲット``)
+2. A bold title summary
+3. A wrapped body paragraph (optional — empty bodies skip the textbox)
+4. A thin horizontal rule separating this item from the next (unless the
+   item is last, or ``rule_between=False``)
+
+Item heights are distributed **equally** across the declared ``height`` (MVP
+interpretation — variable-per-item heights are out of scope for v0.6.0).
+Rendering is wrapped in a ``begin_container`` so ``check_containment`` can
+validate all children stay inside the bounds.
+
+Color tokens (``rule_subtle``, ``primary``, ``text_secondary``) resolve via
+the theme registry when ``theme`` is supplied; otherwise a small
+``_TOKEN_FALLBACK_HEX`` table provides sensible neutral defaults so the
+component renders cleanly without a theme.
+
+Layout (per item, top to bottom):
+
+- Number + caption row: 0.28" tall, two side-by-side textboxes
+  (number in left 0.7", caption in the remainder)
+- 0.04" gap
+- Title row: 0.45" tall, bold
+- 0.08" gap
+- Body row: remaining item height (wrapped, auto-fit + ellipsis)
+- Optional rule (0.008" tall rectangle) inside a 0.04" rule row gap
+  between this item and the next
+
+Circular-import avoidance: imports from ``..shapes`` are deferred to
+function scope (mirrors ``timeline.py`` / ``cards.py`` pattern).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+# --------------------------------------------------------------------------
+# Data model
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class NumberedItem:
+    """A single entry in a numbered list.
+
+    Fields are caller-formatted — the component does not pad/align numbers
+    nor compose separators between number and caption. Pass exactly the
+    string you want rendered.
+
+    Attributes:
+        number: Short number label, e.g. ``"01"``, ``"02"``, ... Rendered
+            in the left-most position of the number row.
+        caption: Descriptor after the number, e.g. ``"／ 主要ターゲット"``.
+            Rendered immediately to the right of ``number`` on the same row.
+        title: Bold summary line.
+        body: Wrapped explanation paragraph. Empty string → body textbox is
+            skipped (cleaner output than a zero-height empty frame).
+    """
+
+    number: str
+    caption: str
+    title: str
+    body: str
+
+
+# --------------------------------------------------------------------------
+# Theme-token fallbacks (no-theme defaults)
+# --------------------------------------------------------------------------
+
+# When ``theme is None`` we still want neutral, readable colors for common
+# semantic tokens. Raw hex input is passed through unchanged by
+# ``_resolve_color``.
+_TOKEN_FALLBACK_HEX = {
+    "primary": "051C2C",
+    "text_secondary": "666666",
+    "rule_subtle": "E0E0E0",
+}
+
+
+def _resolve_color(token_or_hex: str, theme: Optional[str]) -> str:
+    """Resolve a theme token or raw hex to a 6-char hex (no ``#``).
+
+    Mirrors the lightweight pattern used by #135/#136/#132/#133: when a
+    theme name is given, delegate to ``resolve_theme_color``; otherwise
+    look the token up in ``_TOKEN_FALLBACK_HEX`` and return raw-hex input
+    unchanged if it isn't a known token.
+    """
+    if theme:
+        from pptx_mcp_server.theme import resolve_theme_color
+        return resolve_theme_color(token_or_hex, theme)
+    return _TOKEN_FALLBACK_HEX.get(token_or_hex, token_or_hex)
+
+
+# --------------------------------------------------------------------------
+# Per-item layout constants (inches)
+# --------------------------------------------------------------------------
+
+_NUMBER_ROW_H = 0.28       # height of the number+caption row
+_NUMBER_COL_W = 0.70       # width of the number textbox (caption fills remainder)
+_GAP_NUMBER_TITLE = 0.04   # gap between number row and title row
+_TITLE_ROW_H = 0.45        # height of the bold title row
+_GAP_TITLE_BODY = 0.08     # gap between title row and body
+_RULE_ROW_H = 0.04         # vertical allocation for the rule between items
+_RULE_THICKNESS = 0.008    # actual thickness of the rule rectangle
+
+
+# --------------------------------------------------------------------------
+# Public API
+# --------------------------------------------------------------------------
+
+
+def add_numbered_list(
+    slide,
+    items: List[NumberedItem],
+    *,
+    left: float,
+    top: float,
+    width: float,
+    height: float,
+    rule_between: bool = True,
+    rule_color: str = "rule_subtle",
+    number_color: str = "text_secondary",
+    caption_color: str = "text_secondary",
+    title_color: str = "primary",
+    body_color: str = "text_secondary",
+    number_size_pt: float = 10,
+    caption_size_pt: float = 10,
+    title_size_pt: float = 16,
+    body_size_pt: float = 10,
+    theme: Optional[str] = None,
+) -> dict:
+    """Render ``items`` as a vertical numbered list within the declared bounds.
+
+    Each item is laid out as number+caption → title → body, optionally
+    followed by a thin rule. Item heights divide ``height`` equally (minus
+    the combined rule-row allocation when ``rule_between=True``). The last
+    item never has a trailing rule.
+
+    Args:
+        slide: python-pptx slide to draw on.
+        items: Non-empty list of ``NumberedItem`` entries.
+        left, top, width, height: Outer bounding box in inches. All child
+            shapes are guaranteed to lie within these bounds (validated
+            via ``check_containment``).
+        rule_between: When ``True`` (default), draw a thin horizontal rule
+            between consecutive items. Last item never gets a rule.
+        rule_color, number_color, caption_color, title_color, body_color:
+            Theme tokens or raw 6-hex strings. See ``_resolve_color``.
+        number_size_pt, caption_size_pt, title_size_pt, body_size_pt:
+            Font sizes in points. Body/title use auto-fit ellipsis if the
+            content is too long for the allocated space.
+        theme: Optional theme name for token resolution. ``None`` → use
+            ``_TOKEN_FALLBACK_HEX`` defaults.
+
+    Returns:
+        A dict with::
+
+            {
+                "items": [
+                    {
+                        "bounds": {"left", "top", "width", "height"},
+                        "number_shape": shape,
+                        "caption_shape": shape,
+                        "title_shape": shape,
+                        "body_shape": shape | None,   # None when body empty
+                        "rule_shape": shape | None,   # None for last item
+                                                       # or when rule_between=False
+                    },
+                    ...
+                ],
+                "consumed_height": height,
+                "consumed_width": width,
+            }
+
+    Notes:
+        - Body textbox is omitted entirely for empty ``item.body`` (not
+          rendered as a zero-height placeholder).
+        - Long body text is handled by ``add_auto_fit_textbox``'s ellipsis
+          shrinking; no error is raised when content exceeds the allotted
+          space.
+    """
+    # Deferred import: avoids circular dependency between
+    # ``engine.components`` and ``engine.shapes`` (shapes.py registers
+    # shapes with the container stack defined here).
+    from ..shapes import _add_shape, add_auto_fit_textbox
+    from .container import begin_container
+
+    n = len(items)
+    if n == 0:
+        return {"items": [], "consumed_height": 0.0, "consumed_width": width}
+
+    # Resolve all colors once up-front (cheaper + easier to reason about).
+    rule_hex = _resolve_color(rule_color, theme)
+    number_hex = _resolve_color(number_color, theme)
+    caption_hex = _resolve_color(caption_color, theme)
+    title_hex = _resolve_color(title_color, theme)
+    body_hex = _resolve_color(body_color, theme)
+
+    # Allocate per-item height evenly. Rule rows steal (n-1) * _RULE_ROW_H
+    # from the total height so per-item content rectangles remain equal.
+    draw_rules = bool(rule_between) and n >= 2
+    rule_allocation = (n - 1) * _RULE_ROW_H if draw_rules else 0.0
+    item_height = (height - rule_allocation) / n
+
+    results: list[dict] = []
+
+    with begin_container(
+        slide,
+        name="numbered_list",
+        left=left,
+        top=top,
+        width=width,
+        height=height,
+    ):
+        cursor_top = top
+        for idx, item in enumerate(items):
+            item_top = cursor_top
+            item_bounds = {
+                "left": left,
+                "top": item_top,
+                "width": width,
+                "height": item_height,
+            }
+
+            # --- Number row (left 0.7") -----------------------------------
+            number_shape, _ = add_auto_fit_textbox(
+                slide,
+                item.number,
+                left,
+                item_top,
+                _NUMBER_COL_W,
+                _NUMBER_ROW_H,
+                font_size_pt=number_size_pt,
+                min_size_pt=max(1, int(number_size_pt) - 2),
+                color_hex=number_hex,
+                align="left",
+                wrap=False,
+                truncate_with_ellipsis=True,
+            )
+
+            # --- Caption row (right of number) ----------------------------
+            caption_left = left + _NUMBER_COL_W
+            caption_width = max(0.1, width - _NUMBER_COL_W)
+            caption_shape, _ = add_auto_fit_textbox(
+                slide,
+                item.caption,
+                caption_left,
+                item_top,
+                caption_width,
+                _NUMBER_ROW_H,
+                font_size_pt=caption_size_pt,
+                min_size_pt=max(1, int(caption_size_pt) - 2),
+                color_hex=caption_hex,
+                align="left",
+                wrap=False,
+                truncate_with_ellipsis=True,
+            )
+
+            # --- Title row ------------------------------------------------
+            title_top = item_top + _NUMBER_ROW_H + _GAP_NUMBER_TITLE
+            title_shape, _ = add_auto_fit_textbox(
+                slide,
+                item.title,
+                left,
+                title_top,
+                width,
+                _TITLE_ROW_H,
+                font_size_pt=title_size_pt,
+                min_size_pt=max(1, int(title_size_pt) - 4),
+                color_hex=title_hex,
+                bold=True,
+                align="left",
+                wrap=False,
+                truncate_with_ellipsis=True,
+            )
+
+            # --- Body row -------------------------------------------------
+            body_top = title_top + _TITLE_ROW_H + _GAP_TITLE_BODY
+            # Remaining vertical space inside this item's allocated rect.
+            body_height = max(
+                0.0,
+                (item_top + item_height) - body_top,
+            )
+            body_shape = None
+            if item.body and body_height > 0:
+                body_shape, _ = add_auto_fit_textbox(
+                    slide,
+                    item.body,
+                    left,
+                    body_top,
+                    width,
+                    body_height,
+                    font_size_pt=body_size_pt,
+                    min_size_pt=max(1, int(body_size_pt) - 2),
+                    color_hex=body_hex,
+                    align="left",
+                    wrap=True,
+                    truncate_with_ellipsis=True,
+                )
+
+            # --- Optional rule between this item and the next -------------
+            rule_shape = None
+            is_last = idx == n - 1
+            if draw_rules and not is_last:
+                # Place the rule centered within the rule-row gap.
+                rule_row_top = item_top + item_height
+                rule_top_pos = rule_row_top + (_RULE_ROW_H - _RULE_THICKNESS) / 2
+                rule_idx = _add_shape(
+                    slide,
+                    "rectangle",
+                    left,
+                    rule_top_pos,
+                    width,
+                    _RULE_THICKNESS,
+                    fill_color=rule_hex,
+                    no_line=True,
+                )
+                rule_shape = slide.shapes[rule_idx]
+
+            results.append(
+                {
+                    "bounds": item_bounds,
+                    "number_shape": number_shape,
+                    "caption_shape": caption_shape,
+                    "title_shape": title_shape,
+                    "body_shape": body_shape,
+                    "rule_shape": rule_shape,
+                }
+            )
+
+            # Advance cursor past this item (+ rule row if applicable).
+            cursor_top = item_top + item_height
+            if draw_rules and not is_last:
+                cursor_top += _RULE_ROW_H
+
+    return {
+        "items": results,
+        "consumed_height": height,
+        "consumed_width": width,
+    }

--- a/src/pptx_mcp_server/engine/components/section_header.py
+++ b/src/pptx_mcp_server/engine/components/section_header.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
-from ...theme import resolve_theme_color
+from ._util import resolve_component_color as _resolve_color
 from .container import begin_container
 
 # NOTE: ``..shapes`` (engine.shapes) imports ``begin_container`` from this
@@ -40,37 +40,6 @@ from .container import begin_container
 # ``add_auto_fit_textbox`` at the top of this file would form a circular
 # import (engine.shapes ↔ engine.components.__init__). We defer those
 # imports to the body of :func:`add_section_header` instead.
-
-# Fallback hex values used when ``theme`` is ``None`` — matches the
-# MCKINSEY palette which is the historical default across the engine
-# (cards.py, timeline.py follow the same convention, #125).
-_TOKEN_FALLBACK_HEX: dict[str, str] = {
-    "primary": "051C2C",
-    "text_secondary": "666666",
-    "rule_subtle": "E0E0E0",
-}
-
-
-def _resolve_color(token_or_hex: str, theme_name: Optional[str]) -> str:
-    """Resolve a theme token / raw hex to a 6-hex value primitives accept.
-
-    When ``theme_name`` is provided, delegates to the central resolver
-    (``resolve_theme_color``). When no theme is in play and the input is
-    not recognizable as hex, falls back to the MCKINSEY-equivalent default
-    hex value so atomic primitives never receive an unresolved token like
-    ``"primary"`` (which would raise ``Invalid color`` in ``_parse_color``).
-    """
-    if not token_or_hex:
-        return ""
-    if theme_name:
-        return resolve_theme_color(token_or_hex, theme_name)
-    stripped = token_or_hex.lstrip("#")
-    # Heuristic: treat a 6-char all-hex string as a raw color.
-    if len(stripped) == 6 and all(
-        c in "0123456789abcdefABCDEF" for c in stripped
-    ):
-        return stripped
-    return _TOKEN_FALLBACK_HEX.get(token_or_hex, stripped)
 
 # ---------------------------------------------------------------------------
 # Layout constants (inches)

--- a/src/pptx_mcp_server/engine/components/section_header.py
+++ b/src/pptx_mcp_server/engine/components/section_header.py
@@ -1,0 +1,289 @@
+"""SectionHeader block component (Issue #136, v0.6.0).
+
+Renders a vertically-stacked section header composed of:
+
+1. A **title** textbox (single-line, auto-fit by width, bold).
+2. An optional **subtitle** textbox (single-line, auto-fit by width).
+3. A thin **divider** rectangle spanning the full width.
+
+The component is wrapped in ``begin_container`` so ``check_containment``
+can verify that no child shape escapes the declared bounds. Text auto-fit
+uses ``wrap=False`` + ``truncate_with_ellipsis=True`` — this mirrors the
+v0.3.1 ``_title_bar`` behavior and guarantees long strings never wrap into
+a second line.
+
+The function returns a ``dict`` that includes ``consumed_height`` so the
+caller can place body content directly below without re-deriving the
+vertical math. This is the primary contract with callers.
+
+Design notes:
+- Layout constants (``_TITLE_H`` etc.) live at module top for easy tuning
+  and so tests can pin the exact bounds math.
+- Colors are passed through as tokens (``"primary"``, ``"text_secondary"``,
+  ``"rule_subtle"``); ``add_auto_fit_textbox`` and ``_add_shape`` resolve
+  them against ``theme`` internally — we don't resolve here to avoid
+  double-resolving.
+- Divider is a filled rectangle (``no_line=True``) rather than a line
+  connector, matching ``tables_grid`` hairline rule style.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from ...theme import resolve_theme_color
+from .container import begin_container
+
+# NOTE: ``..shapes`` (engine.shapes) imports ``begin_container`` from this
+# components sub-package at module load, so importing ``_add_shape`` /
+# ``add_auto_fit_textbox`` at the top of this file would form a circular
+# import (engine.shapes ↔ engine.components.__init__). We defer those
+# imports to the body of :func:`add_section_header` instead.
+
+# Fallback hex values used when ``theme`` is ``None`` — matches the
+# MCKINSEY palette which is the historical default across the engine
+# (cards.py, timeline.py follow the same convention, #125).
+_TOKEN_FALLBACK_HEX: dict[str, str] = {
+    "primary": "051C2C",
+    "text_secondary": "666666",
+    "rule_subtle": "E0E0E0",
+}
+
+
+def _resolve_color(token_or_hex: str, theme_name: Optional[str]) -> str:
+    """Resolve a theme token / raw hex to a 6-hex value primitives accept.
+
+    When ``theme_name`` is provided, delegates to the central resolver
+    (``resolve_theme_color``). When no theme is in play and the input is
+    not recognizable as hex, falls back to the MCKINSEY-equivalent default
+    hex value so atomic primitives never receive an unresolved token like
+    ``"primary"`` (which would raise ``Invalid color`` in ``_parse_color``).
+    """
+    if not token_or_hex:
+        return ""
+    if theme_name:
+        return resolve_theme_color(token_or_hex, theme_name)
+    stripped = token_or_hex.lstrip("#")
+    # Heuristic: treat a 6-char all-hex string as a raw color.
+    if len(stripped) == 6 and all(
+        c in "0123456789abcdefABCDEF" for c in stripped
+    ):
+        return stripped
+    return _TOKEN_FALLBACK_HEX.get(token_or_hex, stripped)
+
+# ---------------------------------------------------------------------------
+# Layout constants (inches)
+# ---------------------------------------------------------------------------
+# Title strip height — accommodates a 32pt bold line with vertical padding
+# on both sides so auto-fit's single-line render does not clip.
+_TITLE_H = 0.55
+# Gap between title and subtitle (or title and divider if no subtitle).
+_INTRA_GAP_TITLE = 0.08
+# Subtitle strip height — accommodates a 14pt line with padding.
+_SUBTITLE_H = 0.30
+# Gap between subtitle (or title if no subtitle) and the divider rule.
+_INTRA_GAP_SUBTITLE = 0.12
+
+
+@dataclass
+class SectionHeaderSpec:
+    """Declarative spec for :func:`add_section_header`.
+
+    Attributes:
+        title: Section title text (required, non-empty in practice).
+        subtitle: Optional subtitle text; empty string omits the subtitle
+            strip and reduces ``consumed_height``.
+        title_color: Theme token or 6-hex for the title text color.
+        subtitle_color: Theme token or 6-hex for the subtitle text color.
+        title_size_pt: Starting title font size (pt); auto-fit may shrink
+            down to ``title_min_size_pt``.
+        title_min_size_pt: Minimum title font size (pt) before truncation.
+        subtitle_size_pt: Starting subtitle font size (pt).
+        subtitle_min_size_pt: Minimum subtitle font size (pt).
+        divider_color: Theme token or 6-hex for the divider fill.
+        divider_thickness: Divider rectangle height (inches). Defaults to
+            ~0.008" ≈ 0.75pt hairline.
+    """
+
+    title: str
+    subtitle: str = ""
+    title_color: str = "primary"
+    subtitle_color: str = "text_secondary"
+    title_size_pt: float = 32
+    title_min_size_pt: float = 22
+    subtitle_size_pt: float = 14
+    subtitle_min_size_pt: float = 10
+    divider_color: str = "rule_subtle"
+    divider_thickness: float = 0.008
+
+
+def _compute_consumed_height(spec: SectionHeaderSpec) -> float:
+    """Return total vertical footprint of the header in inches.
+
+    Broken out so tests and callers can predict layout without re-running
+    the full render.
+    """
+    h = _TITLE_H + _INTRA_GAP_TITLE
+    if spec.subtitle:
+        h += _SUBTITLE_H
+    h += _INTRA_GAP_SUBTITLE + float(spec.divider_thickness)
+    return h
+
+
+def add_section_header(
+    slide,
+    spec: SectionHeaderSpec,
+    *,
+    left: float,
+    top: float,
+    width: float,
+    theme: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Render a section header (title + optional subtitle + divider rule).
+
+    The full stack is wrapped in a ``begin_container`` with name
+    ``"section_header"`` so ``check_containment`` verifies children stay
+    inside the declared bounds.
+
+    Args:
+        slide: Target python-pptx slide object.
+        spec: Declarative :class:`SectionHeaderSpec`.
+        left, top, width: Outer geometry in inches. The component consumes
+            height dynamically based on whether a subtitle is present; see
+            the returned ``consumed_height`` field.
+        theme: Optional theme name (e.g. ``"ir"``, ``"mckinsey"``).
+            Propagated to atomic primitives so color tokens resolve
+            against the registered theme palette.
+
+    Returns:
+        A dict with:
+
+        - ``title_bounds``: ``{left, top, width, height}`` for the title
+          textbox.
+        - ``subtitle_bounds``: Same shape if a subtitle was rendered,
+          else ``None``.
+        - ``divider_bounds``: ``{left, top, width, height}`` for the
+          divider rectangle.
+        - ``consumed_height`` (float): Total vertical footprint — the
+          caller contract for placing body content.
+        - ``title_actual_font_size`` (float): The post-auto-fit title
+          font size; useful for tests.
+        - ``subtitle_actual_font_size`` (float | None): Post-auto-fit
+          subtitle size, or ``None`` if no subtitle.
+    """
+    # Deferred imports to avoid a circular dependency: ``engine.shapes``
+    # imports ``begin_container`` from this package at load time.
+    from ..shapes import _add_shape, add_auto_fit_textbox
+
+    # Resolve theme tokens upfront so atomic primitives always receive raw
+    # hex. This also keeps ``theme=None`` (unit-test) calls working when
+    # the spec uses the default tokens ``"primary"`` / ``"text_secondary"``
+    # / ``"rule_subtle"``.
+    title_color_hex = _resolve_color(spec.title_color, theme)
+    subtitle_color_hex = _resolve_color(spec.subtitle_color, theme)
+    divider_color_hex = _resolve_color(spec.divider_color, theme)
+
+    consumed_height = _compute_consumed_height(spec)
+
+    title_top = float(top)
+    # If no subtitle, the divider sits right after the title + a single gap.
+    if spec.subtitle:
+        subtitle_top: Optional[float] = title_top + _TITLE_H + _INTRA_GAP_TITLE
+        divider_top = (
+            subtitle_top + _SUBTITLE_H + _INTRA_GAP_SUBTITLE
+        )
+    else:
+        subtitle_top = None
+        divider_top = title_top + _TITLE_H + _INTRA_GAP_SUBTITLE
+
+    with begin_container(
+        slide,
+        name="section_header",
+        left=float(left),
+        top=float(top),
+        width=float(width),
+        height=consumed_height,
+    ):
+        # 1. Title — bold, single-line, auto-fit by width.
+        _, title_actual_font_size = add_auto_fit_textbox(
+            slide,
+            spec.title,
+            left=float(left),
+            top=title_top,
+            width=float(width),
+            height=_TITLE_H,
+            font_size_pt=spec.title_size_pt,
+            min_size_pt=spec.title_min_size_pt,
+            bold=True,
+            color_hex=title_color_hex,
+            align="left",
+            vertical_anchor="top",
+            truncate_with_ellipsis=True,
+            wrap=False,
+            theme=theme,
+        )
+
+        # 2. Optional subtitle — regular weight, single-line.
+        subtitle_actual_font_size: Optional[float] = None
+        subtitle_bounds: Optional[Dict[str, float]] = None
+        if spec.subtitle and subtitle_top is not None:
+            _, subtitle_actual_font_size = add_auto_fit_textbox(
+                slide,
+                spec.subtitle,
+                left=float(left),
+                top=subtitle_top,
+                width=float(width),
+                height=_SUBTITLE_H,
+                font_size_pt=spec.subtitle_size_pt,
+                min_size_pt=spec.subtitle_min_size_pt,
+                bold=False,
+                color_hex=subtitle_color_hex,
+                align="left",
+                vertical_anchor="top",
+                truncate_with_ellipsis=True,
+                wrap=False,
+                theme=theme,
+            )
+            subtitle_bounds = {
+                "left": float(left),
+                "top": float(subtitle_top),
+                "width": float(width),
+                "height": _SUBTITLE_H,
+            }
+
+        # 3. Divider rule — hairline filled rectangle spanning full width.
+        _add_shape(
+            slide,
+            "rectangle",
+            float(left),
+            float(divider_top),
+            float(width),
+            float(spec.divider_thickness),
+            fill_color=divider_color_hex,
+            no_line=True,
+            theme=theme,
+        )
+
+    return {
+        "title_bounds": {
+            "left": float(left),
+            "top": float(title_top),
+            "width": float(width),
+            "height": _TITLE_H,
+        },
+        "subtitle_bounds": subtitle_bounds,
+        "divider_bounds": {
+            "left": float(left),
+            "top": float(divider_top),
+            "width": float(width),
+            "height": float(spec.divider_thickness),
+        },
+        "consumed_height": consumed_height,
+        "title_actual_font_size": float(title_actual_font_size),
+        "subtitle_actual_font_size": (
+            float(subtitle_actual_font_size)
+            if subtitle_actual_font_size is not None
+            else None
+        ),
+    }

--- a/src/pptx_mcp_server/engine/components/section_header.py
+++ b/src/pptx_mcp_server/engine/components/section_header.py
@@ -123,10 +123,18 @@ def _compute_consumed_height(spec: SectionHeaderSpec) -> float:
 
     Broken out so tests and callers can predict layout without re-running
     the full render.
+
+    The ``_INTRA_GAP_TITLE`` (title → subtitle) spacer only applies when a
+    subtitle is present. Without a subtitle the divider sits directly below
+    the title separated by ``_INTRA_GAP_SUBTITLE`` alone. Mirroring the
+    rendering branch in :func:`add_section_header` here ensures the
+    returned ``consumed_height`` equals the actual divider bottom edge, so
+    callers that place body content at ``top + consumed_height`` align
+    flush with the header's rendered footprint.
     """
-    h = _TITLE_H + _INTRA_GAP_TITLE
+    h = _TITLE_H
     if spec.subtitle:
-        h += _SUBTITLE_H
+        h += _INTRA_GAP_TITLE + _SUBTITLE_H
     h += _INTRA_GAP_SUBTITLE + float(spec.divider_thickness)
     return h
 

--- a/src/pptx_mcp_server/engine/shapes.py
+++ b/src/pptx_mcp_server/engine/shapes.py
@@ -20,7 +20,34 @@ from .pptx_io import (
 )
 from .text_metrics import estimate_text_height, estimate_text_width, wrap_text
 
-from ..theme import Theme, resolve_color
+from ..theme import Theme, resolve_color, resolve_theme_color
+
+
+def _resolve_color_by_theme(color, theme):
+    """色トークン / hex を ``theme`` が str か Theme オブジェクトかで分岐解決する.
+
+    #131: v0.5.0 のブロック primitives は ``theme`` を文字列名 (e.g. ``"ir"``)
+    で受け取り ``resolve_theme_color`` 経由で解決する。一方で composites.py 等
+    の旧コールサイトは ``Theme`` オブジェクトを直接渡し ``resolve_color``
+    (string → hex マップ参照) に頼っている。atomic primitives はどちらも
+    受け付けられる必要があるため、この薄いヘルパーで runtime dispatch する。
+
+    - ``theme`` が ``str`` → ``resolve_theme_color(color, theme)`` で 6-hex
+      (no ``#`` prefix) を返す。
+    - ``theme`` が ``Theme`` → 既存の ``resolve_color(theme, color)`` と同じ
+      挙動を保ち、先頭の ``#`` も保持する (下流 ``_parse_color`` は両方扱える)。
+    - それ以外 (``None`` 等) → 入力をそのまま返す。
+
+    ``color`` が falsy なら空文字 / None をそのまま返し、defensive guard を
+    追加しない (呼び出し側は既に ``if color:`` でガードしている)。
+    """
+    if not color:
+        return color
+    if isinstance(theme, str):
+        return resolve_theme_color(color, theme)
+    if isinstance(theme, Theme):
+        return resolve_color(theme, color)
+    return color
 
 # DrawingML 名前空間 (OOXML 直接操作用)。
 _A_NS = "http://schemas.openxmlformats.org/drawingml/2006/main"
@@ -105,7 +132,7 @@ def _apply_font(
     if font_size is not None:
         font.size = Pt(font_size)
     if font_color is not None:
-        color_hex = resolve_color(theme, font_color) if theme else font_color
+        color_hex = _resolve_color_by_theme(font_color, theme) if theme else font_color
         font.color.rgb = _parse_color(color_hex)
     if bold is not None:
         font.bold = bold
@@ -123,7 +150,7 @@ def _apply_font(
         if font_size is not None:
             rfont.size = Pt(font_size)
         if font_color is not None:
-            color_hex = resolve_color(theme, font_color) if theme else font_color
+            color_hex = _resolve_color_by_theme(font_color, theme) if theme else font_color
             rfont.color.rgb = _parse_color(color_hex)
         if bold is not None:
             rfont.bold = bold
@@ -175,12 +202,17 @@ def _add_textbox(
     ``vertical_anchor`` は python-pptx の ``tf.vertical_anchor`` 経由で設定
     する (issue #41)。直接 ``bodyPr.set("anchor", ...)`` を呼ぶと round-trip
     で属性が重複する危険があるため、lxml 直接操作はしない。
+
+    ``theme`` は ``str`` (テーマ名) / ``Theme`` オブジェクトの双方を受け付け
+    る (#131)。``str`` の場合は ``font_color`` のみ ``resolve_theme_color``
+    経由で解決し、``Theme`` オブジェクトの場合は既存挙動 (body/east_asian
+    font のフォールバック + ``resolve_color``) を保つ。
     """
-    if theme:
+    if isinstance(theme, Theme):
         font_name = font_name or theme.fonts.get("body")
         east_asian_font = east_asian_font or theme.fonts.get("east_asian")
-        if font_color:
-            font_color = resolve_color(theme, font_color)
+    if theme and font_color:
+        font_color = _resolve_color_by_theme(font_color, theme)
 
     txBox = slide.shapes.add_textbox(
         Inches(left), Inches(top), Inches(width), Inches(height),
@@ -243,15 +275,25 @@ def _add_shape(
     alignment=None,
     theme=None,
 ):
-    """In-memory: add an auto shape to a slide. Returns shape_index."""
-    if theme:
+    """In-memory: add an auto shape to a slide. Returns shape_index.
+
+    ``theme`` は 2 形態を受け付ける (#131):
+      - ``str`` (e.g. ``"ir"``): ``resolve_theme_color`` 経由で色トークンを
+        6-hex に解決する (v0.5.0 primitives と同じ契約)。
+      - ``Theme`` object: 旧コールサイト互換。``resolve_color`` + ``theme.fonts``
+        参照で解決する。
+    ``None`` (既定) の場合は色はそのまま下流に渡され、既存挙動を保つ。
+    """
+    if isinstance(theme, Theme):
+        # Theme オブジェクト経路: v0.5.0 以前の composites.py 互換。
         font_name = font_name or theme.fonts.get("body")
+    if theme:
         if fill_color:
-            fill_color = resolve_color(theme, fill_color)
+            fill_color = _resolve_color_by_theme(fill_color, theme)
         if line_color:
-            line_color = resolve_color(theme, line_color)
+            line_color = _resolve_color_by_theme(line_color, theme)
         if font_color:
-            font_color = resolve_color(theme, font_color)
+            font_color = _resolve_color_by_theme(font_color, theme)
 
     shape_enum = _SHAPE_MAP.get(shape_type.lower())
     if shape_enum is None:
@@ -451,14 +493,20 @@ def add_shape(
     font_color=None,
     bold=None,
     alignment=None,
+    theme=None,
 ):
-    """File-based wrapper: add an auto shape to a slide."""
+    """File-based wrapper: add an auto shape to a slide.
+
+    ``theme`` は ``str`` (テーマ名) を受け付け、``_add_shape`` に透過する
+    (#131)。``None`` (既定) なら v0.5.1 挙動を保つ。
+    """
     prs = open_pptx(file_path)
     slide = _get_slide(prs, slide_index)
     idx = _add_shape(
         slide, shape_type, left, top, width, height,
         fill_color, line_color, line_width, no_line,
         text, font_name, font_size, font_color, bold, alignment,
+        theme=theme,
     )
     save_pptx(prs, file_path)
     return f"Added {shape_type} [{idx}] on slide [{slide_index}]"
@@ -772,6 +820,7 @@ def add_auto_fit_textbox(
     truncate_with_ellipsis: bool = True,
     east_asian_font: str | None = None,
     wrap: bool = True,
+    theme: str | None = None,
 ) -> tuple[object, float]:
     """指定 box に収まる最大 font size でテキストを描画する.
 
@@ -813,6 +862,9 @@ def add_auto_fit_textbox(
         wrap: True なら高さベースで auto-fit し折り返しを許容する。False なら
             幅ベースで auto-fit し単一行を維持する (``word_wrap=False`` を
             textbox に適用)。既定は後方互換のため True。
+        theme: テーマ名 (e.g. ``"ir"``、``"mckinsey"``)。指定時は ``color_hex``
+            を ``resolve_theme_color`` 経由で 6-hex に解決する (#131)。``None``
+            (既定) なら v0.5.1 の挙動を byte-for-byte 保つ。
 
     Returns:
         ``(shape, actual_font_size)`` のタプル。テスト・デバッグ用途。
@@ -829,6 +881,11 @@ def add_auto_fit_textbox(
         font_size_pt=font_size_pt,
         min_size_pt=min_size_pt,
     )
+
+    # #131: theme トークン → 6-hex を entry で一度だけ解決する。``theme=None``
+    # の場合でも ``resolve_theme_color`` は raw hex の ``#`` を剥離するだけの
+    # 冪等 no-op として振る舞う (v0.5.1 の color_hex="#FF0000" 経路と互換)。
+    color_hex = resolve_theme_color(color_hex, theme)
 
     usable_width = max(width - 2 * _AUTO_FIT_PADDING, 0.01)
 
@@ -896,8 +953,12 @@ def add_auto_fit_textbox_file(
     vertical_anchor: str = "top",
     truncate_with_ellipsis: bool = True,
     wrap: bool = True,
+    theme: str | None = None,
 ) -> dict:
     """File-based wrapper: 指定 box に収まるよう自動縮小する textbox を追加する.
+
+    ``theme`` は ``add_auto_fit_textbox`` に透過する (#131)。``None`` 既定
+    で v0.5.1 挙動を保つ。
 
     Returns:
         ``{"shape_index": int, "slide_index": int, "actual_font_size": float}``
@@ -921,6 +982,7 @@ def add_auto_fit_textbox_file(
         vertical_anchor=vertical_anchor,
         truncate_with_ellipsis=truncate_with_ellipsis,
         wrap=wrap,
+        theme=theme,
     )
     save_pptx(prs, file_path)
     return {

--- a/src/pptx_mcp_server/engine/shapes.py
+++ b/src/pptx_mcp_server/engine/shapes.py
@@ -21,6 +21,7 @@ from .pptx_io import (
 from .text_metrics import estimate_text_height, estimate_text_width, wrap_text
 
 from ..theme import Theme, resolve_color
+from .components.container import _register_with_active_container
 
 # DrawingML 名前空間 (OOXML 直接操作用)。
 _A_NS = "http://schemas.openxmlformats.org/drawingml/2006/main"
@@ -200,6 +201,9 @@ def _add_textbox(
     )
     _apply_paragraph(p, alignment, line_spacing)
 
+    # Container auto-tagging (Issue #130). No-op when no container is active.
+    _register_with_active_container(slide, txBox, left, top, width, height)
+
     return len(list(slide.shapes)) - 1
 
 
@@ -220,7 +224,16 @@ def _add_image(slide, image_path, left, top, width=None, height=None):
     if height is not None:
         kwargs["height"] = Inches(height)
 
-    slide.shapes.add_picture(image_path, **kwargs)
+    pic = slide.shapes.add_picture(image_path, **kwargs)
+
+    # Container auto-tagging (Issue #130). Resolve effective w/h from the
+    # created picture (when caller omitted width/height, pptx fills in the
+    # native-aspect sizes) so the registry holds the true bbox.
+    emu_to_in = 1 / 914400
+    effective_w = (pic.width or 0) * emu_to_in
+    effective_h = (pic.height or 0) * emu_to_in
+    _register_with_active_container(slide, pic, left, top, effective_w, effective_h)
+
     return len(list(slide.shapes)) - 1
 
 
@@ -283,6 +296,9 @@ def _add_shape(
         p.text = text
         _apply_font(p, font_name, font_size, font_color, bold, None, None, theme=None)
         _apply_paragraph(p, alignment, None)
+
+    # Container auto-tagging (Issue #130). No-op when no container is active.
+    _register_with_active_container(slide, shape, left, top, width, height)
 
     return len(list(slide.shapes)) - 1
 

--- a/src/pptx_mcp_server/engine/validation.py
+++ b/src/pptx_mcp_server/engine/validation.py
@@ -1364,63 +1364,75 @@ def check_containment(
       境界を逸脱しつつ outer には収まる shape は inner 側でのみ検出される。
     - findings の ``slide_index`` は presentation.slides 中の 0-origin
       index。同一 slide オブジェクトが複数 index を持つ想定はしない。
+
+    **Consumed-on-use contract:** 各 slide の処理完了後、module-level の
+    ``_SLIDE_REGISTRY`` から当該 slide のエントリを ``clear_slide_containers``
+    で削除する。これにより long-running プロセス (MCP server など) で
+    ``list[ContainerBounds]`` がリークせず、また CPython が ``id()`` を
+    再利用しても新しい slide に古い bounds が混入しない。
+    呼び出し側の責務は: ``begin_container`` でコンテナを宣言 → 直後に
+    ``check_containment`` で検証、というペアを守ること。
     """
-    from .components.container import iter_slide_containers
+    from .components.container import clear_slide_containers, iter_slide_containers
 
     findings: List[ValidationFinding] = []
 
     for slide_index, slide in enumerate(presentation.slides):
         containers = list(iter_slide_containers(slide))
-        if not containers:
-            continue
-        for bounds in containers:
-            inner_left, inner_top, inner_right, inner_bottom = bounds.inner_bounds()
-            for child in bounds.children:
-                c_left = child.left
-                c_top = child.top
-                c_right = child.left + child.width
-                c_bottom = child.top + child.height
+        try:
+            for bounds in containers:
+                inner_left, inner_top, inner_right, inner_bottom = bounds.inner_bounds()
+                for child in bounds.children:
+                    c_left = child.left
+                    c_top = child.top
+                    c_right = child.left + child.width
+                    c_bottom = child.top + child.height
 
-                # オフセット量。正値は「外側にはみ出している距離 (inches)」。
-                dx_left = (inner_left - c_left)
-                dx_right = (c_right - inner_right)
-                dy_top = (inner_top - c_top)
-                dy_bottom = (c_bottom - inner_bottom)
+                    # オフセット量。正値は「外側にはみ出している距離 (inches)」。
+                    dx_left = (inner_left - c_left)
+                    dx_right = (c_right - inner_right)
+                    dy_top = (inner_top - c_top)
+                    dy_bottom = (c_bottom - inner_bottom)
 
-                overflow_parts: List[str] = []
-                if dx_left > tolerance:
-                    overflow_parts.append(f"left by {dx_left:.3f}\"")
-                if dx_right > tolerance:
-                    overflow_parts.append(f"right by {dx_right:.3f}\"")
-                if dy_top > tolerance:
-                    overflow_parts.append(f"top by {dy_top:.3f}\"")
-                if dy_bottom > tolerance:
-                    overflow_parts.append(f"bottom by {dy_bottom:.3f}\"")
+                    overflow_parts: List[str] = []
+                    if dx_left > tolerance:
+                        overflow_parts.append(f"left by {dx_left:.3f}\"")
+                    if dx_right > tolerance:
+                        overflow_parts.append(f"right by {dx_right:.3f}\"")
+                    if dy_top > tolerance:
+                        overflow_parts.append(f"top by {dy_top:.3f}\"")
+                    if dy_bottom > tolerance:
+                        overflow_parts.append(f"bottom by {dy_bottom:.3f}\"")
 
-                if not overflow_parts:
-                    continue
+                    if not overflow_parts:
+                        continue
 
-                shape_label = child.name or "<unnamed>"
-                overflow_desc = ", ".join(overflow_parts)
-                message = (
-                    f"shape '{shape_label}' exits container "
-                    f"'{bounds.name}' ({overflow_desc})"
-                )
-                suggested = (
-                    f"reposition or resize shape to fit within "
-                    f"[{inner_left:.2f}, {inner_top:.2f}, "
-                    f"{inner_right:.2f}, {inner_bottom:.2f}] (inches)"
-                )
-                findings.append(
-                    ValidationFinding(
-                        severity="error",
-                        slide_index=slide_index,
-                        shape_name=shape_label,
-                        category="shape_outside_container",
-                        message=message,
-                        suggested_fix=suggested,
+                    shape_label = child.name or "<unnamed>"
+                    overflow_desc = ", ".join(overflow_parts)
+                    message = (
+                        f"shape '{shape_label}' exits container "
+                        f"'{bounds.name}' ({overflow_desc})"
                     )
-                )
+                    suggested = (
+                        f"reposition or resize shape to fit within "
+                        f"[{inner_left:.2f}, {inner_top:.2f}, "
+                        f"{inner_right:.2f}, {inner_bottom:.2f}] (inches)"
+                    )
+                    findings.append(
+                        ValidationFinding(
+                            severity="error",
+                            slide_index=slide_index,
+                            shape_name=shape_label,
+                            category="shape_outside_container",
+                            message=message,
+                            suggested_fix=suggested,
+                        )
+                    )
+        finally:
+            # Consumed-on-use: drop the registry entry so long-running
+            # processes don't leak and id(slide) reuse can't bleed stale
+            # bounds into a freshly-loaded slide.
+            clear_slide_containers(slide)
 
     return findings
 
@@ -1565,12 +1577,16 @@ def check_deck_extended(
 
     # summary: ValidationFinding 由来 + legacy (overlaps / out_of_bounds) を集計する。
     # 詳細な severity mapping は docstring 参照。
-    errors = sum(
-        1 for f in overflow_errors + divider + containment if f.severity == "error"
-    )
+    # 注: containment は _place で by_slide に絞り込まれた後のリストから数えることで
+    #     out-of-range な finding が summary.errors だけに混入する不整合を防ぐ
+    #     (per-slide legacy keys `overlaps` / `out_of_bounds` と同じ扱い)。
+    errors = sum(1 for f in overflow_errors + divider if f.severity == "error")
     for slide_data in slides_out:
         errors += len(slide_data["overlaps"])
         errors += len(slide_data["out_of_bounds"])
+        errors += sum(
+            1 for f in slide_data["containment"] if f.get("severity") == "error"
+        )
     warnings_count = sum(1 for f in unreadable if f.severity == "warning")
     warnings_count += sum(1 for f in title_wrap if f.severity == "warning")
     warnings_count += sum(1 for f in font_missing if f.severity == "warning")

--- a/src/pptx_mcp_server/engine/validation.py
+++ b/src/pptx_mcp_server/engine/validation.py
@@ -1341,6 +1341,90 @@ def check_title_wrap(
     return findings
 
 
+def check_containment(
+    presentation: Presentation,
+    *,
+    tolerance: float = 0.01,
+) -> List[ValidationFinding]:
+    """宣言済み ``begin_container`` の内側に登録された shape が境界を超えて
+    いないかを検出する (Issue #130).
+
+    ``engine.components.container.begin_container`` で宣言したコンテナには、
+    ``with`` ブロック中に追加された shape (``_add_shape`` / ``_add_textbox``
+    / ``_add_image`` 経由) が ``ShapeRef`` として登録される。本関数はその
+    登録情報を走査し、子 shape の bbox がコンテナの padding 適用後内側矩形
+    から ``tolerance`` (既定 0.01 inches ≈ 0.25 mm) 以上はみ出した場合に
+    ``error`` / category ``shape_outside_container`` の finding を返す。
+
+    - 登録時点で (live shape ではなく) キャッシュされた bbox を見るため、
+      python-pptx の shape 再ロードに影響されない。shape が後から削除・
+      移動された場合でも、宣言時点のリスクは正しく報告できる。
+    - ネストコンテナは ``begin_container`` のスタック順に処理される。
+      child は innermost container に対してのみ登録されるため、inner の
+      境界を逸脱しつつ outer には収まる shape は inner 側でのみ検出される。
+    - findings の ``slide_index`` は presentation.slides 中の 0-origin
+      index。同一 slide オブジェクトが複数 index を持つ想定はしない。
+    """
+    from .components.container import iter_slide_containers
+
+    findings: List[ValidationFinding] = []
+
+    for slide_index, slide in enumerate(presentation.slides):
+        containers = list(iter_slide_containers(slide))
+        if not containers:
+            continue
+        for bounds in containers:
+            inner_left, inner_top, inner_right, inner_bottom = bounds.inner_bounds()
+            for child in bounds.children:
+                c_left = child.left
+                c_top = child.top
+                c_right = child.left + child.width
+                c_bottom = child.top + child.height
+
+                # オフセット量。正値は「外側にはみ出している距離 (inches)」。
+                dx_left = (inner_left - c_left)
+                dx_right = (c_right - inner_right)
+                dy_top = (inner_top - c_top)
+                dy_bottom = (c_bottom - inner_bottom)
+
+                overflow_parts: List[str] = []
+                if dx_left > tolerance:
+                    overflow_parts.append(f"left by {dx_left:.3f}\"")
+                if dx_right > tolerance:
+                    overflow_parts.append(f"right by {dx_right:.3f}\"")
+                if dy_top > tolerance:
+                    overflow_parts.append(f"top by {dy_top:.3f}\"")
+                if dy_bottom > tolerance:
+                    overflow_parts.append(f"bottom by {dy_bottom:.3f}\"")
+
+                if not overflow_parts:
+                    continue
+
+                shape_label = child.name or "<unnamed>"
+                overflow_desc = ", ".join(overflow_parts)
+                message = (
+                    f"shape '{shape_label}' exits container "
+                    f"'{bounds.name}' ({overflow_desc})"
+                )
+                suggested = (
+                    f"reposition or resize shape to fit within "
+                    f"[{inner_left:.2f}, {inner_top:.2f}, "
+                    f"{inner_right:.2f}, {inner_bottom:.2f}] (inches)"
+                )
+                findings.append(
+                    ValidationFinding(
+                        severity="error",
+                        slide_index=slide_index,
+                        shape_name=shape_label,
+                        category="shape_outside_container",
+                        message=message,
+                        suggested_fix=suggested,
+                    )
+                )
+
+    return findings
+
+
 def check_deck_extended(
     presentation: Presentation,
     *,
@@ -1372,6 +1456,7 @@ def check_deck_extended(
                     "inconsistent_gaps": [...],
                     "title_wrap": [...],
                     "font_not_measured": [...],  # real-font path のみ
+                    "containment": [...],        # Issue #130
                 },
                 ...
             ],
@@ -1393,6 +1478,7 @@ def check_deck_extended(
         - ``out_of_bounds`` (slide 外に出ている shape)
         - ``text_overflow`` (``check_text_overflow``)
         - ``divider_collision`` (``check_divider_collision``)
+        - ``containment`` (``check_containment`` — Issue #130)
     - ``warnings``:
         - ``unreadable_text`` (``check_unreadable_text``)
         - ``title_wrap`` (``check_title_wrap``)
@@ -1432,6 +1518,7 @@ def check_deck_extended(
         max_lines_subtitle=max_lines_subtitle,
         title_font_threshold=title_font_threshold,
     )
+    containment = check_containment(presentation)
 
     # slide index ごとに集約
     by_slide: Dict[int, Dict[str, List[Any]]] = {}
@@ -1452,6 +1539,7 @@ def check_deck_extended(
             "inconsistent_gaps": [],
             "title_wrap": [],
             "font_not_measured": [],
+            "containment": [],
         }
 
     def _place(findings: List[ValidationFinding], key: str) -> None:
@@ -1471,12 +1559,15 @@ def check_deck_extended(
     _place(divider, "divider_collision")
     _place(gaps, "inconsistent_gaps")
     _place(title_wrap, "title_wrap")
+    _place(containment, "containment")
 
     slides_out = [by_slide[i] for i in sorted(by_slide.keys())]
 
     # summary: ValidationFinding 由来 + legacy (overlaps / out_of_bounds) を集計する。
     # 詳細な severity mapping は docstring 参照。
-    errors = sum(1 for f in overflow_errors + divider if f.severity == "error")
+    errors = sum(
+        1 for f in overflow_errors + divider + containment if f.severity == "error"
+    )
     for slide_data in slides_out:
         errors += len(slide_data["overlaps"])
         errors += len(slide_data["out_of_bounds"])

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -148,6 +148,22 @@ choice, etc.) — that belongs in the calling agent's system prompt.
 - `pptx_check_layout` catches overlaps / overflow after building.
 - `pptx_render_slide` for optional PNG preview (needs LibreOffice + poppler).
 
+## Block Components (v0.6.0+)
+Higher-level composed shapes. Each renders multiple primitives inside a
+bounded rectangle and auto-tags children for containment validation.
+- `pptx_add_kpi_row` — N cells: 9pt label / 26pt bold value / optional detail.
+- `pptx_add_metric_card_row` — N cards side-by-side: label / title / chart
+  slot (image or placeholder) / optional metrics row.
+- `pptx_add_numbered_list` — N numbered items stacked (number + caption +
+  bold title + wrapped body), optional rules between.
+- `pptx_add_section_header` — title + optional subtitle + divider rule;
+  returns `consumed_height` for placing body content below.
+- `pptx_add_page_marker` — top-right "section / P.XX" marker (fixed pos).
+- `pptx_add_slide_footer` — bottom-edge left/right footer text (fixed pos).
+All accept an optional `theme` kwarg; color fields take theme tokens
+(`"primary"`, `"text_secondary"`, `"rule_subtle"`, `"highlight_row"`) or
+raw 6-hex.
+
 ## Available Themes
 Pass `"theme": "<name>"` in slide specs for `build_slide` / `build_deck`.
 Available: `mckinsey` (default), `deloitte`, `neutral`, `ir` (Japanese IR /

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -333,8 +333,9 @@ def pptx_add_auto_fit_textbox(
     align: str = "left",
     vertical_anchor: str = "top",
     truncate_with_ellipsis: bool = True,
+    theme: str = None,
 ) -> str:
-    """Add a textbox that auto-shrinks font size to fit a fixed box. Starts from font_size_pt and steps down 0.5pt until text fits height, or reaches min_size_pt. If still overflowing at min and truncate_with_ellipsis=True, trailing chars are replaced with an ellipsis. Returns a dict with shape_index, shape_name, and actual_font_size."""
+    """Add a textbox that auto-shrinks font size to fit a fixed box. Starts from font_size_pt and steps down 0.5pt until text fits height, or reaches min_size_pt. If still overflowing at min and truncate_with_ellipsis=True, trailing chars are replaced with an ellipsis. ``theme`` (e.g. "ir", "mckinsey") resolves token color_hex (e.g. "primary") to the theme's hex. Returns a dict with shape_index, shape_name, and actual_font_size."""
     try:
         result = add_auto_fit_textbox_file(
             file_path, slide_index, text, left, top, width, height,
@@ -346,6 +347,7 @@ def pptx_add_auto_fit_textbox(
             align=align,
             vertical_anchor=vertical_anchor,
             truncate_with_ellipsis=truncate_with_ellipsis,
+            theme=theme,
         )
         # engine returns a dict {shape_index, shape_name, actual_font_size, ...}
         return _success(result)
@@ -479,13 +481,15 @@ def pptx_add_shape(
     font_color: str = None,
     bold: bool = None,
     alignment: str = None,
+    theme: str = None,
 ) -> str:
-    """Add an auto shape. Types: rectangle, rounded_rectangle, oval, triangle, diamond, chevron, arrow_right, arrow_left, arrow_up, arrow_down, callout, star_5, hexagon, pentagon. Position/size in inches. Colors as hex. WARNING: text inside shapes renders BEHIND any shapes placed on top. For labels over background shapes, use pptx_add_textbox instead."""
+    """Add an auto shape. Types: rectangle, rounded_rectangle, oval, triangle, diamond, chevron, arrow_right, arrow_left, arrow_up, arrow_down, callout, star_5, hexagon, pentagon. Position/size in inches. Colors as hex or theme token when ``theme`` is given (e.g. theme="ir", fill_color="primary"). WARNING: text inside shapes renders BEHIND any shapes placed on top. For labels over background shapes, use pptx_add_textbox instead."""
     try:
         return _success({"message": add_shape(
             file_path, slide_index, shape_type, left, top, width, height,
             fill_color, line_color, line_width, no_line,
             text, font_name, font_size, font_color, bold, alignment,
+            theme=theme,
         )})
     except Exception as e:
         return _err(e)

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -111,6 +111,10 @@ from .engine import (
     TimelinePhase,
     TimelineMilestone,
     add_milestone_timeline,
+    PageMarkerSpec,
+    SlideFooterSpec,
+    add_page_marker,
+    add_slide_footer,
 )
 from .engine.pptx_io import open_pptx, save_pptx, _get_slide
 
@@ -1128,6 +1132,84 @@ def pptx_add_milestone_timeline(
         elif render_info.get("reason") != "disabled":
             result["render_warning"] = render_info
         return _success(result)
+    except Exception as e:
+        return _err(e)
+
+
+# --- Markers (page marker / slide footer) -------------------------
+
+@mcp.tool()
+def pptx_add_page_marker(
+    file_path: str,
+    slide_index: int,
+    section: str,
+    page: str,
+    theme: Optional[str] = None,
+) -> str:
+    """Add a top-right page marker (section line + page line) to a slide.
+
+    Uses fixed conventional position (right margin 0.5", top 0.35"),
+    two right-aligned single-line textboxes stacked vertically.
+    ``theme`` resolves the default ``text_secondary`` color token when set
+    (e.g. ``theme="ir"``).
+
+    Returns ``{"bounds": {"left","top","width","height"}}``.
+    """
+    try:
+        prs = open_pptx(file_path)
+        slide = _get_slide(prs, slide_index)
+        sw = prs.slide_width / 914400
+        sh = prs.slide_height / 914400
+        spec = PageMarkerSpec(section=section, page=page)
+        result = add_page_marker(
+            slide, spec,
+            slide_width=sw, slide_height=sh,
+            theme=theme,
+        )
+        save_pptx(prs, file_path)
+        return _success({
+            "message": f"Added page marker to slide {slide_index}",
+            "bounds": result["bounds"],
+        })
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def pptx_add_slide_footer(
+    file_path: str,
+    slide_index: int,
+    left_text: str = "IR Presentation · FY Q3",
+    right_text: Optional[str] = None,
+    theme: Optional[str] = None,
+) -> str:
+    """Add a bottom-of-slide footer (left + optional right textboxes).
+
+    Uses fixed conventional position (bottom offset 0.4", side margin 0.5").
+    If ``right_text`` is ``None`` or empty, only the left textbox is drawn.
+    ``theme`` resolves the default ``text_secondary`` color token when set.
+
+    Returns ``{"bounds": {"left","top","width","height"}}``.
+    """
+    try:
+        prs = open_pptx(file_path)
+        slide = _get_slide(prs, slide_index)
+        sw = prs.slide_width / 914400
+        sh = prs.slide_height / 914400
+        spec = SlideFooterSpec(
+            left_text=left_text,
+            right_text=right_text or "",
+        )
+        result = add_slide_footer(
+            slide, spec,
+            slide_width=sw, slide_height=sh,
+            theme=theme,
+        )
+        save_pptx(prs, file_path)
+        return _success({
+            "message": f"Added slide footer to slide {slide_index}",
+            "bounds": result["bounds"],
+        })
     except Exception as e:
         return _err(e)
 

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -106,6 +106,8 @@ from .engine import (
     check_deck_extended,
     CardSpec,
     add_responsive_card_row,
+    SectionHeaderSpec,
+    add_section_header,
     TableColumnSpec,
     add_data_table,
     TimelinePhase,
@@ -871,6 +873,60 @@ def pptx_add_responsive_card_row(
 
         render_info = _auto_render(file_path, slide_index)
         # result は既に richer dict — auto-render の結果を同じ dict にマージ。
+        if render_info.get("rendered"):
+            result["preview_path"] = render_info.get("preview_path")
+        elif render_info.get("reason") != "disabled":
+            result["render_warning"] = render_info
+        return _success(result)
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def pptx_add_section_header(
+    file_path: str,
+    slide_index: int,
+    title: str,
+    subtitle: Optional[str] = None,
+    left: float = 0.9,
+    top: float = 0.45,
+    width: float = 11.533,
+    theme: Optional[str] = None,
+) -> str:
+    """Add a section header (title + optional subtitle + divider rule).
+
+    Renders a vertically-stacked block comprising a bold title, an optional
+    subtitle beneath it, and a full-width hairline divider. Title and
+    subtitle use single-line auto-fit (no wrap) with ellipsis truncation
+    so long strings do not spill to a second row.
+
+    Defaults target the McKinsey 13.333×7.5 slide layout: the header sits
+    near the top of the slide with ~0.9" left/right margins.
+
+    Returns JSON with ``title_bounds``, ``subtitle_bounds`` (may be
+    ``None``), ``divider_bounds``, and ``consumed_height`` — use the last
+    value to place body content directly below the header.
+    """
+    try:
+        spec = SectionHeaderSpec(
+            title=title,
+            subtitle=subtitle or "",
+        )
+        prs = open_pptx(file_path)
+        slide = _get_slide(prs, slide_index)
+
+        result = add_section_header(
+            slide,
+            spec,
+            left=left,
+            top=top,
+            width=width,
+            theme=theme,
+        )
+
+        save_pptx(prs, file_path)
+
+        render_info = _auto_render(file_path, slide_index)
         if render_info.get("rendered"):
             result["preview_path"] = render_info.get("preview_path")
         elif render_info.get("reason") != "disabled":

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -972,6 +972,9 @@ def pptx_add_section_header(
             theme=theme,
         )
 
+        # Envelope invariant: result must have 'message' (#120).
+        result["message"] = f"Added section header on slide [{slide_index}]"
+
         save_pptx(prs, file_path)
 
         render_info = _auto_render(file_path, slide_index)

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -111,6 +111,8 @@ from .engine import (
     TimelinePhase,
     TimelineMilestone,
     add_milestone_timeline,
+    KPISpec,
+    add_kpi_row_block,
 )
 from .engine.pptx_io import open_pptx, save_pptx, _get_slide
 
@@ -717,18 +719,23 @@ def pptx_add_section_divider(
 
 
 @mcp.tool()
-def pptx_add_kpi_row(
+def pptx_add_kpi_row_legacy(
     file_path: str,
     slide_index: int,
     kpis: List[Dict[str, Any]],
     y: float,
 ) -> str:
-    """Add a row of KPI callout boxes.
+    """(Deprecated) Add a row of KPI callout boxes.
 
     ``kpis``: list of dicts, e.g. ``[{"value":"107.8M","label":"Revenue"}]``.
     ``y``: vertical position in inches.
     v0.3.0 (#97): was ``kpis_json: str``.
     Auto-renders a preview PNG ONLY when PPTX_MCP_AUTO_RENDER=1.
+
+    DEPRECATED (v0.6.0, #133): this is the legacy simple-callout variant.
+    New callers should prefer the block-component ``pptx_add_kpi_row``,
+    which supports theme tokens, optional card frames, detail lines, and
+    container-aware containment validation.
     """
     try:
         if not isinstance(kpis, list):
@@ -871,6 +878,103 @@ def pptx_add_responsive_card_row(
 
         render_info = _auto_render(file_path, slide_index)
         # result は既に richer dict — auto-render の結果を同じ dict にマージ。
+        if render_info.get("rendered"):
+            result["preview_path"] = render_info.get("preview_path")
+        elif render_info.get("reason") != "disabled":
+            result["render_warning"] = render_info
+        return _success(result)
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def pptx_add_kpi_row(
+    file_path: str,
+    slide_index: int,
+    kpis: List[Dict[str, Any]],
+    left: float,
+    top: float,
+    width: float,
+    height: float = 0.95,
+    gap: float = 0.15,
+    card_fill: Optional[str] = None,
+    card_border: Optional[str] = None,
+    theme: Optional[str] = None,
+) -> str:
+    """Add a row of N KPI cells (label / big value / optional detail).
+
+    Each cell stacks a 9pt label, a 26pt bold value (single-line auto-fit),
+    and an optional 8pt detail line. Cells are evenly distributed across
+    ``width`` with ``gap`` inches between them; ``n == 1`` consumes full
+    width with no gap.
+
+    ``kpis``: list of dicts with keys ``label``, ``value``, ``detail``
+    (optional), ``value_color`` (theme token or hex, default ``"primary"``),
+    ``delta_color`` (reserved for future delta variant).
+
+    When ``card_fill`` or ``card_border`` is provided the component draws
+    a rectangle per cell behind the text (e.g. ``card_fill="highlight_row"``
+    for a cream band, ``card_border="rule_subtle"`` for a thin frame).
+
+    ``theme``: theme registry key (e.g. ``"ir"``, ``"mckinsey"``). When
+    omitted, built-in fallback colors are used for tokens. Auto-renders a
+    preview PNG ONLY when PPTX_MCP_AUTO_RENDER=1.
+    """
+    try:
+        if not isinstance(kpis, list):
+            return _error(
+                "INVALID_PARAMETER",
+                "kpis must be a list of dicts.",
+                parameter="kpis",
+                hint='Pass a native list, e.g. [{"label":"Revenue","value":"107.8M"}].',
+                issue=133,
+            )
+        # Strict-key validation per dict — surfaces typos with an actionable
+        # message rather than letting KPISpec(**d) raise a bare TypeError.
+        _kpi_known_keys = {f.name for f in fields(KPISpec)}
+        for i, spec in enumerate(kpis):
+            if not isinstance(spec, dict):
+                raise EngineError(
+                    ErrorCode.INVALID_PARAMETER,
+                    f"kpis[{i}]: must be a dict, got {type(spec).__name__}.",
+                )
+            unknown = set(spec.keys()) - _kpi_known_keys
+            if unknown:
+                raise EngineError(
+                    ErrorCode.INVALID_PARAMETER,
+                    (
+                        f"kpis[{i}]: unknown keys {sorted(unknown)}; "
+                        f"known keys: {sorted(_kpi_known_keys)}."
+                    ),
+                )
+        kpi_objs = [KPISpec(**d) for d in kpis]
+        prs = open_pptx(file_path)
+        slide = _get_slide(prs, slide_index)
+
+        row_result = add_kpi_row_block(
+            slide,
+            kpi_objs,
+            left=left,
+            top=top,
+            width=width,
+            height=height,
+            gap=gap,
+            theme=theme,
+            card_fill=card_fill,
+            card_border=card_border,
+        )
+
+        # Serialize before save so a broken result dict doesn't corrupt the
+        # file on disk (mirrors #34 pattern used by pptx_add_responsive_card_row).
+        result: Dict[str, Any] = {
+            "message": f"Added KPI row with {len(kpi_objs)} cells on slide [{slide_index}]",
+            "cells": [{"bounds": c["bounds"]} for c in row_result["cells"]],
+            "consumed_height": row_result["consumed_height"],
+        }
+
+        save_pptx(prs, file_path)
+
+        render_info = _auto_render(file_path, slide_index)
         if render_info.get("rendered"):
             result["preview_path"] = render_info.get("preview_path")
         elif render_info.get("reason") != "disabled":

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -111,6 +111,8 @@ from .engine import (
     TimelinePhase,
     TimelineMilestone,
     add_milestone_timeline,
+    NumberedItem,
+    add_numbered_list,
 )
 from .engine.pptx_io import open_pptx, save_pptx, _get_slide
 
@@ -1128,6 +1130,96 @@ def pptx_add_milestone_timeline(
         elif render_info.get("reason") != "disabled":
             result["render_warning"] = render_info
         return _success(result)
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def pptx_add_numbered_list(
+    file_path: str,
+    slide_index: int,
+    items: List[Dict[str, Any]],
+    left: float,
+    top: float,
+    width: float,
+    height: float,
+    rule_between: bool = True,
+    theme: Optional[str] = None,
+) -> str:
+    """Add a numbered list (N items stacked with optional rules between).
+
+    Each item renders as a number + caption row, bold title, and wrapped
+    body paragraph. Items divide the bounding ``height`` equally. A thin
+    horizontal rule separates consecutive items unless ``rule_between=False``
+    or the item is last.
+
+    ``items`` is a list of dicts with required keys: ``number``, ``caption``,
+    ``title``, ``body`` (all strings). ``body`` may be empty to skip the body
+    textbox for that item.
+    """
+    try:
+        if not isinstance(items, list):
+            return _error(
+                "INVALID_PARAMETER",
+                "items must be a list of dicts.",
+                parameter="items",
+                hint="Pass a native list, e.g. [{\"number\":\"01\",\"caption\":\"...\",\"title\":\"...\",\"body\":\"...\"}].",
+            )
+
+        _known = {f.name for f in fields(NumberedItem)}
+        for i, d in enumerate(items):
+            if not isinstance(d, dict):
+                raise EngineError(
+                    ErrorCode.INVALID_PARAMETER,
+                    f"items[{i}]: must be a dict, got {type(d).__name__}.",
+                )
+            unknown = set(d.keys()) - _known
+            if unknown:
+                raise EngineError(
+                    ErrorCode.INVALID_PARAMETER,
+                    (
+                        f"items[{i}]: unknown keys {sorted(unknown)}; "
+                        f"known keys: {sorted(_known)}."
+                    ),
+                )
+
+        item_objs = [NumberedItem(**d) for d in items]
+
+        prs = open_pptx(file_path)
+        slide = _get_slide(prs, slide_index)
+
+        result = add_numbered_list(
+            slide,
+            item_objs,
+            left=left,
+            top=top,
+            width=width,
+            height=height,
+            rule_between=rule_between,
+            theme=theme,
+        )
+
+        # Envelope invariant: result must have 'message' (#120).
+        # Shape references are python-pptx objects and aren't JSON-serialisable,
+        # so we expose only the per-item bounds and top-level sizes.
+        serialised = {
+            "items": [
+                {"bounds": entry["bounds"]}
+                for entry in result["items"]
+            ],
+            "consumed_height": result["consumed_height"],
+            "consumed_width": result["consumed_width"],
+            "message": f"Added numbered list with {len(items)} item(s)",
+        }
+
+        save_pptx(prs, file_path)
+
+        render_info = _auto_render(file_path, slide_index)
+        if render_info.get("rendered"):
+            serialised["preview_path"] = render_info.get("preview_path")
+        elif render_info.get("reason") != "disabled":
+            serialised["render_warning"] = render_info
+        return _success(serialised)
     except Exception as e:
         return _err(e)
 

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -111,6 +111,9 @@ from .engine import (
     TimelinePhase,
     TimelineMilestone,
     add_milestone_timeline,
+    MetricEntry,
+    MetricCardSpec,
+    add_metric_card_row,
 )
 from .engine.pptx_io import open_pptx, save_pptx, _get_slide
 
@@ -1119,6 +1122,130 @@ def pptx_add_milestone_timeline(
             f"Added milestone timeline "
             f"({len(phases)} phases, {len(milestones)} milestones)"
         )
+
+        save_pptx(prs, file_path)
+
+        render_info = _auto_render(file_path, slide_index)
+        if render_info.get("rendered"):
+            result["preview_path"] = render_info.get("preview_path")
+        elif render_info.get("reason") != "disabled":
+            result["render_warning"] = render_info
+        return _success(result)
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def pptx_add_metric_card_row(
+    file_path: str,
+    slide_index: int,
+    cards: List[Dict[str, Any]],
+    left: float,
+    top: float,
+    width: float,
+    height: float,
+    gap: float = 0.3,
+    theme: Optional[str] = None,
+) -> str:
+    """Add a row of N MetricCard block components side-by-side (#132).
+
+    Each card stacks, top-to-bottom: small ``label`` → ``title`` → chart
+    (image when ``chart_image_path`` set, else blank placeholder rectangle)
+    → optional metrics row with per-cell ``(label, value)`` pairs.
+
+    ``cards``: list of card dicts. Supported keys: ``label``, ``title``,
+    ``chart_image_path``, ``metrics`` (list of ``{"label","value"}`` dicts),
+    ``fill_color``, ``border_color``, ``border_width``, ``label_color``,
+    ``title_color``, ``metric_label_color``, ``metric_value_color``,
+    ``padding``, ``title_size_pt``, ``label_size_pt``,
+    ``metric_label_size_pt``, ``metric_value_size_pt``. Colors accept hex
+    (no ``#``) or theme tokens when ``theme`` is provided.
+
+    Returns a dict ``{"cards": [{"left","top","width","height"}, ...],
+    "consumed_height": <float>, "consumed_width": <float>}``. Auto-renders
+    a preview PNG only when ``PPTX_MCP_AUTO_RENDER=1``.
+    """
+    try:
+        if not isinstance(cards, list):
+            return _error(
+                "INVALID_PARAMETER",
+                "cards must be a list of dicts.",
+                parameter="cards",
+                hint="Pass a native list, e.g. [{\"label\":\"KPI\",\"title\":\"Revenue\"}].",
+                issue=132,
+            )
+
+        _card_known = {f.name for f in fields(MetricCardSpec)}
+        _metric_known = {f.name for f in fields(MetricEntry)}
+
+        card_specs: List[MetricCardSpec] = []
+        for i, spec in enumerate(cards):
+            if not isinstance(spec, dict):
+                raise EngineError(
+                    ErrorCode.INVALID_PARAMETER,
+                    f"card[{i}]: must be a dict, got {type(spec).__name__}.",
+                )
+            unknown = set(spec.keys()) - _card_known
+            if unknown:
+                raise EngineError(
+                    ErrorCode.INVALID_PARAMETER,
+                    (
+                        f"card[{i}]: unknown keys {sorted(unknown)}; "
+                        f"known keys: {sorted(_card_known)}."
+                    ),
+                )
+            # Validate + coerce nested metrics list.
+            metrics_raw = spec.get("metrics") or []
+            if not isinstance(metrics_raw, list):
+                raise EngineError(
+                    ErrorCode.INVALID_PARAMETER,
+                    (
+                        f"card[{i}].metrics must be a list of dicts, got "
+                        f"{type(metrics_raw).__name__}."
+                    ),
+                )
+            metric_objs: List[MetricEntry] = []
+            for j, m in enumerate(metrics_raw):
+                if not isinstance(m, dict):
+                    raise EngineError(
+                        ErrorCode.INVALID_PARAMETER,
+                        (
+                            f"card[{i}].metrics[{j}]: must be a dict, got "
+                            f"{type(m).__name__}."
+                        ),
+                    )
+                m_unknown = set(m.keys()) - _metric_known
+                if m_unknown:
+                    raise EngineError(
+                        ErrorCode.INVALID_PARAMETER,
+                        (
+                            f"card[{i}].metrics[{j}]: unknown keys "
+                            f"{sorted(m_unknown)}; known keys: "
+                            f"{sorted(_metric_known)}."
+                        ),
+                    )
+                metric_objs.append(MetricEntry(**m))
+
+            spec_copy = dict(spec)
+            spec_copy["metrics"] = metric_objs
+            card_specs.append(MetricCardSpec(**spec_copy))
+
+        prs = open_pptx(file_path)
+        slide = _get_slide(prs, slide_index)
+
+        result = add_metric_card_row(
+            slide,
+            card_specs,
+            left=left,
+            top=top,
+            width=width,
+            height=height,
+            gap=gap,
+            theme=theme,
+        )
+
+        # Envelope invariant: result must have 'message' (#120).
+        result["message"] = f"Added metric card row ({len(card_specs)} cards)."
 
         save_pptx(prs, file_path)
 

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -735,7 +735,23 @@ def pptx_add_kpi_row_legacy(
     DEPRECATED (v0.6.0, #133): this is the legacy simple-callout variant.
     New callers should prefer the block-component ``pptx_add_kpi_row``,
     which supports theme tokens, optional card frames, detail lines, and
-    container-aware containment validation.
+    container-aware containment validation. This tool will be removed in
+    v0.7.0.
+
+    Migration to pptx_add_kpi_row (v0.6.0)::
+
+        # Before (legacy):
+        pptx_add_kpi_row(file_path, slide_index, kpis=[...], y=2.5)
+        # After:
+        pptx_add_kpi_row(
+            file_path, slide_index, kpis=[...],
+            left=0.5, top=2.5, width=12.0,
+        )
+
+    The new tool takes ``left`` / ``top`` / ``width`` (and optional
+    ``height``, ``gap``, ``card_fill``, ``card_border``, ``theme``) in
+    place of the single ``y`` parameter. Each KPI dict may now also carry
+    ``detail`` and ``value_color`` fields.
     """
     try:
         if not isinstance(kpis, list):

--- a/src/pptx_mcp_server/server.py
+++ b/src/pptx_mcp_server/server.py
@@ -64,6 +64,11 @@ from ._render import (
     _auto_render_timeout,
     _run_auto_render,
 )
+from ._tool_registry import (
+    advanced_tool_names,
+    is_advanced_enabled,
+    mcp_tool,
+)
 from .engine import (
     EngineError,
     ErrorCode,
@@ -188,6 +193,38 @@ timeout/failure. `pptx_check_layout(detailed=True)` embeds its `slides` /
 `TABLE_ERROR`, `CHART_ERROR`, `INTERNAL_ERROR`. On failure, read `error.hint`
 (if present) for recovery guidance.
 
+## Tool Tiers (v0.6.0+; #137)
+The MCP surface is split into two tiers to keep the default agent-facing
+catalog focused on the productive block-component + batch layer:
+
+- **Default surface** — setup/inspection (`pptx_create`, `pptx_get_info`,
+  `pptx_read_slide`, `pptx_add_slide`), block components
+  (`pptx_add_section_header`, `pptx_add_kpi_row`,
+  `pptx_add_metric_card_row`, `pptx_add_numbered_list`,
+  `pptx_add_page_marker`, `pptx_add_slide_footer`), high-level
+  primitives (`pptx_add_data_table`, `pptx_add_responsive_card_row`,
+  `pptx_add_milestone_timeline`, `pptx_add_flex_container`,
+  `pptx_add_chart`, `pptx_add_image`), batch build (`pptx_build_slide`,
+  `pptx_build_deck`), and validation/rendering (`pptx_check_layout`,
+  `pptx_render_slide`).
+- **Advanced tier** — raw shape primitives (`pptx_add_textbox`,
+  `pptx_add_shape`, `pptx_add_auto_fit_textbox`), low-level edit ops
+  (`pptx_edit_text`, `pptx_add_paragraph`, `pptx_delete_shape`,
+  `pptx_list_shapes`, `pptx_format_shape`), slide-level editing
+  (`pptx_set_dimensions`, `pptx_set_slide_background`,
+  `pptx_move_slide`, `pptx_delete_slide`, `pptx_duplicate_slide`),
+  table editing primitives (`pptx_add_table`, `pptx_edit_table_cell`,
+  `pptx_edit_table_cells`, `pptx_format_table`), connectors / callouts
+  / icons (`pptx_add_connector`, `pptx_add_callout`, `pptx_add_icon`,
+  `pptx_list_icons`), composite helpers (`pptx_add_section_divider`,
+  `pptx_add_content_slide`, `pptx_add_bullet_block`), and the legacy
+  `pptx_add_kpi_row_legacy`.
+
+Advanced-tier tools are **hidden from the MCP catalog by default**.
+Opt in by setting `PPTX_MCP_INCLUDE_ADVANCED=1` in the environment
+before the server starts (accepts `1`/`true`/`yes`). The env var is
+read once at import, so restart the server after changing it.
+
 ## Auto-Render (opt-in; OFF by default)
 Enable via `PPTX_MCP_AUTO_RENDER=1`; timeout (seconds) via
 `PPTX_MCP_RENDER_TIMEOUT` (default 10). On timeout/failure the primary tool
@@ -216,7 +253,7 @@ def _auto_render(file_path: str, slide_index: int) -> Dict[str, Any]:
 
 # --- Presentation ------------------------------------------------
 
-@mcp.tool()
+@mcp_tool(mcp)
 def pptx_create(
     file_path: str,
     width_inches: float = 13.333,
@@ -229,7 +266,7 @@ def pptx_create(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp)
 def pptx_get_info(file_path: str) -> str:
     """Get presentation overview: slide count, dimensions, shape summaries."""
     try:
@@ -238,7 +275,7 @@ def pptx_get_info(file_path: str) -> str:
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp)
 def pptx_read_slide(file_path: str, slide_index: int) -> str:
     """Read detailed content of a slide -- all shapes, text, tables."""
     try:
@@ -247,7 +284,7 @@ def pptx_read_slide(file_path: str, slide_index: int) -> str:
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_list_shapes(file_path: str, slide_index: int) -> str:
     """List all shapes on a slide with indices, types, positions, text preview."""
     try:
@@ -258,7 +295,7 @@ def pptx_list_shapes(file_path: str, slide_index: int) -> str:
 
 # --- Slides -------------------------------------------------------
 
-@mcp.tool()
+@mcp_tool(mcp)
 def pptx_add_slide(file_path: str, layout_index: int = 6) -> str:
     """Add a new slide. Layout 6 = Blank (most common)."""
     try:
@@ -267,7 +304,7 @@ def pptx_add_slide(file_path: str, layout_index: int = 6) -> str:
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_move_slide(file_path: str, from_index: int, to_index: int) -> str:
     """Move a slide from one position to another. 0-based indices."""
     try:
@@ -276,7 +313,7 @@ def pptx_move_slide(file_path: str, from_index: int, to_index: int) -> str:
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_delete_slide(file_path: str, slide_index: int) -> str:
     """Delete a slide by 0-based index."""
     try:
@@ -285,7 +322,7 @@ def pptx_delete_slide(file_path: str, slide_index: int) -> str:
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_duplicate_slide(file_path: str, slide_index: int) -> str:
     """Duplicate a slide (appended at end)."""
     try:
@@ -294,7 +331,7 @@ def pptx_duplicate_slide(file_path: str, slide_index: int) -> str:
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_set_slide_background(file_path: str, slide_index: int, color: str) -> str:
     """Set solid background color for a slide. Color as hex e.g. '051C2C' (without #)."""
     try:
@@ -303,7 +340,7 @@ def pptx_set_slide_background(file_path: str, slide_index: int, color: str) -> s
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_set_dimensions(file_path: str, width: float, height: float) -> str:
     """Set presentation slide dimensions in inches (applies to all slides)."""
     try:
@@ -314,7 +351,7 @@ def pptx_set_dimensions(file_path: str, width: float, height: float) -> str:
 
 # --- Textboxes ----------------------------------------------------
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_add_textbox(
     file_path: str,
     slide_index: int,
@@ -345,7 +382,7 @@ def pptx_add_textbox(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_add_auto_fit_textbox(
     file_path: str,
     slide_index: int,
@@ -384,7 +421,7 @@ def pptx_add_auto_fit_textbox(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp)
 def pptx_add_flex_container(
     file_path: str,
     slide_index: int,
@@ -436,7 +473,7 @@ def pptx_add_flex_container(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_edit_text(
     file_path: str,
     slide_index: int,
@@ -463,7 +500,7 @@ def pptx_edit_text(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_add_paragraph(
     file_path: str,
     slide_index: int,
@@ -491,7 +528,7 @@ def pptx_add_paragraph(
 
 # --- Shapes -------------------------------------------------------
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_add_shape(
     file_path: str,
     slide_index: int,
@@ -524,7 +561,7 @@ def pptx_add_shape(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp)
 def pptx_add_image(
     file_path: str,
     slide_index: int,
@@ -541,7 +578,7 @@ def pptx_add_image(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_delete_shape(file_path: str, slide_index: int, shape_index: int) -> str:
     """Delete a shape from a slide by its 0-based index."""
     try:
@@ -550,7 +587,7 @@ def pptx_delete_shape(file_path: str, slide_index: int, shape_index: int) -> str
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_format_shape(
     file_path: str,
     slide_index: int,
@@ -579,7 +616,7 @@ def pptx_format_shape(
 
 # --- Tables -------------------------------------------------------
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_add_table(
     file_path: str,
     slide_index: int,
@@ -639,7 +676,7 @@ def pptx_add_table(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_edit_table_cell(
     file_path: str,
     slide_index: int,
@@ -663,7 +700,7 @@ def pptx_edit_table_cell(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_edit_table_cells(
     file_path: str,
     slide_index: int,
@@ -689,7 +726,7 @@ def pptx_edit_table_cells(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_format_table(
     file_path: str,
     slide_index: int,
@@ -712,7 +749,7 @@ def pptx_format_table(
 
 # --- Composites ---------------------------------------------------
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_add_content_slide(
     file_path: str,
     title: str,
@@ -729,7 +766,7 @@ def pptx_add_content_slide(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_add_section_divider(
     file_path: str,
     title: str,
@@ -745,7 +782,7 @@ def pptx_add_section_divider(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_add_kpi_row_legacy(
     file_path: str,
     slide_index: int,
@@ -796,7 +833,7 @@ def pptx_add_kpi_row_legacy(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_add_bullet_block(
     file_path: str,
     slide_index: int,
@@ -828,7 +865,7 @@ def pptx_add_bullet_block(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp)
 def pptx_add_responsive_card_row(
     file_path: str,
     slide_index: int,
@@ -930,7 +967,7 @@ def pptx_add_responsive_card_row(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp)
 def pptx_add_section_header(
     file_path: str,
     slide_index: int,
@@ -987,7 +1024,7 @@ def pptx_add_section_header(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp)
 def pptx_add_kpi_row(
     file_path: str,
     slide_index: int,
@@ -1084,7 +1121,7 @@ def pptx_add_kpi_row(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp)
 def pptx_add_data_table(
     file_path: str,
     slide_index: int,
@@ -1214,7 +1251,7 @@ def pptx_add_data_table(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp)
 def pptx_add_milestone_timeline(
     file_path: str,
     slide_index: int,
@@ -1338,7 +1375,7 @@ def pptx_add_milestone_timeline(
 
 # --- Markers (page marker / slide footer) -------------------------
 
-@mcp.tool()
+@mcp_tool(mcp)
 def pptx_add_page_marker(
     file_path: str,
     slide_index: int,
@@ -1375,7 +1412,7 @@ def pptx_add_page_marker(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp)
 def pptx_add_slide_footer(
     file_path: str,
     slide_index: int,
@@ -1414,7 +1451,7 @@ def pptx_add_slide_footer(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp)
 def pptx_add_numbered_list(
     file_path: str,
     slide_index: int,
@@ -1504,7 +1541,7 @@ def pptx_add_numbered_list(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp)
 def pptx_add_metric_card_row(
     file_path: str,
     slide_index: int,
@@ -1630,7 +1667,7 @@ def pptx_add_metric_card_row(
 
 # --- Batch Build --------------------------------------------------
 
-@mcp.tool()
+@mcp_tool(mcp)
 def pptx_build_slide(
     file_path: str,
     spec: Dict[str, Any],
@@ -1682,7 +1719,7 @@ def pptx_build_slide(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp)
 def pptx_build_deck(
     file_path: str,
     slides: List[Dict[str, Any]],
@@ -1716,7 +1753,7 @@ def pptx_build_deck(
 
 # --- Connectors & Callouts ----------------------------------------
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_add_connector(
     file_path: str,
     slide_index: int,
@@ -1749,7 +1786,7 @@ def pptx_add_connector(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_add_callout(
     file_path: str,
     slide_index: int,
@@ -1788,7 +1825,7 @@ def pptx_add_callout(
 
 # --- Icons --------------------------------------------------------
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_list_icons(
     category: str = "",
     search: str = "",
@@ -1810,7 +1847,7 @@ def pptx_list_icons(
         return _err(e)
 
 
-@mcp.tool()
+@mcp_tool(mcp, advanced=True)
 def pptx_add_icon(
     file_path: str,
     slide_index: int,
@@ -1837,7 +1874,7 @@ def pptx_add_icon(
 
 # --- Charts -------------------------------------------------------
 
-@mcp.tool()
+@mcp_tool(mcp)
 def pptx_add_chart(
     file_path: str,
     slide_index: int,
@@ -1878,7 +1915,7 @@ def pptx_add_chart(
 
 # --- Rendering ----------------------------------------------------
 
-@mcp.tool()
+@mcp_tool(mcp)
 def pptx_render_slide(
     file_path: str,
     slide_index: int = -1,
@@ -1931,7 +1968,7 @@ def _format_check_layout_summary(result: Dict[str, Any]) -> str:
     return f"Found {len(lines)} layout issues:\n" + "\n".join(lines)
 
 
-@mcp.tool()
+@mcp_tool(mcp)
 def pptx_check_layout(
     file_path: str,
     detailed: bool = False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,28 @@ import pytest
 from pptx import Presentation
 from pptx.util import Inches
 
+from pptx_mcp_server.engine.components.container import clear_container_registry
 from pptx_mcp_server.theme import MCKINSEY, Theme
 from pptx_mcp_server.engine.pptx_io import save_pptx
+
+
+@pytest.fixture(autouse=True)
+def _isolated_container_registry():
+    """Ensure every test starts and ends with a clean container registry.
+
+    The v0.6.0 container primitive (#130) uses a module-level registry to
+    associate child shapes with their parent container for post-hoc
+    containment validation. Without explicit cleanup, state from one test
+    can leak into the next — especially tests that set up entries but
+    never call ``check_containment`` (which otherwise consumes them).
+
+    Clearing is a no-op for tests that don't use containers, so this is
+    safe to apply globally. Previously lived as 5 duplicated autouse
+    fixtures across component test modules (Task G cleanup).
+    """
+    clear_container_registry()
+    yield
+    clear_container_registry()
 
 
 @pytest.fixture

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -18,7 +18,6 @@ import pytest
 from pptx_mcp_server.engine.components.container import (
     ContainerBounds,
     begin_container,
-    clear_container_registry,
 )
 from pptx_mcp_server.engine.shapes import (
     _add_shape,
@@ -31,12 +30,8 @@ from pptx_mcp_server.engine.validation import (
 )
 
 
-@pytest.fixture(autouse=True)
-def _isolated_registry():
-    """Ensure each test starts with a clean container registry."""
-    clear_container_registry()
-    yield
-    clear_container_registry()
+# Container registry isolation is provided globally by the autouse
+# ``_isolated_container_registry`` fixture in ``tests/conftest.py`` (Task G).
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -295,6 +295,91 @@ def test_no_container_active_is_noop(one_slide_prs):
     assert check_containment(one_slide_prs) == []
 
 
+def test_check_containment_consumes_registry_no_phantom_findings(
+    blank_prs,
+):
+    """Second build of the deck must not inherit stale container bounds.
+
+    Regression for the id(slide)-reuse + memory-leak hazard: check_containment
+    should clear its per-slide registry entries as it goes, so a later deck
+    built in the same process cannot receive phantom shape_outside_container
+    findings from a previous run.
+    """
+    from pptx_mcp_server.engine.components.container import (
+        _SLIDE_REGISTRY,
+        iter_slide_containers,
+    )
+
+    # --- First deck: overflow on purpose, validate, confirm cleanup. ---
+    layout = blank_prs.slide_layouts[6]
+    slide1 = blank_prs.slides.add_slide(layout)
+    with begin_container(
+        slide1, name="card",
+        left=1.0, top=1.0, width=3.0, height=2.0,
+    ):
+        _add_textbox(slide1, 1.2, 2.8, 2.6, 0.5, text="overflow!")
+
+    findings1 = check_containment(blank_prs)
+    assert len(findings1) == 1
+    # After validation, the registry must not retain entries for this slide.
+    assert list(iter_slide_containers(slide1)) == []
+    assert id(slide1) not in _SLIDE_REGISTRY
+
+    # --- Second pass (no new declarations): zero phantom findings. ---
+    findings2 = check_containment(blank_prs)
+    assert findings2 == []
+
+    # --- Second deck built in the same process: declare a CLEAN container.
+    # If registry cleanup regressed, a stale list for id(slide1) (or a reused
+    # id) could leak overflow children into this new pass.
+    slide2 = blank_prs.slides.add_slide(layout)
+    with begin_container(
+        slide2, name="card2",
+        left=1.0, top=1.0, width=3.0, height=2.0,
+    ):
+        _add_textbox(slide2, 1.2, 1.2, 2.0, 0.5, text="inside")
+
+    findings3 = check_containment(blank_prs)
+    assert findings3 == []
+
+
+def test_check_deck_extended_summary_errors_match_placed_containment(
+    one_slide_prs,
+):
+    """summary.errors must count only containment findings that were placed.
+
+    Regression for the double-count hazard where a finding with an
+    out-of-range slide_index was dropped by _place but still counted in
+    summary.errors — producing a summary that didn't match the per-slide
+    lists.
+    """
+    slide = one_slide_prs.slides[0]
+    with begin_container(
+        slide, name="metric_card",
+        left=1.0, top=1.0, width=3.0, height=2.0,
+    ):
+        _add_textbox(slide, 1.2, 2.8, 2.6, 0.5, text="overflow!")  # bottom overflow
+
+    result = check_deck_extended(one_slide_prs)
+
+    placed_containment_errors = sum(
+        1
+        for slide_data in result["slides"]
+        for f in slide_data["containment"]
+        if f.get("severity") == "error"
+    )
+    placed_overlaps = sum(len(s["overlaps"]) for s in result["slides"])
+    placed_oob = sum(len(s["out_of_bounds"]) for s in result["slides"])
+
+    # Per-slide containment list should have exactly 1 entry (normal path).
+    assert placed_containment_errors == 1
+    # summary.errors should equal the sum of all placed error-severity items
+    # — i.e. never larger than what the caller can see in the per-slide view.
+    assert result["summary"]["errors"] == (
+        placed_containment_errors + placed_overlaps + placed_oob
+    )
+
+
 def test_stack_cleaned_after_context_exit(one_slide_prs):
     """begin_container exit 後に innermost 判定が外れる (stack pop 確認)."""
     slide = one_slide_prs.slides[0]

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,0 +1,314 @@
+"""Container primitive と check_containment バリデータのテスト (Issue #130).
+
+- ``begin_container`` 内部で追加された shape が境界内なら findings 0
+- 0.3" 下はみ出しで shape_outside_container を 1 件検出
+- ネスト時、inner を出るが outer には収まる shape は inner 側でのみ検出
+- ``padding`` で内側を絞った場合に overflow が出る
+- ``tolerance`` で微小 float drift は無視される
+- ``check_deck_extended`` の ``slides[i].containment`` へ発火 + summary.errors に集計
+
+test の独立性を保つため、各テストの先頭で ``clear_container_registry`` を呼ぶ
+(モジュール level dict のため、同一プロセス内テスト間で干渉しうる)。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pptx_mcp_server.engine.components.container import (
+    ContainerBounds,
+    begin_container,
+    clear_container_registry,
+)
+from pptx_mcp_server.engine.shapes import (
+    _add_shape,
+    _add_textbox,
+    add_auto_fit_textbox,
+)
+from pptx_mcp_server.engine.validation import (
+    check_containment,
+    check_deck_extended,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry():
+    """Ensure each test starts with a clean container registry."""
+    clear_container_registry()
+    yield
+    clear_container_registry()
+
+
+# ---------------------------------------------------------------------------
+# 単一 container: 内側 / 外側
+# ---------------------------------------------------------------------------
+
+
+def test_container_child_fully_inside_has_no_finding(one_slide_prs):
+    slide = one_slide_prs.slides[0]
+    with begin_container(
+        slide,
+        name="metric_card_0",
+        left=1.0, top=1.0, width=3.0, height=2.0,
+    ):
+        _add_textbox(slide, 1.2, 1.2, 2.6, 0.4, text="Title")
+        _add_textbox(slide, 1.2, 1.8, 2.6, 0.8, text="Body copy within bounds")
+
+    findings = check_containment(one_slide_prs)
+    assert findings == []
+
+
+def test_container_child_overflow_bottom_flagged(one_slide_prs):
+    """Issue 原因となった pattern: metric_y が card bottom から 0.3" 下."""
+    slide = one_slide_prs.slides[0]
+    # Card: top=1.0, height=2.0 → bottom = 3.0"
+    # Child textbox: top=2.8, height=0.5 → bottom = 3.3" (0.3" 超過)
+    with begin_container(
+        slide,
+        name="metric_card_0",
+        left=1.0, top=1.0, width=3.0, height=2.0,
+    ):
+        _add_textbox(slide, 1.2, 2.8, 2.6, 0.5, text="42%")
+
+    findings = check_containment(one_slide_prs)
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.category == "shape_outside_container"
+    assert f.severity == "error"
+    assert f.slide_index == 0
+    # メッセージに overshoot 量と container name が含まれる
+    assert "metric_card_0" in f.message
+    assert "0.300" in f.message or "0.3" in f.message
+    assert "bottom" in f.message
+
+
+def test_container_child_overflow_right_flagged(one_slide_prs):
+    slide = one_slide_prs.slides[0]
+    # Card: left=1.0, width=3.0 → right = 4.0"
+    # Child: left=3.5, width=1.0 → right = 4.5" (0.5" 超過)
+    with begin_container(
+        slide,
+        name="card",
+        left=1.0, top=1.0, width=3.0, height=2.0,
+    ):
+        _add_shape(slide, "rectangle", 3.5, 1.2, 1.0, 0.5)
+
+    findings = check_containment(one_slide_prs)
+    assert len(findings) == 1
+    assert "right" in findings[0].message
+
+
+# ---------------------------------------------------------------------------
+# Nested containers
+# ---------------------------------------------------------------------------
+
+
+def test_nested_inner_overflow_flagged_on_inner_only(one_slide_prs):
+    """inner を出るが outer には収まる child: inner 側だけで 1 件."""
+    slide = one_slide_prs.slides[0]
+    # Outer: [0.5, 0.5, 10.0, 6.0]  → right=10.5, bottom=6.5
+    # Inner: [1.0, 1.0,  3.0, 2.0]  → right=4.0,  bottom=3.0
+    # Child: left=3.8, top=1.2, w=1.0, h=0.5 → right=4.8, bottom=1.7
+    #        inner right=4.0 を 0.8" 超過。outer right=10.5 の内側。
+    with begin_container(
+        slide, name="outer",
+        left=0.5, top=0.5, width=10.0, height=6.0,
+    ):
+        with begin_container(
+            slide, name="inner",
+            left=1.0, top=1.0, width=3.0, height=2.0,
+        ):
+            _add_textbox(slide, 3.8, 1.2, 1.0, 0.5, text="overflow")
+
+    findings = check_containment(one_slide_prs)
+    # inner のみ flag される (outer からは child 未登録)。
+    assert len(findings) == 1
+    assert "inner" in findings[0].message
+    assert "outer" not in findings[0].message
+
+
+def test_nested_child_inside_both_has_no_finding(one_slide_prs):
+    slide = one_slide_prs.slides[0]
+    with begin_container(
+        slide, name="outer",
+        left=0.5, top=0.5, width=10.0, height=6.0,
+    ):
+        with begin_container(
+            slide, name="inner",
+            left=1.0, top=1.0, width=3.0, height=2.0,
+        ):
+            _add_textbox(slide, 1.2, 1.2, 2.6, 0.5, text="inside both")
+
+    assert check_containment(one_slide_prs) == []
+
+
+# ---------------------------------------------------------------------------
+# Padding
+# ---------------------------------------------------------------------------
+
+
+def test_padding_shrinks_inner_bounds(one_slide_prs):
+    """padding=0.1 で inner 境界が内側に寄ると、境界線上の child が flag される."""
+    slide = one_slide_prs.slides[0]
+    # Container: [1.0, 1.0, 3.0, 2.0], padding=0.1
+    # padding 適用後 inner: [1.1, 1.1, 3.9, 2.9]
+    # Child: [1.0, 1.1, 0.5, 0.5] → left=1.0 は inner_left=1.1 から 0.1" はみ出す。
+    with begin_container(
+        slide, name="padded",
+        left=1.0, top=1.0, width=3.0, height=2.0,
+        padding=0.1,
+    ):
+        _add_shape(slide, "rectangle", 1.0, 1.1, 0.5, 0.5)
+
+    findings = check_containment(one_slide_prs)
+    assert len(findings) == 1
+    assert "left" in findings[0].message
+
+
+def test_padding_zero_allows_boundary_touch(one_slide_prs):
+    """padding=0 では境界線上の child は flag されない (0 exit だから)."""
+    slide = one_slide_prs.slides[0]
+    # Container: [1.0, 1.0, 3.0, 2.0]  → inner = outer
+    # Child flush to the top-left corner: [1.0, 1.0, 0.5, 0.5]
+    with begin_container(
+        slide, name="card",
+        left=1.0, top=1.0, width=3.0, height=2.0,
+    ):
+        _add_shape(slide, "rectangle", 1.0, 1.0, 0.5, 0.5)
+
+    assert check_containment(one_slide_prs) == []
+
+
+# ---------------------------------------------------------------------------
+# Tolerance
+# ---------------------------------------------------------------------------
+
+
+def test_tolerance_absorbs_small_float_drift(one_slide_prs):
+    """tolerance (既定 0.01") 未満のはみ出しは flag されない."""
+    slide = one_slide_prs.slides[0]
+    # Container right = 4.0
+    # Child right = 4.005 (0.005" 超過; tolerance=0.01 > 0.005)
+    with begin_container(
+        slide, name="card",
+        left=1.0, top=1.0, width=3.0, height=2.0,
+    ):
+        _add_shape(slide, "rectangle", 3.5, 1.2, 0.505, 0.5)
+
+    assert check_containment(one_slide_prs) == []
+
+
+def test_tolerance_custom_strict(one_slide_prs):
+    """tolerance=0 で同じ child が flag される."""
+    slide = one_slide_prs.slides[0]
+    with begin_container(
+        slide, name="card",
+        left=1.0, top=1.0, width=3.0, height=2.0,
+    ):
+        _add_shape(slide, "rectangle", 3.5, 1.2, 0.505, 0.5)
+
+    findings = check_containment(one_slide_prs, tolerance=0.0)
+    assert len(findings) == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration with check_deck_extended
+# ---------------------------------------------------------------------------
+
+
+def test_check_deck_extended_includes_containment_key(one_slide_prs):
+    slide = one_slide_prs.slides[0]
+    with begin_container(
+        slide, name="metric_card",
+        left=1.0, top=1.0, width=3.0, height=2.0,
+    ):
+        _add_textbox(slide, 1.2, 2.8, 2.6, 0.5, text="42%")  # bottom overflow
+
+    result = check_deck_extended(one_slide_prs)
+    assert "slides" in result
+    assert "containment" in result["slides"][0]
+    # 1 件検出
+    assert len(result["slides"][0]["containment"]) == 1
+    # summary.errors に加算されている
+    assert result["summary"]["errors"] >= 1
+    # finding の structure (ValidationFinding.to_dict 由来)
+    finding_dict = result["slides"][0]["containment"][0]
+    assert finding_dict["category"] == "shape_outside_container"
+    assert finding_dict["severity"] == "error"
+    assert finding_dict["slide_index"] == 0
+
+
+def test_check_deck_extended_clean_deck_has_empty_containment(one_slide_prs):
+    """何も declare しなくても ``containment`` key は存在し空リストとなる."""
+    result = check_deck_extended(one_slide_prs)
+    assert result["slides"][0]["containment"] == []
+
+
+def test_auto_fit_textbox_is_auto_tagged(one_slide_prs):
+    """add_auto_fit_textbox 経由の shape も containment チェックの対象."""
+    slide = one_slide_prs.slides[0]
+    with begin_container(
+        slide, name="card",
+        left=1.0, top=1.0, width=3.0, height=2.0,
+    ):
+        # top=2.9, height=0.3 → bottom=3.2 (card bottom=3.0 を 0.2" 超過)
+        add_auto_fit_textbox(
+            slide, "overflow!", 1.2, 2.9, 2.6, 0.3,
+            font_size_pt=10, min_size_pt=8,
+        )
+
+    findings = check_containment(one_slide_prs)
+    assert len(findings) == 1
+    assert "bottom" in findings[0].message
+
+
+# ---------------------------------------------------------------------------
+# API guarantees
+# ---------------------------------------------------------------------------
+
+
+def test_container_bounds_dataclass_fields():
+    b = ContainerBounds(name="x", left=0.0, top=0.0, width=1.0, height=1.0)
+    assert b.padding == 0.0
+    assert b.children == []
+    assert b.inner_bounds() == (0.0, 0.0, 1.0, 1.0)
+
+
+def test_begin_container_yields_bounds(one_slide_prs):
+    slide = one_slide_prs.slides[0]
+    with begin_container(
+        slide, name="card",
+        left=1.0, top=1.0, width=3.0, height=2.0, padding=0.05,
+    ) as bounds:
+        assert isinstance(bounds, ContainerBounds)
+        assert bounds.name == "card"
+        assert bounds.padding == 0.05
+        inner = bounds.inner_bounds()
+        assert inner == pytest.approx((1.05, 1.05, 3.95, 2.95))
+
+
+def test_no_container_active_is_noop(one_slide_prs):
+    """Shapes added outside any begin_container are not tagged."""
+    slide = one_slide_prs.slides[0]
+    _add_textbox(slide, 1.0, 1.0, 2.0, 0.5, text="naked")
+    # No container declared → check_containment sees nothing.
+    assert check_containment(one_slide_prs) == []
+
+
+def test_stack_cleaned_after_context_exit(one_slide_prs):
+    """begin_container exit 後に innermost 判定が外れる (stack pop 確認)."""
+    slide = one_slide_prs.slides[0]
+    with begin_container(
+        slide, name="c1",
+        left=1.0, top=1.0, width=3.0, height=2.0,
+    ):
+        _add_textbox(slide, 1.2, 1.2, 2.0, 0.5, text="in")
+    # context 終了後の add は tag されない
+    _add_textbox(slide, 0.0, 0.0, 0.1, 0.1, text="out")
+
+    # c1 には child が 1 つだけ登録され、"out" は含まれない
+    from pptx_mcp_server.engine.components.container import iter_slide_containers
+
+    containers = list(iter_slide_containers(slide))
+    assert len(containers) == 1
+    assert len(containers[0].children) == 1

--- a/tests/test_integration_v060.py
+++ b/tests/test_integration_v060.py
@@ -1,0 +1,550 @@
+"""End-to-end integration tests for v0.6.0 block components.
+
+Unlike the per-component unit tests (``test_section_header.py``,
+``test_kpi_row.py``, ``test_metric_card.py``, ``test_numbered_list.py``,
+``test_markers.py``), this module exercises **combinations** of all five
+block components on a single slide and validates with
+``check_containment``. The intent is to catch interactions that only
+surface when the components are composed together:
+
+- Do the components' ``consumed_height`` / ``bounds`` return values
+  compose cleanly (no overlap / no phantom gaps)?
+- Does every component respect its declared ``begin_container`` bounds
+  when sibling components are present on the same slide?
+- Does theme resolution stay consistent across all five when a single
+  theme name (``"ir"``) is threaded through?
+- Does the validator surface real bugs (not just happy-path green)?
+
+All tests build their own ``Presentation`` so they're self-contained and
+the module-level container registry stays clean between tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pptx import Presentation
+from pptx.util import Inches
+
+from pptx_mcp_server.engine.components.container import (
+    begin_container,
+    clear_container_registry,
+)
+from pptx_mcp_server.engine.components.section_header import (
+    SectionHeaderSpec,
+    add_section_header,
+)
+from pptx_mcp_server.engine.components.markers import (
+    PageMarkerSpec,
+    SlideFooterSpec,
+    add_page_marker,
+    add_slide_footer,
+)
+from pptx_mcp_server.engine.components.kpi_row import (
+    KPISpec,
+    add_kpi_row,
+)
+from pptx_mcp_server.engine.components.numbered_list import (
+    NumberedItem,
+    add_numbered_list,
+)
+from pptx_mcp_server.engine.components.metric_card import (
+    MetricCardSpec,
+    MetricEntry,
+    add_metric_card,
+    add_metric_card_row,
+)
+from pptx_mcp_server.engine.validation import check_containment
+from pptx_mcp_server.theme import resolve_theme_color
+
+
+# Slide dimensions used consistently across these integration tests.
+# McKinsey-style 16:9 (13.333 x 7.5). Matches the ``blank_prs`` conftest
+# fixture so results compare against the existing unit tests.
+_SLIDE_W = 13.333
+_SLIDE_H = 7.5
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry():
+    """Each test starts and ends with a clean container registry.
+
+    ``check_containment`` normally clears registry entries consumed-on-use,
+    but tests that set up state without calling it (or that assert on
+    findings mid-test) still need explicit isolation to avoid cross-test
+    bleed.
+    """
+    clear_container_registry()
+    yield
+    clear_container_registry()
+
+
+def _new_prs_with_blank_slide():
+    """Build a fresh 16:9 Presentation with one blank slide.
+
+    Each test creates its own so the module-level container registry is
+    keyed by a fresh ``id(slide)`` — avoiding id reuse across tests.
+    """
+    prs = Presentation()
+    prs.slide_width = Inches(_SLIDE_W)
+    prs.slide_height = Inches(_SLIDE_H)
+    layout = prs.slide_layouts[6]
+    prs.slides.add_slide(layout)
+    return prs
+
+
+def _first_run_hex(shape) -> str:
+    """Return the first run's font color as an uppercase 6-hex string."""
+    run = shape.text_frame.paragraphs[0].runs[0]
+    return str(run.font.color.rgb).upper()
+
+
+# ---------------------------------------------------------------------------
+# Test 1: All 5 block components on a single IR-themed slide
+# ---------------------------------------------------------------------------
+
+
+def test_ir_executive_summary_slide_all_components():
+    """Compose page_marker + section_header + kpi_row + metric_card_row +
+    slide_footer on one slide and verify containment is clean end-to-end.
+
+    This is the canonical "realistic IR exec-summary" layout and the most
+    important regression test for v0.6.0: if any two components interact
+    badly (e.g. one's declared bounds overlap another's shapes), this
+    test surfaces it via a containment finding.
+    """
+    prs = _new_prs_with_blank_slide()
+    slide = prs.slides[0]
+    before = len(list(slide.shapes))
+
+    # 1) Page marker (top-right, fixed offsets).
+    add_page_marker(
+        slide,
+        PageMarkerSpec(section="FINANCIAL SUMMARY", page="P.01 / FY Q3"),
+        slide_width=_SLIDE_W,
+        slide_height=_SLIDE_H,
+        theme="ir",
+    )
+
+    # 2) Section header near top-left, below page marker row.
+    header_left = 0.5
+    header_top = 0.9
+    header_width = _SLIDE_W - 1.0
+    header_result = add_section_header(
+        slide,
+        SectionHeaderSpec(
+            title="FY Q3 Executive Summary",
+            subtitle="Revenue, margin and growth highlights",
+        ),
+        left=header_left,
+        top=header_top,
+        width=header_width,
+        theme="ir",
+    )
+    header_bottom = header_top + header_result["consumed_height"]
+
+    # 3) KPI row directly below the section header (+ small breathing gap).
+    kpi_top = header_bottom + 0.2
+    kpi_height = 0.95
+    add_kpi_row(
+        slide,
+        [
+            KPISpec(label="Revenue", value="107.8M", detail="+12% QoQ"),
+            KPISpec(label="Op Margin", value="28.5%", detail="+2.1pp"),
+            KPISpec(label="Net Income", value="22.4M", detail="+8% YoY"),
+            KPISpec(label="FCF", value="18.9M", detail="+15% YoY"),
+        ],
+        left=header_left,
+        top=kpi_top,
+        width=header_width,
+        height=kpi_height,
+        gap=0.15,
+        theme="ir",
+    )
+    kpi_bottom = kpi_top + kpi_height
+
+    # 4) Metric card row below the KPI row.
+    card_top = kpi_bottom + 0.3
+    card_height = 3.2
+    add_metric_card_row(
+        slide,
+        [
+            MetricCardSpec(
+                label="REVENUE",
+                title="Revenue by Segment",
+                metrics=[
+                    MetricEntry(label="Consumer", value="62M"),
+                    MetricEntry(label="Enterprise", value="45M"),
+                ],
+            ),
+            MetricCardSpec(
+                label="MARGIN",
+                title="Margin Trajectory",
+                metrics=[
+                    MetricEntry(label="Gross", value="48%"),
+                    MetricEntry(label="Operating", value="28%"),
+                ],
+            ),
+        ],
+        left=header_left,
+        top=card_top,
+        width=header_width,
+        height=card_height,
+        gap=0.3,
+        theme="ir",
+    )
+
+    # 5) Slide footer at bottom (fixed offsets).
+    add_slide_footer(
+        slide,
+        SlideFooterSpec(
+            left_text="IR Presentation - FY Q3",
+            right_text="Confidential",
+        ),
+        slide_width=_SLIDE_W,
+        slide_height=_SLIDE_H,
+        theme="ir",
+    )
+
+    # -------------------------------------------------------------------
+    # Assertions
+    # -------------------------------------------------------------------
+
+    # All expected shapes exist:
+    #   page_marker:       2 (section + page textboxes)
+    #   section_header:    3 (title + subtitle textboxes + divider rect)
+    #   kpi_row (4 cells): 12 (each cell: label + value + detail = 3)
+    #   metric_card_row:   2 cards; each card = frame rect + label + title +
+    #                      chart placeholder + 2*(metric label + metric value)
+    #                      = 1 + 1 + 1 + 1 + 4 = 8 shapes per card → 16
+    #   slide_footer:      2 (left + right textboxes)
+    # Total: 2 + 3 + 12 + 16 + 2 = 35.
+    after = len(list(slide.shapes))
+    total_added = after - before
+    assert total_added == 35, (
+        f"expected 35 shapes total across all five components, got {total_added}"
+    )
+
+    # check_containment must be clean. This is the strongest whole-slide
+    # assertion: every child of every declared component container must lie
+    # inside its declared bounds.
+    findings = check_containment(prs)
+    assert findings == [], (
+        f"expected no containment findings on integration slide, "
+        f"got {findings}"
+    )
+
+    # Spot-check IR theme propagation: ONE shape per component must resolve
+    # to the expected IR-theme color. We cover the four theme-consuming
+    # components (markers provide both page + footer).
+    ir_primary = resolve_theme_color("primary", "ir").upper()  # 0A2540
+    ir_text_secondary = resolve_theme_color("text_secondary", "ir").upper()  # 6B7280
+
+    textboxes = [s for s in slide.shapes if s.has_text_frame]
+
+    # The section_header title is the first 32pt bold textbox; find by
+    # bold+text to avoid fragile index dependencies. Title color = primary.
+    header_title = next(
+        s for s in textboxes
+        if s.text_frame.text == "FY Q3 Executive Summary"
+    )
+    assert _first_run_hex(header_title) == ir_primary
+
+    # Section header subtitle uses text_secondary.
+    header_subtitle = next(
+        s for s in textboxes
+        if s.text_frame.text == "Revenue, margin and growth highlights"
+    )
+    assert _first_run_hex(header_subtitle) == ir_text_secondary
+
+    # KPI value "107.8M" must use IR primary.
+    kpi_value = next(
+        s for s in textboxes if s.text_frame.text == "107.8M"
+    )
+    assert _first_run_hex(kpi_value) == ir_primary
+
+    # Metric card title "Revenue by Segment" must use IR primary.
+    card_title = next(
+        s for s in textboxes if s.text_frame.text == "Revenue by Segment"
+    )
+    assert _first_run_hex(card_title) == ir_primary
+
+    # Page marker section line uses IR text_secondary.
+    page_marker = next(
+        s for s in textboxes if s.text_frame.text == "FINANCIAL SUMMARY"
+    )
+    assert _first_run_hex(page_marker) == ir_text_secondary
+
+    # Slide footer left uses IR text_secondary.
+    footer_left = next(
+        s for s in textboxes if s.text_frame.text == "IR Presentation - FY Q3"
+    )
+    assert _first_run_hex(footer_left) == ir_text_secondary
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Numbered list placed flush below a section header
+# ---------------------------------------------------------------------------
+
+
+def test_numbered_list_plus_section_header_positioning():
+    """Section header's ``consumed_height`` is the correct y-offset for
+    placing a numbered list directly below. Both components should share
+    their x extent without overlap, and ``check_containment`` should
+    produce zero findings.
+    """
+    prs = _new_prs_with_blank_slide()
+    slide = prs.slides[0]
+
+    left = 0.9
+    top = 0.5
+    width = _SLIDE_W - 1.8  # matches the existing test_section_header.py pattern
+
+    header_result = add_section_header(
+        slide,
+        SectionHeaderSpec(
+            title="Strategic Priorities",
+            subtitle="FY26 roadmap anchors",
+        ),
+        left=left,
+        top=top,
+        width=width,
+        theme="ir",
+    )
+    consumed = header_result["consumed_height"]
+
+    # Numbered list flush below the header's rendered footprint.
+    list_top = top + consumed
+    list_height = 4.5  # generous — 3 items at 1.5" each
+    list_result = add_numbered_list(
+        slide,
+        [
+            NumberedItem(
+                number="01",
+                caption="/ Focus",
+                title="Double down on enterprise",
+                body="Prioritise accounts > $1M ARR.",
+            ),
+            NumberedItem(
+                number="02",
+                caption="/ Efficiency",
+                title="Reduce unit cost",
+                body="Target 15% reduction in COGS.",
+            ),
+            NumberedItem(
+                number="03",
+                caption="/ Expansion",
+                title="Launch in EU-2 region",
+                body="Certification tracks mid-year.",
+            ),
+        ],
+        left=left,
+        top=list_top,
+        width=width,
+        height=list_height,
+        theme="ir",
+    )
+
+    # Invariant 1: list reports the declared bounds back unchanged.
+    assert list_result["consumed_height"] == pytest.approx(list_height)
+    assert list_result["consumed_width"] == pytest.approx(width)
+
+    # Invariant 2: header divider bottom edge matches list top (no gap, no
+    # overlap). This is the fundamental consumed_height contract.
+    divider = header_result["divider_bounds"]
+    divider_bottom = divider["top"] + divider["height"]
+    assert divider_bottom == pytest.approx(list_top, abs=1e-6)
+
+    # Invariant 3: first numbered item top == list_top (flush).
+    first_item_top = list_result["items"][0]["bounds"]["top"]
+    assert first_item_top == pytest.approx(list_top, abs=1e-6)
+
+    # Invariant 4: containment is clean.
+    findings = check_containment(prs)
+    assert findings == [], f"unexpected containment findings: {findings}"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Metric card row below KPI row, bounds-stacked
+# ---------------------------------------------------------------------------
+
+
+def test_metric_card_with_kpi_row_above_no_overlap():
+    """KPI row at top. Metric card row placed directly below using the
+    KPI row's bottom (top + height) as the card row's top. No overlap and
+    clean containment.
+    """
+    prs = _new_prs_with_blank_slide()
+    slide = prs.slides[0]
+
+    left = 0.5
+    top = 0.8
+    width = _SLIDE_W - 1.0
+
+    # KPI row.
+    kpi_height = 0.95
+    kpi_result = add_kpi_row(
+        slide,
+        [
+            KPISpec(label="ARR", value="$120M"),
+            KPISpec(label="NRR", value="118%"),
+            KPISpec(label="CAC payback", value="14mo"),
+        ],
+        left=left,
+        top=top,
+        width=width,
+        height=kpi_height,
+        gap=0.2,
+    )
+
+    # Use first cell's bounds to derive KPI row bottom (should equal
+    # top + kpi_height; verifying here ties the two sides of the contract).
+    first_cell_top = kpi_result["cells"][0]["bounds"]["top"]
+    first_cell_h = kpi_result["cells"][0]["bounds"]["height"]
+    kpi_bottom = first_cell_top + first_cell_h
+    assert kpi_bottom == pytest.approx(top + kpi_height, abs=1e-6)
+
+    # Metric card row flush below the KPI row (with a small visual gap).
+    card_top = kpi_bottom + 0.25
+    card_height = 3.5
+    card_result = add_metric_card_row(
+        slide,
+        [
+            MetricCardSpec(
+                label="GROWTH",
+                title="Pipeline health",
+                metrics=[
+                    MetricEntry(label="New", value="$42M"),
+                    MetricEntry(label="Expansion", value="$28M"),
+                ],
+            ),
+            MetricCardSpec(
+                label="RETENTION",
+                title="Churn profile",
+                metrics=[
+                    MetricEntry(label="Gross", value="4.2%"),
+                    MetricEntry(label="Net", value="-1.8%"),
+                ],
+            ),
+        ],
+        left=left,
+        top=card_top,
+        width=width,
+        height=card_height,
+        gap=0.3,
+    )
+
+    # Card row reports back the declared bounds.
+    assert card_result["consumed_height"] == pytest.approx(card_height)
+
+    # Invariant: no KPI-cell bottom exceeds the card row's top — they don't
+    # physically overlap.
+    for cell in kpi_result["cells"]:
+        cell_bottom = cell["bounds"]["top"] + cell["bounds"]["height"]
+        assert cell_bottom <= card_top + 1e-6
+
+    # Containment is clean for both components together.
+    findings = check_containment(prs)
+    assert findings == [], f"unexpected containment findings: {findings}"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Containment surfaces real overflows in a combined layout
+# ---------------------------------------------------------------------------
+
+
+def test_check_containment_catches_overflow_in_combined_slide():
+    """Deliberately under-size a ``kpi_row`` so its internal value/detail
+    textboxes escape the declared kpi_row container. Containment must
+    surface at least one finding — this validates that the integration
+    path surfaces bugs, not just happy paths.
+
+    Why kpi_row: the component unconditionally renders its value textbox
+    starting at ``top + _LABEL_H + _LABEL_VALUE_GAP = top + 0.24`` and
+    extending ``_VALUE_H = 0.50`` down (so value bottom = top + 0.74).
+    Declaring ``height=0.4`` makes the container bottom = top + 0.4, so
+    the value textbox escapes by ~0.34" — well beyond the 0.01"
+    containment tolerance.
+    """
+    prs = _new_prs_with_blank_slide()
+    slide = prs.slides[0]
+
+    # Add a legitimate header first so the slide has a normal component
+    # alongside the intentionally-broken one — mirrors a real-world
+    # "I shrank this component and broke it" regression.
+    add_section_header(
+        slide,
+        SectionHeaderSpec(title="Broken layout demo", subtitle="kpi row squeezed"),
+        left=0.5,
+        top=0.5,
+        width=_SLIDE_W - 1.0,
+    )
+
+    # Too-small KPI row: height 0.4 < required ~0.94" for detail bottom.
+    add_kpi_row(
+        slide,
+        [
+            KPISpec(label="Revenue", value="107.8M", detail="+12% QoQ"),
+            KPISpec(label="Margin", value="28.5%", detail="+2.1pp"),
+        ],
+        left=0.5,
+        top=2.0,
+        width=_SLIDE_W - 1.0,
+        height=0.4,  # deliberately too small
+        gap=0.2,
+    )
+
+    findings = check_containment(prs)
+    assert len(findings) >= 1, (
+        "expected at least one containment finding for the squeezed "
+        "kpi_row, got none"
+    )
+    # All findings should be from the kpi_row container (not the header).
+    kpi_findings = [
+        f for f in findings if "kpi_row" in f.message
+    ]
+    assert kpi_findings, (
+        f"expected at least one finding referencing 'kpi_row', got: "
+        f"{[f.message for f in findings]}"
+    )
+    # Each finding is an error severity + category shape_outside_container.
+    for f in kpi_findings:
+        assert f.severity == "error"
+        assert f.category == "shape_outside_container"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: engine/__init__.py re-exports every v0.6.0 block component
+# ---------------------------------------------------------------------------
+
+
+def test_all_block_components_importable_from_engine_root():
+    """The v0.6.0 block components must be importable from the engine root
+    package via the names declared in ``engine/__init__.py``'s ``__all__``.
+
+    Regression guard: if a future refactor drops a name from ``__all__``
+    (or accidentally renames it), this test fails before downstream code.
+    The set below intentionally covers the full v0.6.0 surface the task
+    spec calls out.
+    """
+    from pptx_mcp_server.engine import (
+        add_section_header,
+        add_page_marker,
+        add_slide_footer,
+        add_numbered_list,
+        add_kpi_row_block,
+        add_metric_card,
+        add_metric_card_row,
+    )
+
+    # Each must be a callable (function). None of them should be ``None``
+    # or a leftover attribute that happens to import cleanly.
+    for fn in (
+        add_section_header,
+        add_page_marker,
+        add_slide_footer,
+        add_numbered_list,
+        add_kpi_row_block,
+        add_metric_card,
+        add_metric_card_row,
+    ):
+        assert callable(fn), f"{fn!r} is not callable"

--- a/tests/test_integration_v060.py
+++ b/tests/test_integration_v060.py
@@ -27,7 +27,6 @@ from pptx.util import Inches
 
 from pptx_mcp_server.engine.components.container import (
     begin_container,
-    clear_container_registry,
 )
 from pptx_mcp_server.engine.components.section_header import (
     SectionHeaderSpec,
@@ -64,18 +63,11 @@ _SLIDE_W = 13.333
 _SLIDE_H = 7.5
 
 
-@pytest.fixture(autouse=True)
-def _isolated_registry():
-    """Each test starts and ends with a clean container registry.
-
-    ``check_containment`` normally clears registry entries consumed-on-use,
-    but tests that set up state without calling it (or that assert on
-    findings mid-test) still need explicit isolation to avoid cross-test
-    bleed.
-    """
-    clear_container_registry()
-    yield
-    clear_container_registry()
+# Container registry isolation is provided globally by the autouse
+# ``_isolated_container_registry`` fixture in ``tests/conftest.py`` (Task G).
+# ``check_containment`` normally clears registry entries consumed-on-use,
+# but tests that set up state without calling it (or that assert on
+# findings mid-test) still need explicit isolation to avoid cross-test bleed.
 
 
 def _new_prs_with_blank_slide():

--- a/tests/test_kpi_row.py
+++ b/tests/test_kpi_row.py
@@ -1,0 +1,292 @@
+"""Tests for the KPIRow block component (Issue #133, v0.6.0).
+
+Covers layout math, auto-fit shrink of long values, card-frame rendering,
+theme-token resolution, n==1 / n==6 edge cases, and containment. A
+backward-compat smoke test for the renamed legacy MCP tool is included so
+the rename from ``pptx_add_kpi_row`` → ``pptx_add_kpi_row_legacy`` cannot
+regress silently.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from pptx_mcp_server.engine.components.container import (
+    clear_container_registry,
+)
+from pptx_mcp_server.engine.components.kpi_row import KPISpec, add_kpi_row
+from pptx_mcp_server.engine.validation import check_containment
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry():
+    """Each test starts with a clean container registry (Issue #130 pattern)."""
+    clear_container_registry()
+    yield
+    clear_container_registry()
+
+
+def _hex(shape_fill):
+    """Return the shape's solid-fill color as a ``#``-less 6-hex string."""
+    return str(shape_fill.fore_color.rgb)
+
+
+# ---------------------------------------------------------------------------
+# 1) Even distribution over 12" width with 3 cells
+# ---------------------------------------------------------------------------
+
+
+def test_three_kpis_evenly_distributed_12in(slide):
+    kpis = [
+        KPISpec(label="Revenue", value="107.8M"),
+        KPISpec(label="Margin", value="28.5%"),
+        KPISpec(label="Growth", value="+12%"),
+    ]
+    result = add_kpi_row(
+        slide, kpis,
+        left=1.0, top=2.0, width=12.0, gap=0.15,
+    )
+
+    assert len(result["cells"]) == 3
+    # cell_w = (12.0 - 2*0.15) / 3 = 11.7/3 = 3.9
+    expected_w = (12.0 - 2 * 0.15) / 3
+    for c in result["cells"]:
+        assert c["bounds"]["width"] == pytest.approx(expected_w, abs=1e-9)
+
+    # Exact x positions: 1.0, 1.0 + 3.9 + 0.15, 1.0 + 2*(3.9+0.15).
+    step = expected_w + 0.15
+    expected_x = [1.0, 1.0 + step, 1.0 + 2 * step]
+    for exp, c in zip(expected_x, result["cells"]):
+        assert c["bounds"]["left"] == pytest.approx(exp, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# 2) Long CJK value auto-shrinks below starting 26pt
+# ---------------------------------------------------------------------------
+
+
+def test_long_cjk_value_auto_fits(slide):
+    kpis = [
+        KPISpec(label="Brand", value="プレミアムモルツ +156%"),
+    ]
+    result = add_kpi_row(
+        slide, kpis,
+        left=1.0, top=2.0, width=3.0,
+    )
+
+    assert len(result["cells"]) == 1
+    # wrap=False で width に収めるために shrink が走るはず。
+    assert result["cells"][0]["value_actual_font_size"] < 26.0
+
+
+# ---------------------------------------------------------------------------
+# 3) card_fill="highlight_row" with theme="ir" resolves through IR palette
+# ---------------------------------------------------------------------------
+
+
+def test_card_fill_highlight_row_ir_theme(slide):
+    kpis = [
+        KPISpec(label="A", value="1"),
+        KPISpec(label="B", value="2"),
+    ]
+    result = add_kpi_row(
+        slide, kpis,
+        left=1.0, top=2.0, width=6.0,
+        theme="ir",
+        card_fill="highlight_row",
+    )
+
+    # IR theme: highlight_row = "#F0F0F0" (see theme.py).
+    from pptx_mcp_server.theme import resolve_theme_color
+    expected = resolve_theme_color("highlight_row", "ir").upper()
+
+    for c in result["cells"]:
+        assert c["card_shape"] is not None
+        assert _hex(c["card_shape"].fill).upper() == expected
+
+
+# ---------------------------------------------------------------------------
+# 4) Detail line rendered below value when spec.detail is non-empty
+# ---------------------------------------------------------------------------
+
+
+def test_detail_rendered_below_value(slide):
+    kpis = [
+        KPISpec(label="Revenue", value="107.8M", detail="+12% QoQ"),
+    ]
+    result = add_kpi_row(
+        slide, kpis,
+        left=1.0, top=2.0, width=3.0, height=1.0,
+    )
+
+    c = result["cells"][0]
+    assert c["detail_shape"] is not None
+    # detail top should be strictly below value top.
+    from pptx.util import Emu
+    value_top_emu = c["value_shape"].top
+    detail_top_emu = c["detail_shape"].top
+    assert detail_top_emu > value_top_emu
+
+
+# ---------------------------------------------------------------------------
+# 5) n == 1: cell spans full width, no gap applied
+# ---------------------------------------------------------------------------
+
+
+def test_single_kpi_full_width_no_gap(slide):
+    kpis = [KPISpec(label="Total", value="42")]
+    result = add_kpi_row(
+        slide, kpis,
+        left=1.0, top=2.0, width=4.0, gap=0.15,
+    )
+
+    assert len(result["cells"]) == 1
+    b = result["cells"][0]["bounds"]
+    assert b["width"] == pytest.approx(4.0, abs=1e-9)
+    assert b["left"] == pytest.approx(1.0, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# 6) n == 6: many narrow cells
+# ---------------------------------------------------------------------------
+
+
+def test_six_kpis_each_narrow(slide):
+    kpis = [KPISpec(label=f"L{i}", value=str(i)) for i in range(6)]
+    result = add_kpi_row(
+        slide, kpis,
+        left=0.5, top=2.0, width=12.0, gap=0.15,
+    )
+
+    assert len(result["cells"]) == 6
+    # cell_w = (12.0 - 5*0.15) / 6 = 11.25/6 = 1.875
+    expected_w = (12.0 - 5 * 0.15) / 6
+    for c in result["cells"]:
+        assert c["bounds"]["width"] == pytest.approx(expected_w, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# 7) theme="ir" resolves all tokens on value + label + detail + border
+# ---------------------------------------------------------------------------
+
+
+def test_theme_ir_resolves_all_tokens(slide):
+    """Passing theme='ir' + mixed tokens should resolve to IR hex everywhere."""
+    kpis = [
+        KPISpec(label="Rev", value="100M", detail="+5% YoY", value_color="primary"),
+    ]
+    result = add_kpi_row(
+        slide, kpis,
+        left=1.0, top=2.0, width=4.0,
+        theme="ir",
+        card_fill="highlight_row",
+        card_border="rule_subtle",
+    )
+
+    from pptx_mcp_server.theme import resolve_theme_color
+
+    c = result["cells"][0]
+    # Card fill + border resolved.
+    assert _hex(c["card_shape"].fill).upper() == resolve_theme_color("highlight_row", "ir").upper()
+    # IR primary = #0A2540.
+    primary_hex = resolve_theme_color("primary", "ir").upper()
+    # Value textbox first run color.
+    value_run = c["value_shape"].text_frame.paragraphs[0].runs[0]
+    assert str(value_run.font.color.rgb).upper() == primary_hex
+
+    # text_secondary from IR = #6B7280 — label & detail should use it.
+    ts_hex = resolve_theme_color("text_secondary", "ir").upper()
+    label_run = c["label_shape"].text_frame.paragraphs[0].runs[0]
+    detail_run = c["detail_shape"].text_frame.paragraphs[0].runs[0]
+    assert str(label_run.font.color.rgb).upper() == ts_hex
+    assert str(detail_run.font.color.rgb).upper() == ts_hex
+
+
+# ---------------------------------------------------------------------------
+# 8) Containment: all child shapes stay inside the kpi_row container bbox
+# ---------------------------------------------------------------------------
+
+
+def test_check_containment_zero_findings(one_slide_prs):
+    slide = one_slide_prs.slides[0]
+    kpis = [
+        KPISpec(label="A", value="1"),
+        KPISpec(label="B", value="2", detail="note"),
+        KPISpec(label="C", value="3"),
+    ]
+    add_kpi_row(
+        slide, kpis,
+        left=1.0, top=2.0, width=10.0, height=0.95, gap=0.15,
+    )
+    findings = check_containment(one_slide_prs)
+    # All child shapes must fit inside the declared "kpi_row" container.
+    assert findings == [], f"Unexpected containment findings: {findings}"
+
+
+# ---------------------------------------------------------------------------
+# 9) MCP-tool backward compat: legacy rename still callable
+# ---------------------------------------------------------------------------
+
+
+def test_pptx_add_kpi_row_legacy_backward_compat(pptx_file):
+    """Verify the renamed legacy MCP tool still works for existing callers."""
+    from pptx_mcp_server.server import pptx_add_kpi_row_legacy
+
+    result_json = pptx_add_kpi_row_legacy(
+        pptx_file,
+        0,
+        [{"label": "Rev", "value": "100"}],
+        2.0,
+    )
+    payload = json.loads(result_json)
+    assert payload["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# 10) MCP-tool smoke: new pptx_add_kpi_row writes and validates
+# ---------------------------------------------------------------------------
+
+
+def test_pptx_add_kpi_row_mcp_tool(pptx_file):
+    """The new block-component MCP tool should write a file without error."""
+    from pptx_mcp_server.server import pptx_add_kpi_row
+
+    result_json = pptx_add_kpi_row(
+        file_path=pptx_file,
+        slide_index=0,
+        kpis=[
+            {"label": "Revenue", "value": "107.8M", "detail": "+12% QoQ"},
+            {"label": "Margin", "value": "28.5%"},
+        ],
+        left=1.0,
+        top=2.0,
+        width=8.0,
+    )
+    payload = json.loads(result_json)
+    assert payload["ok"] is True
+    assert len(payload["result"]["cells"]) == 2
+    assert payload["result"]["consumed_height"] == pytest.approx(0.95)
+
+
+# ---------------------------------------------------------------------------
+# 11) MCP-tool strict-key: unknown key on a kpi dict is rejected
+# ---------------------------------------------------------------------------
+
+
+def test_pptx_add_kpi_row_rejects_unknown_key(pptx_file):
+    from pptx_mcp_server.server import pptx_add_kpi_row
+
+    result_json = pptx_add_kpi_row(
+        file_path=pptx_file,
+        slide_index=0,
+        kpis=[{"label": "A", "value": "1", "typo_field": 1}],
+        left=1.0,
+        top=2.0,
+        width=4.0,
+    )
+    payload = json.loads(result_json)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "INVALID_PARAMETER"
+    assert "typo_field" in payload["error"]["message"]

--- a/tests/test_kpi_row.py
+++ b/tests/test_kpi_row.py
@@ -13,19 +13,11 @@ import json
 
 import pytest
 
-from pptx_mcp_server.engine.components.container import (
-    clear_container_registry,
-)
 from pptx_mcp_server.engine.components.kpi_row import KPISpec, add_kpi_row
 from pptx_mcp_server.engine.validation import check_containment
 
-
-@pytest.fixture(autouse=True)
-def _isolated_registry():
-    """Each test starts with a clean container registry (Issue #130 pattern)."""
-    clear_container_registry()
-    yield
-    clear_container_registry()
+# Container registry isolation is provided globally by the autouse
+# ``_isolated_container_registry`` fixture in ``tests/conftest.py`` (Task G).
 
 
 def _hex(shape_fill):

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -1,0 +1,163 @@
+"""PageMarker / SlideFooter block primitives のテスト (v0.6.0, #135).
+
+配置座標は ``markers.py`` 冒頭の固定オフセット定数で決まる。テストでは
+戻り値 ``bounds`` と実 shape の bbox が一致すること、右テキスト空文字
+時の skip 挙動、theme 指定時の色解決、MCP ツールからの往復 (tempfile
+での save → 再オープン) を検証する。
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+
+from pptx_mcp_server.engine.components.markers import (
+    PageMarkerSpec,
+    SlideFooterSpec,
+    add_page_marker,
+    add_slide_footer,
+)
+from pptx_mcp_server.theme import IR
+
+
+# EMU (914400 per inch) → inches
+def _in(emu: int) -> float:
+    return emu / 914400
+
+
+def test_page_marker_renders_two_textboxes_top_right(slide):
+    """``add_page_marker`` は 2 つの textbox を右上に作り、bounds を返す."""
+    slide_w = 13.333
+    slide_h = 7.5
+    # color="text_secondary" はテーマトークンなので theme 指定必須。
+    spec = PageMarkerSpec(section="FINANCIAL SUMMARY", page="P.05 ／ FY Q3")
+
+    before = len(list(slide.shapes))
+    result = add_page_marker(
+        slide, spec,
+        slide_width=slide_w, slide_height=slide_h,
+        theme="ir",
+    )
+    after = len(list(slide.shapes))
+
+    # 2 つの shape が新規に追加される。
+    assert after - before == 2
+    assert result["section_shape"] is not None
+    assert result["page_shape"] is not None
+
+    # bounds は右端が slide_width - 0.5" に達しており、スライド内に収まる。
+    b = result["bounds"]
+    assert b["left"] + b["width"] == pytest.approx(slide_w - 0.5, abs=1e-6)
+    assert b["left"] + b["width"] <= slide_w
+    assert b["top"] >= 0
+    assert b["top"] + b["height"] <= slide_h
+
+    # section shape の top は page shape の top より上にある (2 行積み)。
+    sec_top = _in(result["section_shape"].top)
+    page_top = _in(result["page_shape"].top)
+    assert sec_top < page_top
+    # 両 shape は同じ left / width を持つ (右端揃え)。
+    assert _in(result["section_shape"].left) == pytest.approx(
+        _in(result["page_shape"].left), abs=1e-6
+    )
+    assert _in(result["section_shape"].width) == pytest.approx(
+        _in(result["page_shape"].width), abs=1e-6
+    )
+
+
+def test_slide_footer_both_texts(slide):
+    """left_text と right_text がともに非空なら 2 shape 作る."""
+    slide_w = 13.333
+    slide_h = 7.5
+    spec = SlideFooterSpec(
+        left_text="IR Presentation · FY Q3",
+        right_text="Confidential",
+    )
+    before = len(list(slide.shapes))
+    result = add_slide_footer(
+        slide, spec,
+        slide_width=slide_w, slide_height=slide_h,
+        theme="ir",
+    )
+    after = len(list(slide.shapes))
+
+    assert after - before == 2
+    assert result["left_shape"] is not None
+    assert result["right_shape"] is not None
+
+    # top は slide_height - 0.4".
+    assert _in(result["left_shape"].top) == pytest.approx(slide_h - 0.4, abs=1e-6)
+    assert _in(result["right_shape"].top) == pytest.approx(slide_h - 0.4, abs=1e-6)
+
+    # 左は left=0.5", 右は right 端が slide_width - 0.5" に揃う。
+    assert _in(result["left_shape"].left) == pytest.approx(0.5, abs=1e-6)
+    r_left = _in(result["right_shape"].left)
+    r_width = _in(result["right_shape"].width)
+    assert r_left + r_width == pytest.approx(slide_w - 0.5, abs=1e-6)
+
+
+def test_slide_footer_right_text_empty_skipped(slide):
+    """right_text="" のとき右テキストボックスは作られない."""
+    slide_w = 13.333
+    slide_h = 7.5
+    spec = SlideFooterSpec(left_text="Only left", right_text="")
+    before = len(list(slide.shapes))
+    result = add_slide_footer(
+        slide, spec,
+        slide_width=slide_w, slide_height=slide_h,
+        theme="ir",
+    )
+    after = len(list(slide.shapes))
+
+    # 1 shape だけ追加される。
+    assert after - before == 1
+    assert result["left_shape"] is not None
+    assert result["right_shape"] is None
+
+
+def test_theme_ir_resolves_color(slide):
+    """theme="ir" + color="text_secondary" → IR の text_secondary hex が適用される."""
+    slide_w = 13.333
+    slide_h = 7.5
+    spec = PageMarkerSpec(section="SEC", page="P.01")
+    result = add_page_marker(
+        slide, spec,
+        slide_width=slide_w, slide_height=slide_h,
+        theme="ir",
+    )
+    expected = IR.colors["text_secondary"].lstrip("#")
+    run = result["section_shape"].text_frame.paragraphs[0].runs[0]
+    assert run.font.color.rgb == RGBColor.from_string(expected)
+
+
+def test_mcp_tool_page_marker_roundtrip(tmp_path):
+    """MCP ツール pptx_add_page_marker → save → 再オープンで shape が残る."""
+    # server import は module level で重いため、テスト内で遅延 import する。
+    from pptx_mcp_server.server import pptx_add_page_marker, pptx_create
+
+    path = str(tmp_path / "marker.pptx")
+    create_resp = json.loads(pptx_create(path))
+    assert create_resp["ok"] is True
+
+    # blank slide を追加しておく (pptx_create は slide を作らない)。
+    from pptx_mcp_server.server import pptx_add_slide
+    add_resp = json.loads(pptx_add_slide(path, layout_index=6))
+    assert add_resp["ok"] is True
+
+    resp = json.loads(pptx_add_page_marker(
+        path, slide_index=0,
+        section="FINANCIAL SUMMARY",
+        page="P.05 ／ FY Q3",
+        theme="ir",
+    ))
+    assert resp["ok"] is True, resp
+    assert "bounds" in resp["result"]
+
+    # 再オープンして shape が残っていることを確認。
+    prs = Presentation(path)
+    slide = prs.slides[0]
+    # 2 shape 追加されている。
+    assert len(list(slide.shapes)) >= 2

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -133,6 +133,51 @@ def test_theme_ir_resolves_color(slide):
     assert run.font.color.rgb == RGBColor.from_string(expected)
 
 
+def test_page_marker_no_theme_does_not_crash(slide):
+    """theme=None with default ``color="text_secondary"`` must fall back to a
+    hardcoded hex instead of raising ``EngineError: Invalid color: #text_secondary``.
+
+    Regression for CQ review I1 on #135: the MCP tool default is ``theme=None``,
+    so any caller invoking ``pptx_add_page_marker(path, 0, "S", "P")`` without
+    a theme previously got a cryptic error.
+    """
+    slide_w = 13.333
+    slide_h = 7.5
+    spec = PageMarkerSpec(section="S", page="P")  # default color="text_secondary"
+
+    before = len(list(slide.shapes))
+    result = add_page_marker(
+        slide, spec,
+        slide_width=slide_w, slide_height=slide_h,
+        # theme=None (default)
+    )
+    after = len(list(slide.shapes))
+
+    # 2 shape 追加され、例外は起きない。
+    assert after - before == 2
+    assert result["section_shape"] is not None
+    assert result["page_shape"] is not None
+
+
+def test_slide_footer_no_theme_does_not_crash(slide):
+    """theme=None with default ``color="text_secondary"`` must succeed for footer."""
+    slide_w = 13.333
+    slide_h = 7.5
+    spec = SlideFooterSpec(left_text="L", right_text="R")  # default color
+
+    before = len(list(slide.shapes))
+    result = add_slide_footer(
+        slide, spec,
+        slide_width=slide_w, slide_height=slide_h,
+        # theme=None (default)
+    )
+    after = len(list(slide.shapes))
+
+    assert after - before == 2
+    assert result["left_shape"] is not None
+    assert result["right_shape"] is not None
+
+
 def test_mcp_tool_page_marker_roundtrip(tmp_path):
     """MCP ツール pptx_add_page_marker → save → 再オープンで shape が残る."""
     # server import は module level で重いため、テスト内で遅延 import する。

--- a/tests/test_metric_card.py
+++ b/tests/test_metric_card.py
@@ -275,6 +275,19 @@ def test_theme_ir_resolves_palette(one_slide_prs):
 
 
 # ---------------------------------------------------------------------------
+# 9a. Missing chart_image_path raises before any shapes are added
+# ---------------------------------------------------------------------------
+
+
+def test_missing_chart_image_path_raises_before_shapes_added(slide):
+    spec = MetricCardSpec(title="X", chart_image_path="/nonexistent.png")
+    n_before = len(slide.shapes)
+    with pytest.raises(EngineError, match="does not exist"):
+        add_metric_card(slide, spec, left=1, top=1, width=5, height=5)
+    assert len(slide.shapes) == n_before  # no partial shapes leaked
+
+
+# ---------------------------------------------------------------------------
 # 9. check_containment returns no findings for properly-sized card
 # ---------------------------------------------------------------------------
 

--- a/tests/test_metric_card.py
+++ b/tests/test_metric_card.py
@@ -18,7 +18,6 @@ import pytest
 from PIL import Image
 from pptx.enum.shapes import MSO_SHAPE_TYPE
 
-from pptx_mcp_server.engine.components.container import clear_container_registry
 from pptx_mcp_server.engine.components.metric_card import (
     MetricCardSpec,
     MetricEntry,
@@ -28,13 +27,8 @@ from pptx_mcp_server.engine.components.metric_card import (
 from pptx_mcp_server.engine.pptx_io import EngineError, ErrorCode
 from pptx_mcp_server.engine.validation import check_containment
 
-
-@pytest.fixture(autouse=True)
-def _isolated_registry():
-    """Each test starts with a clean container registry."""
-    clear_container_registry()
-    yield
-    clear_container_registry()
+# Container registry isolation is provided globally by the autouse
+# ``_isolated_container_registry`` fixture in ``tests/conftest.py`` (Task G).
 
 
 def _in(emu: int) -> float:

--- a/tests/test_metric_card.py
+++ b/tests/test_metric_card.py
@@ -1,0 +1,302 @@
+"""MetricCard block component tests (Issue #132).
+
+Covers:
+- Single-card layout (label/title/chart/metrics all inside bounds).
+- Empty metrics list → chart area expands.
+- Metrics row splits horizontal space evenly.
+- ``chart_image_path`` provided → chart shape is a Picture.
+- Row variant with N cards (equal widths, correct gap).
+- Heterogeneous metrics counts in a row (each card independent).
+- Too-small height raises EngineError(INVALID_PARAMETER).
+- Theme resolution for ``theme="ir"`` produces IR-palette fills/borders.
+- ``check_containment`` finds no overflow for correctly-bounded cards.
+"""
+
+from __future__ import annotations
+
+import pytest
+from PIL import Image
+from pptx.enum.shapes import MSO_SHAPE_TYPE
+
+from pptx_mcp_server.engine.components.container import clear_container_registry
+from pptx_mcp_server.engine.components.metric_card import (
+    MetricCardSpec,
+    MetricEntry,
+    add_metric_card,
+    add_metric_card_row,
+)
+from pptx_mcp_server.engine.pptx_io import EngineError, ErrorCode
+from pptx_mcp_server.engine.validation import check_containment
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry():
+    """Each test starts with a clean container registry."""
+    clear_container_registry()
+    yield
+    clear_container_registry()
+
+
+def _in(emu: int) -> float:
+    """EMU → inches."""
+    return emu / 914400
+
+
+def _bbox(shape) -> tuple[float, float, float, float]:
+    return _in(shape.left), _in(shape.top), _in(shape.width), _in(shape.height)
+
+
+def _make_image(tmp_path, name="chart.png", size=(200, 100), color="blue") -> str:
+    path = tmp_path / name
+    Image.new("RGB", size, color=color).save(path)
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# 1. Single card: label/title/chart/metrics all inside bounds
+# ---------------------------------------------------------------------------
+
+
+def test_single_card_all_children_inside_bounds(one_slide_prs):
+    slide = one_slide_prs.slides[0]
+    spec = MetricCardSpec(
+        label="KPI",
+        title="Revenue 2024",
+        metrics=[
+            MetricEntry(label="Q1", value="$10M"),
+            MetricEntry(label="Q2", value="$12M"),
+            MetricEntry(label="Q3", value="$15M"),
+            MetricEntry(label="Q4", value="$18M"),
+        ],
+    )
+    result = add_metric_card(
+        slide, spec, left=1.0, top=1.0, width=5.0, height=4.5,
+    )
+
+    # Bounds reflect the arguments.
+    assert result["bounds"] == {
+        "left": 1.0, "top": 1.0, "width": 5.0, "height": 4.5,
+    }
+
+    # We expect 4 metric cells.
+    assert len(result["metric_shapes"]) == 4
+
+    # All child shapes (label, title, chart, 8 metric shapes) should lie
+    # inside the outer card bbox.
+    outer_l, outer_t, outer_r, outer_b = 1.0, 1.0, 6.0, 5.5
+    children = [
+        result["label_shape"],
+        result["title_shape"],
+        result["chart_shape"],
+    ]
+    for pair in result["metric_shapes"]:
+        children.extend(pair)
+
+    for child in children:
+        l, t, w, h = _bbox(child)
+        assert l >= outer_l - 0.01
+        assert t >= outer_t - 0.01
+        assert l + w <= outer_r + 0.01
+        assert t + h <= outer_b + 0.01
+
+
+# ---------------------------------------------------------------------------
+# 2. Zero metrics → chart area expands (no metrics shapes)
+# ---------------------------------------------------------------------------
+
+
+def test_zero_metrics_expands_chart(one_slide_prs):
+    slide = one_slide_prs.slides[0]
+
+    with_metrics_spec = MetricCardSpec(
+        label="A", title="B",
+        metrics=[MetricEntry(label="x", value="1")],
+    )
+    no_metrics_spec = MetricCardSpec(label="A", title="B", metrics=[])
+
+    r_with = add_metric_card(
+        slide, with_metrics_spec, left=0.5, top=0.5, width=4.0, height=4.5,
+    )
+    r_without = add_metric_card(
+        slide, no_metrics_spec, left=5.0, top=0.5, width=4.0, height=4.5,
+    )
+
+    assert r_without["metric_shapes"] == []
+
+    # Chart area for the no-metrics card should be taller than the
+    # with-metrics card by (metrics_row_h + chart_metrics_gap) ≈ 1.0".
+    _, _, _, chart_h_with = _bbox(r_with["chart_shape"])
+    _, _, _, chart_h_without = _bbox(r_without["chart_shape"])
+    assert chart_h_without > chart_h_with
+    assert chart_h_without - chart_h_with == pytest.approx(1.0, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# 3. Four metrics: cells evenly distributed horizontally
+# ---------------------------------------------------------------------------
+
+
+def test_four_metrics_even_split(one_slide_prs):
+    slide = one_slide_prs.slides[0]
+    spec = MetricCardSpec(
+        label="A", title="B",
+        metrics=[MetricEntry(label=f"L{i}", value=str(i)) for i in range(4)],
+        padding=0.3,
+    )
+    r = add_metric_card(slide, spec, left=1.0, top=1.0, width=5.0, height=4.5)
+
+    # Inner width = 5.0 - 2*0.3 = 4.4"  →  each cell = 1.1"
+    cell_w = 4.4 / 4
+    inner_left = 1.0 + 0.3
+    for i, (m_label, _m_value) in enumerate(r["metric_shapes"]):
+        expected_x = inner_left + i * cell_w
+        actual_l, _, actual_w, _ = _bbox(m_label)
+        assert actual_l == pytest.approx(expected_x, abs=0.02)
+        assert actual_w == pytest.approx(cell_w, abs=0.02)
+
+
+# ---------------------------------------------------------------------------
+# 4. chart_image_path provided → chart_shape is a Picture
+# ---------------------------------------------------------------------------
+
+
+def test_chart_image_path_uses_picture(one_slide_prs, tmp_path):
+    slide = one_slide_prs.slides[0]
+    img_path = _make_image(tmp_path)
+    spec = MetricCardSpec(label="A", title="B", chart_image_path=img_path)
+
+    r = add_metric_card(slide, spec, left=1.0, top=1.0, width=5.0, height=4.5)
+    assert r["chart_shape"].shape_type == MSO_SHAPE_TYPE.PICTURE
+
+    # Without image, the chart shape is a plain AUTO_SHAPE rectangle.
+    spec_noimg = MetricCardSpec(label="A", title="B")
+    r2 = add_metric_card(
+        slide, spec_noimg, left=7.0, top=1.0, width=5.0, height=4.5,
+    )
+    assert r2["chart_shape"].shape_type == MSO_SHAPE_TYPE.AUTO_SHAPE
+
+
+# ---------------------------------------------------------------------------
+# 5. Row of 3 cards: equal widths + correct gaps
+# ---------------------------------------------------------------------------
+
+
+def test_row_of_three_cards(one_slide_prs):
+    slide = one_slide_prs.slides[0]
+    specs = [
+        MetricCardSpec(label=f"K{i}", title=f"T{i}",
+                       metrics=[MetricEntry(label="x", value="1")])
+        for i in range(3)
+    ]
+    result = add_metric_card_row(
+        slide, specs, left=0.5, top=0.5, width=12.0, height=4.5, gap=0.3,
+    )
+
+    assert len(result["cards"]) == 3
+    assert result["consumed_height"] == 4.5
+    assert result["consumed_width"] == 12.0
+
+    # card_w = (12.0 - 2 * 0.3) / 3 = 3.8"
+    expected_w = (12.0 - 2 * 0.3) / 3
+    xs = [c["left"] for c in result["cards"]]
+    widths = [c["width"] for c in result["cards"]]
+    assert widths == [pytest.approx(expected_w, abs=1e-6)] * 3
+    # Gap invariant: xs[i+1] - (xs[i] + width) == gap
+    for i in range(2):
+        assert xs[i + 1] - (xs[i] + widths[i]) == pytest.approx(0.3, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# 6. Row of 3 cards with heterogeneous metrics counts [0, 2, 4]
+# ---------------------------------------------------------------------------
+
+
+def test_row_heterogeneous_metrics_counts(one_slide_prs):
+    slide = one_slide_prs.slides[0]
+    specs = [
+        MetricCardSpec(label="A", title="T0", metrics=[]),
+        MetricCardSpec(
+            label="B", title="T1",
+            metrics=[MetricEntry(label="x", value="1"),
+                     MetricEntry(label="y", value="2")],
+        ),
+        MetricCardSpec(
+            label="C", title="T2",
+            metrics=[MetricEntry(label=f"L{i}", value=str(i))
+                     for i in range(4)],
+        ),
+    ]
+    result = add_metric_card_row(
+        slide, specs, left=0.5, top=0.5, width=12.0, height=4.5, gap=0.3,
+    )
+    assert len(result["cards"]) == 3
+    # Each card's bounds dict has the same height regardless of metric count.
+    assert all(c["height"] == 4.5 for c in result["cards"])
+
+
+# ---------------------------------------------------------------------------
+# 7. Too-small height raises EngineError(INVALID_PARAMETER)
+# ---------------------------------------------------------------------------
+
+
+def test_too_small_height_raises(one_slide_prs):
+    slide = one_slide_prs.slides[0]
+    spec = MetricCardSpec(label="A", title="B")
+
+    with pytest.raises(EngineError) as exc_info:
+        add_metric_card(
+            slide, spec, left=1.0, top=1.0, width=5.0, height=0.5,
+        )
+
+    err = exc_info.value
+    assert err.code == ErrorCode.INVALID_PARAMETER
+    assert "MetricCard height too small" in err.args[0]
+
+
+# ---------------------------------------------------------------------------
+# 8. theme="ir" resolves defaults to IR-palette hex values
+# ---------------------------------------------------------------------------
+
+
+def test_theme_ir_resolves_palette(one_slide_prs):
+    slide = one_slide_prs.slides[0]
+    spec = MetricCardSpec(
+        label="KPI",
+        title="Revenue",
+        fill_color="background",   # IR token → #F8F9F5
+        border_color="rule_subtle",  # IR token → #E0E0E0
+    )
+    r = add_metric_card(
+        slide, spec, left=1.0, top=1.0, width=5.0, height=4.5, theme="ir",
+    )
+    frame = r["frame_shape"]
+    assert str(frame.fill.fore_color.rgb) == "F8F9F5"
+    assert str(frame.line.color.rgb) == "E0E0E0"
+
+
+# ---------------------------------------------------------------------------
+# 9. check_containment returns no findings for properly-sized card
+# ---------------------------------------------------------------------------
+
+
+def test_check_containment_clean(one_slide_prs):
+    slide = one_slide_prs.slides[0]
+    specs = [
+        MetricCardSpec(
+            label=f"K{i}", title=f"Metric {i}",
+            metrics=[
+                MetricEntry(label="Now", value="10"),
+                MetricEntry(label="Target", value="20"),
+            ],
+        )
+        for i in range(3)
+    ]
+    add_metric_card_row(
+        slide, specs, left=0.5, top=1.0, width=12.0, height=5.0, gap=0.3,
+    )
+
+    findings = check_containment(one_slide_prs)
+    assert findings == [], (
+        "MetricCard children should all be inside their container bounds; "
+        f"got: {findings}"
+    )

--- a/tests/test_numbered_list.py
+++ b/tests/test_numbered_list.py
@@ -20,8 +20,10 @@ from pptx_mcp_server.engine.components.numbered_list import (
     _NUMBER_ROW_H,
     _RULE_ROW_H,
 )
-from pptx_mcp_server.engine.components.container import clear_container_registry
 from pptx_mcp_server.engine.validation import check_containment
+
+# Container registry isolation is provided globally by the autouse
+# ``_isolated_container_registry`` fixture in ``tests/conftest.py`` (Task G).
 
 
 EMU_PER_INCH = 914400
@@ -29,14 +31,6 @@ EMU_PER_INCH = 914400
 
 def _in(emu: int) -> float:
     return emu / EMU_PER_INCH
-
-
-@pytest.fixture(autouse=True)
-def _isolated_registry():
-    """Each test starts with a clean container registry."""
-    clear_container_registry()
-    yield
-    clear_container_registry()
 
 
 def _four_items() -> list[NumberedItem]:

--- a/tests/test_numbered_list.py
+++ b/tests/test_numbered_list.py
@@ -1,0 +1,281 @@
+"""Tests for the ``add_numbered_list`` block component (Issue #134).
+
+Covers:
+- 4-item even height distribution inside the declared bounds
+- Empty ``body`` → ``body_shape`` is None (body textbox skipped)
+- ``rule_between=False`` → no rule shapes for any item
+- Long body auto-fits via truncate-with-ellipsis (no exception)
+- Theme='ir' → colors resolve to IR theme hex values
+- Single item → no rule drawn
+- ``check_containment`` emits zero findings (all children inside bounds)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pptx_mcp_server.engine.components.numbered_list import (
+    NumberedItem,
+    add_numbered_list,
+    _NUMBER_ROW_H,
+    _RULE_ROW_H,
+)
+from pptx_mcp_server.engine.components.container import clear_container_registry
+from pptx_mcp_server.engine.validation import check_containment
+
+
+EMU_PER_INCH = 914400
+
+
+def _in(emu: int) -> float:
+    return emu / EMU_PER_INCH
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry():
+    """Each test starts with a clean container registry."""
+    clear_container_registry()
+    yield
+    clear_container_registry()
+
+
+def _four_items() -> list[NumberedItem]:
+    return [
+        NumberedItem(
+            number=f"0{i + 1}",
+            caption=f"／ caption {i + 1}",
+            title=f"Title {i + 1}",
+            body=f"Body copy number {i + 1}.",
+        )
+        for i in range(4)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Layout
+# ---------------------------------------------------------------------------
+
+
+def test_four_items_evenly_distributed_8in(slide):
+    """4 items, height=8" → item tops advance by the item slot height.
+
+    With ``rule_between=True`` the 3 rule rows (0.04" each) eat into
+    ``height`` so ``item_height = (8 - 3*0.04) / 4 = 1.97"``. Each item
+    advances by ``item_height + 0.04`` except the last.
+    """
+    result = add_numbered_list(
+        slide, _four_items(),
+        left=0.5, top=0.5, width=6.0, height=8.0,
+        rule_between=True,
+    )
+
+    assert len(result["items"]) == 4
+    expected_item_h = (8.0 - 3 * _RULE_ROW_H) / 4
+    # Each item's bounds.top should advance by (item_h + rule_row_h) per step
+    # (except the advance past the last item, which doesn't exist here).
+    stride = expected_item_h + _RULE_ROW_H
+    for i, entry in enumerate(result["items"]):
+        expected_top = 0.5 + i * stride
+        assert entry["bounds"]["top"] == pytest.approx(expected_top, abs=1e-4)
+        assert entry["bounds"]["height"] == pytest.approx(expected_item_h, abs=1e-4)
+        assert entry["bounds"]["left"] == pytest.approx(0.5, abs=1e-6)
+        assert entry["bounds"]["width"] == pytest.approx(6.0, abs=1e-6)
+
+    assert result["consumed_height"] == pytest.approx(8.0, abs=1e-6)
+    assert result["consumed_width"] == pytest.approx(6.0, abs=1e-6)
+
+
+def test_empty_body_body_shape_is_none(slide):
+    """Item with empty body → ``body_shape`` is None (textbox omitted)."""
+    items = [
+        NumberedItem("01", "／ a", "Title A", "Body A"),
+        NumberedItem("02", "／ b", "Title B", ""),   # empty body
+        NumberedItem("03", "／ c", "Title C", "Body C"),
+    ]
+    result = add_numbered_list(
+        slide, items,
+        left=0.5, top=0.5, width=6.0, height=6.0,
+    )
+
+    assert result["items"][0]["body_shape"] is not None
+    assert result["items"][1]["body_shape"] is None
+    assert result["items"][2]["body_shape"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Rule behavior
+# ---------------------------------------------------------------------------
+
+
+def test_rule_between_false_no_rules(slide):
+    """``rule_between=False`` → every item has ``rule_shape is None``."""
+    result = add_numbered_list(
+        slide, _four_items(),
+        left=0.5, top=0.5, width=6.0, height=8.0,
+        rule_between=False,
+    )
+
+    for entry in result["items"]:
+        assert entry["rule_shape"] is None
+
+
+def test_single_item_no_rule(slide):
+    """n == 1 → no rule drawn regardless of ``rule_between``."""
+    items = [NumberedItem("01", "／ solo", "Solo title", "Body of the only item.")]
+    result = add_numbered_list(
+        slide, items,
+        left=1.0, top=1.0, width=5.0, height=3.0,
+        rule_between=True,
+    )
+
+    assert len(result["items"]) == 1
+    assert result["items"][0]["rule_shape"] is None
+
+
+def test_rule_between_true_last_has_no_rule(slide):
+    """Regression: the last item never gets a trailing rule."""
+    result = add_numbered_list(
+        slide, _four_items(),
+        left=0.5, top=0.5, width=6.0, height=8.0,
+        rule_between=True,
+    )
+
+    # First 3 items have rules, last does not.
+    for i, entry in enumerate(result["items"]):
+        if i < 3:
+            assert entry["rule_shape"] is not None, f"item {i} missing rule"
+        else:
+            assert entry["rule_shape"] is None
+
+
+# ---------------------------------------------------------------------------
+# Auto-fit
+# ---------------------------------------------------------------------------
+
+
+def test_long_body_auto_fits_with_wrap(slide):
+    """A very long body renders without error and gets a live body_shape."""
+    long_body = "This is a very long body text that should wrap across multiple lines. " * 10
+    items = [
+        NumberedItem("01", "／ long", "Long body item", long_body),
+    ]
+    result = add_numbered_list(
+        slide, items,
+        left=0.5, top=0.5, width=5.0, height=3.0,
+    )
+
+    body_shape = result["items"][0]["body_shape"]
+    assert body_shape is not None
+    # Body shape width should match the declared width in EMU.
+    assert _in(body_shape.width) == pytest.approx(5.0, abs=1e-3)
+    # word_wrap must be True for wrapped body rendering.
+    assert body_shape.text_frame.word_wrap is True
+
+
+# ---------------------------------------------------------------------------
+# Theme resolution
+# ---------------------------------------------------------------------------
+
+
+def test_theme_ir_resolves_colors(slide):
+    """theme='ir' resolves number/caption to text_secondary, title to primary."""
+    # IR theme (see theme.py): primary=#0A2540, text_secondary=#6B7280,
+    # rule_subtle=#E0E0E0.
+    result = add_numbered_list(
+        slide,
+        [NumberedItem("01", "／ c", "Title 1", "Body 1"),
+         NumberedItem("02", "／ c", "Title 2", "Body 2")],
+        left=0.5, top=0.5, width=6.0, height=4.0,
+        theme="ir",
+    )
+
+    number_shape = result["items"][0]["number_shape"]
+    caption_shape = result["items"][0]["caption_shape"]
+    title_shape = result["items"][0]["title_shape"]
+    rule_shape = result["items"][0]["rule_shape"]  # between item 0 and 1
+
+    # Number uses text_secondary (6B7280)
+    number_run = number_shape.text_frame.paragraphs[0].runs[0]
+    assert str(number_run.font.color.rgb) == "6B7280"
+
+    # Caption uses text_secondary (6B7280)
+    caption_run = caption_shape.text_frame.paragraphs[0].runs[0]
+    assert str(caption_run.font.color.rgb) == "6B7280"
+
+    # Title uses primary (0A2540)
+    title_run = title_shape.text_frame.paragraphs[0].runs[0]
+    assert str(title_run.font.color.rgb) == "0A2540"
+
+    # Rule uses rule_subtle (E0E0E0)
+    assert rule_shape is not None
+    assert str(rule_shape.fill.fore_color.rgb) == "E0E0E0"
+
+
+# ---------------------------------------------------------------------------
+# Containment
+# ---------------------------------------------------------------------------
+
+
+def test_check_containment_zero_findings(one_slide_prs):
+    """All rendered children must lie inside the declared bounds."""
+    slide = one_slide_prs.slides[0]
+    add_numbered_list(
+        slide, _four_items(),
+        left=0.5, top=0.5, width=6.0, height=8.0,
+        rule_between=True,
+    )
+
+    findings = check_containment(one_slide_prs)
+    assert findings == []
+
+
+def test_check_containment_zero_findings_no_rules(one_slide_prs):
+    """Same but with rule_between=False — still zero findings."""
+    slide = one_slide_prs.slides[0]
+    add_numbered_list(
+        slide, _four_items(),
+        left=0.5, top=0.5, width=6.0, height=8.0,
+        rule_between=False,
+    )
+
+    findings = check_containment(one_slide_prs)
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# MCP tool boundary
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_tool_strict_key_validation(pptx_file):
+    """Unknown keys on the items dict are rejected with INVALID_PARAMETER."""
+    from pptx_mcp_server.server import pptx_add_numbered_list
+
+    out = pptx_add_numbered_list(
+        file_path=pptx_file,
+        slide_index=0,
+        items=[{"number": "01", "caption": "c", "title": "t", "body": "b", "bogus": "x"}],
+        left=0.5, top=0.5, width=6.0, height=3.0,
+    )
+    assert "INVALID_PARAMETER" in out or "unknown" in out
+
+
+def test_mcp_tool_success_path(pptx_file):
+    """Happy path through the MCP tool returns a success envelope."""
+    import json
+
+    from pptx_mcp_server.server import pptx_add_numbered_list
+
+    out = pptx_add_numbered_list(
+        file_path=pptx_file,
+        slide_index=0,
+        items=[
+            {"number": "01", "caption": "／ a", "title": "T1", "body": "B1"},
+            {"number": "02", "caption": "／ b", "title": "T2", "body": "B2"},
+        ],
+        left=0.5, top=0.5, width=6.0, height=4.0,
+    )
+    parsed = json.loads(out)
+    assert parsed.get("ok") is True
+    assert len(parsed["result"]["items"]) == 2
+    assert parsed["result"]["consumed_height"] == pytest.approx(4.0, abs=1e-6)

--- a/tests/test_section_header.py
+++ b/tests/test_section_header.py
@@ -1,0 +1,154 @@
+"""Tests for the SectionHeader block component (Issue #136).
+
+Covers:
+
+- Shape layout (two textboxes + one divider rectangle).
+- Auto-fit contract: short text keeps base size; long text shrinks.
+- ``wrap=False`` is propagated to the resulting textbox.
+- Subtitle omission reduces ``consumed_height`` and yields
+  ``subtitle_bounds=None``.
+- Theme tokens (``primary``, ``text_secondary``) resolve against the IR
+  theme's palette.
+- ``check_containment`` returns zero findings for a normal header
+  (regression safety for ``begin_container`` wrapping).
+"""
+
+from __future__ import annotations
+
+from pptx.enum.shapes import MSO_SHAPE_TYPE
+
+from pptx_mcp_server.engine.components.section_header import (
+    SectionHeaderSpec,
+    add_section_header,
+    _TITLE_H,
+    _SUBTITLE_H,
+    _INTRA_GAP_TITLE,
+    _INTRA_GAP_SUBTITLE,
+)
+from pptx_mcp_server.engine.validation import check_containment
+
+
+def test_title_subtitle_divider_creates_three_shapes(slide):
+    """With subtitle → 2 textboxes + 1 filled rectangle divider."""
+    spec = SectionHeaderSpec(
+        title="Market Outlook",
+        subtitle="Q4 2026 — Key Takeaways",
+    )
+    result = add_section_header(
+        slide, spec, left=0.9, top=0.45, width=11.533,
+    )
+
+    textboxes = [
+        s for s in slide.shapes if s.shape_type == MSO_SHAPE_TYPE.TEXT_BOX
+    ]
+    auto_shapes = [
+        s for s in slide.shapes if s.shape_type == MSO_SHAPE_TYPE.AUTO_SHAPE
+    ]
+    assert len(textboxes) == 2, "expected title + subtitle textboxes"
+    assert len(auto_shapes) == 1, "expected exactly one divider rectangle"
+
+    # Sanity: result dict exposes all three regions.
+    assert result["title_bounds"] is not None
+    assert result["subtitle_bounds"] is not None
+    assert result["divider_bounds"] is not None
+
+
+def test_short_title_keeps_base_font_size(slide):
+    """Short title easily fits 11.533" width at 32pt → no shrink."""
+    spec = SectionHeaderSpec(title="Summary")
+    result = add_section_header(
+        slide, spec, left=0.9, top=0.45, width=11.533,
+    )
+    # Default title_size_pt is 32; short text must not shrink.
+    assert result["title_actual_font_size"] == 32.0
+
+
+def test_long_title_auto_fits_single_line(slide):
+    """Very long title shrinks below 32pt AND stays single-line (word_wrap=False)."""
+    long_title = (
+        "Comprehensive strategic review of market dynamics, competitive "
+        "positioning, and long-term growth opportunities across all segments"
+    )
+    spec = SectionHeaderSpec(title=long_title)
+    result = add_section_header(
+        slide, spec, left=0.9, top=0.45, width=11.533,
+    )
+    assert result["title_actual_font_size"] < 32.0
+
+    # Find the title textbox (first TEXT_BOX added).
+    textboxes = [
+        s for s in slide.shapes if s.shape_type == MSO_SHAPE_TYPE.TEXT_BOX
+    ]
+    assert textboxes, "title textbox should exist"
+    title_shape = textboxes[0]
+    # wrap=False must propagate to the textbox's word_wrap property.
+    assert title_shape.text_frame.word_wrap is False
+
+
+def test_no_subtitle_divider_closer_to_title(slide):
+    """subtitle="" → only 1 textbox; consumed_height drops by subtitle strip."""
+    spec_no_sub = SectionHeaderSpec(title="Title only", subtitle="")
+    result = add_section_header(
+        slide, spec_no_sub, left=0.9, top=0.45, width=11.533,
+    )
+
+    textboxes = [
+        s for s in slide.shapes if s.shape_type == MSO_SHAPE_TYPE.TEXT_BOX
+    ]
+    assert len(textboxes) == 1, "no subtitle → only title textbox"
+    assert result["subtitle_bounds"] is None
+
+    # Without subtitle, consumed_height excludes _SUBTITLE_H exactly.
+    # Layout: title + gap + subtitle + gap + divider (full)
+    #   vs   title + gap           + divider (no-subtitle)
+    # Delta = _SUBTITLE_H (+_INTRA_GAP_TITLE already applied either way).
+    # Compute the "with subtitle" height from a matching spec to avoid
+    # hard-coding internal constants in the delta check.
+    full_spec = SectionHeaderSpec(title="Title only", subtitle="sub")
+    full_height = (
+        _TITLE_H + _INTRA_GAP_TITLE + _SUBTITLE_H
+        + _INTRA_GAP_SUBTITLE + full_spec.divider_thickness
+    )
+    assert result["consumed_height"] < full_height
+    assert abs(
+        (full_height - result["consumed_height"]) - _SUBTITLE_H
+    ) < 1e-6
+
+
+def test_theme_ir_resolves_colors(slide):
+    """theme='ir' → title uses IR primary (#0A2540), subtitle uses text_secondary (#6B7280)."""
+    spec = SectionHeaderSpec(
+        title="IR Headline",
+        subtitle="Investor relations subtitle",
+    )
+    add_section_header(
+        slide, spec, left=0.9, top=0.45, width=11.533, theme="ir",
+    )
+
+    textboxes = [
+        s for s in slide.shapes if s.shape_type == MSO_SHAPE_TYPE.TEXT_BOX
+    ]
+    assert len(textboxes) == 2
+    title_shape, subtitle_shape = textboxes[0], textboxes[1]
+
+    title_rgb = title_shape.text_frame.paragraphs[0].runs[0].font.color.rgb
+    subtitle_rgb = subtitle_shape.text_frame.paragraphs[0].runs[0].font.color.rgb
+
+    # IR theme: primary = 0A2540, text_secondary = 6B7280.
+    assert str(title_rgb) == "0A2540"
+    assert str(subtitle_rgb) == "6B7280"
+
+
+def test_check_containment_zero_findings(one_slide_prs):
+    """Rendering SectionHeader into begin_container must not trigger
+    `shape_outside_container` findings — nothing should escape bounds."""
+    slide = one_slide_prs.slides[0]
+    spec = SectionHeaderSpec(
+        title="Bounded header",
+        subtitle="Subtitle also bounded",
+    )
+    add_section_header(
+        slide, spec, left=0.9, top=0.45, width=11.533,
+    )
+    findings = check_containment(one_slide_prs)
+    assert findings == [], f"expected no containment findings, got {findings}"

--- a/tests/test_section_header.py
+++ b/tests/test_section_header.py
@@ -30,12 +30,13 @@ from pptx_mcp_server.engine.validation import check_containment
 
 def test_title_subtitle_divider_creates_three_shapes(slide):
     """With subtitle → 2 textboxes + 1 filled rectangle divider."""
+    top = 0.45
     spec = SectionHeaderSpec(
         title="Market Outlook",
         subtitle="Q4 2026 — Key Takeaways",
     )
     result = add_section_header(
-        slide, spec, left=0.9, top=0.45, width=11.533,
+        slide, spec, left=0.9, top=top, width=11.533,
     )
 
     textboxes = [
@@ -51,6 +52,18 @@ def test_title_subtitle_divider_creates_three_shapes(slide):
     assert result["title_bounds"] is not None
     assert result["subtitle_bounds"] is not None
     assert result["divider_bounds"] is not None
+
+    # Absolute invariant: the divider's bottom edge must equal
+    # top + consumed_height, so callers placing body content at
+    # ``top + consumed_height`` align flush with the header's footprint.
+    divider_bottom = (
+        result["divider_bounds"]["top"] + result["divider_bounds"]["height"]
+    )
+    expected_bottom = top + result["consumed_height"]
+    assert abs(divider_bottom - expected_bottom) < 1e-6, (
+        f"divider bottom ({divider_bottom}) must equal "
+        f"top + consumed_height ({expected_bottom})"
+    )
 
 
 def test_short_title_keeps_base_font_size(slide):
@@ -87,9 +100,10 @@ def test_long_title_auto_fits_single_line(slide):
 
 def test_no_subtitle_divider_closer_to_title(slide):
     """subtitle="" → only 1 textbox; consumed_height drops by subtitle strip."""
+    top = 0.45
     spec_no_sub = SectionHeaderSpec(title="Title only", subtitle="")
     result = add_section_header(
-        slide, spec_no_sub, left=0.9, top=0.45, width=11.533,
+        slide, spec_no_sub, left=0.9, top=top, width=11.533,
     )
 
     textboxes = [
@@ -98,10 +112,11 @@ def test_no_subtitle_divider_closer_to_title(slide):
     assert len(textboxes) == 1, "no subtitle → only title textbox"
     assert result["subtitle_bounds"] is None
 
-    # Without subtitle, consumed_height excludes _SUBTITLE_H exactly.
-    # Layout: title + gap + subtitle + gap + divider (full)
-    #   vs   title + gap           + divider (no-subtitle)
-    # Delta = _SUBTITLE_H (+_INTRA_GAP_TITLE already applied either way).
+    # Without subtitle, consumed_height drops by the subtitle strip AND the
+    # title→subtitle gap (which is only relevant when a subtitle follows).
+    # Layout: title + gap_title + subtitle + gap_subtitle + divider (full)
+    #   vs   title              +            gap_subtitle + divider (no-sub)
+    # Delta = _INTRA_GAP_TITLE + _SUBTITLE_H.
     # Compute the "with subtitle" height from a matching spec to avoid
     # hard-coding internal constants in the delta check.
     full_spec = SectionHeaderSpec(title="Title only", subtitle="sub")
@@ -111,8 +126,21 @@ def test_no_subtitle_divider_closer_to_title(slide):
     )
     assert result["consumed_height"] < full_height
     assert abs(
-        (full_height - result["consumed_height"]) - _SUBTITLE_H
+        (full_height - result["consumed_height"])
+        - (_INTRA_GAP_TITLE + _SUBTITLE_H)
     ) < 1e-6
+
+    # Absolute invariant: divider bottom edge must equal top + consumed_height.
+    # This guards against the "phantom gap" regression where
+    # _compute_consumed_height and the rendered divider position disagree.
+    divider_bottom = (
+        result["divider_bounds"]["top"] + result["divider_bounds"]["height"]
+    )
+    expected_bottom = top + result["consumed_height"]
+    assert abs(divider_bottom - expected_bottom) < 1e-6, (
+        f"divider bottom ({divider_bottom}) must equal "
+        f"top + consumed_height ({expected_bottom})"
+    )
 
 
 def test_theme_ir_resolves_colors(slide):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -49,7 +49,7 @@ from pptx_mcp_server.server import (
     pptx_format_table,
     pptx_add_content_slide,
     pptx_add_section_divider,
-    pptx_add_kpi_row,
+    pptx_add_kpi_row_legacy,
     pptx_add_bullet_block,
     pptx_add_image,
     pptx_render_slide,
@@ -135,7 +135,7 @@ class TestToolRegistration:
             "pptx_format_table",
             "pptx_add_content_slide",
             "pptx_add_section_divider",
-            "pptx_add_kpi_row",
+            "pptx_add_kpi_row_legacy",
             "pptx_add_bullet_block",
             "pptx_render_slide",
         ]
@@ -251,12 +251,12 @@ class TestStructuredParams:
 
     def test_add_kpi_row_with_native_list(self, deck):
         kpis = [{"value": "99", "label": "Score"}]
-        result = pptx_add_kpi_row(deck, 0, kpis, 2.0)
+        result = pptx_add_kpi_row_legacy(deck, 0, kpis, 2.0)
         payload = _unwrap_ok(result)
         assert "Added 1 KPI" in payload["message"]
 
     def test_add_kpi_row_wrong_type_rejected(self, deck):
-        result = pptx_add_kpi_row(deck, 0, "not a list", 2.0)  # type: ignore[arg-type]
+        result = pptx_add_kpi_row_legacy(deck, 0, "not a list", 2.0)  # type: ignore[arg-type]
         err = _unwrap_err(result)
         assert err["code"] == "INVALID_PARAMETER"
         assert err["parameter"] == "kpis"
@@ -770,7 +770,7 @@ class TestAutoRenderOptIn:
         monkeypatch.setattr(server_mod, "render_slide", fake_render)
 
         # invalid slide_index → add_kpi_row raises before _auto_render runs.
-        result = server_mod.pptx_add_kpi_row(
+        result = server_mod.pptx_add_kpi_row_legacy(
             deck, 999, [{"value": "1", "label": "x"}], 2.0
         )
         _unwrap_err(result)
@@ -942,7 +942,7 @@ class TestStrictNestedValidation:
 
     def test_kpi_row_rejects_unknown_key(self, deck):
         err = _unwrap_err(
-            pptx_add_kpi_row(
+            pptx_add_kpi_row_legacy(
                 deck,
                 slide_index=0,
                 kpis=[{"label": "x", "value": "y", "typo": 1}],
@@ -954,7 +954,7 @@ class TestStrictNestedValidation:
 
     def test_kpi_row_valid_still_works(self, deck):
         payload = _unwrap_ok(
-            pptx_add_kpi_row(
+            pptx_add_kpi_row_legacy(
                 deck,
                 slide_index=0,
                 kpis=[{"label": "Rev", "value": "100"}],

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -108,35 +108,18 @@ class TestToolRegistration:
 
     def test_all_tools_registered(self):
         # FastMCP stores tools internally; list them via the _tool_manager.
-        # v0.3.1 (#108): dropped hardcoded "25 tools" drift. The expected
-        # list is a *subset* — new tools can be added without editing this
-        # assertion as long as the core tools stay registered.
+        # v0.3.1 (#108): dropped hardcoded "25 tools" drift.
+        # v0.6.0 (#137): tool tiering — advanced tools are hidden from
+        # the default registry (env-gate ``PPTX_MCP_INCLUDE_ADVANCED``).
+        # The expected list below therefore only contains **default-tier**
+        # tools so the assertion holds without setting the env var.
         tool_names = list(mcp._tool_manager._tools.keys())
         expected = [
             "pptx_create",
             "pptx_get_info",
             "pptx_read_slide",
-            "pptx_list_shapes",
             "pptx_add_slide",
-            "pptx_delete_slide",
-            "pptx_duplicate_slide",
-            "pptx_set_slide_background",
-            "pptx_set_dimensions",
-            "pptx_add_textbox",
-            "pptx_edit_text",
-            "pptx_add_paragraph",
-            "pptx_add_shape",
             "pptx_add_image",
-            "pptx_delete_shape",
-            "pptx_format_shape",
-            "pptx_add_table",
-            "pptx_edit_table_cell",
-            "pptx_edit_table_cells",
-            "pptx_format_table",
-            "pptx_add_content_slide",
-            "pptx_add_section_divider",
-            "pptx_add_kpi_row_legacy",
-            "pptx_add_bullet_block",
             "pptx_render_slide",
         ]
         for name in expected:
@@ -1080,9 +1063,13 @@ class TestNoStale25Tools:
     def test_no_hardcoded_25_tools_assertion(self):
         # v0.3.1 (#108): the test asserts that the live FastMCP
         # registration has at least the core tools, without a brittle
-        # hardcoded count. 37+ tools are registered today.
+        # hardcoded count.
+        # v0.6.0 (#137): with tool tiering, the default surface is
+        # ~20 tools (45 - 25 advanced). The historical > 25 bound no
+        # longer holds with tiering enabled, so the assertion now
+        # guards against accidental collapse of the default surface.
         tool_names = list(mcp._tool_manager._tools.keys())
-        assert len(tool_names) > 25, (
-            "FastMCP should register well beyond the historical 25-tool "
-            f"baseline — got {len(tool_names)}"
+        assert len(tool_names) >= 15, (
+            "Default MCP surface should register at least the block-"
+            f"component + batch tier — got {len(tool_names)}"
         )

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -242,3 +242,31 @@ class TestResponsiveCardRowFileRoundTrip:
                 ):
                     inside += 1
             assert inside >= 1, f"placement {p} has no shapes inside"
+
+
+# =============================================================================
+# pptx_add_section_header envelope invariant (#120 / #136 regression)
+# =============================================================================
+
+
+class TestAddSectionHeaderMcpEnvelope:
+    """``pptx_add_section_header`` must include a ``message`` key in its
+    result dict, matching the v0.3.0 envelope invariant (#120)."""
+
+    def test_result_has_message_key(self, blank_pptx):
+        """Happy-path MCP call returns ``result["message"]`` (not silently dropped)."""
+        from pptx_mcp_server.server import pptx_add_section_header
+
+        out = pptx_add_section_header(
+            file_path=blank_pptx,
+            slide_index=0,
+            title="Section One",
+            subtitle="A subtitle line",
+        )
+        parsed = json.loads(out)
+        assert parsed.get("ok") is True
+        assert "message" in parsed["result"], (
+            "pptx_add_section_header must set result['message'] per envelope invariant (#120)."
+        )
+        assert isinstance(parsed["result"]["message"], str)
+        assert parsed["result"]["message"]  # non-empty

--- a/tests/test_theme_atomics.py
+++ b/tests/test_theme_atomics.py
@@ -1,0 +1,215 @@
+"""#131: theme-aware atomic primitives のテスト.
+
+v0.5.0 で ``add_responsive_card_row`` / ``add_data_table`` /
+``add_milestone_timeline`` に入った theme string 契約を、v0.6.0 では
+atomic primitives (``add_auto_fit_textbox`` + ``_add_shape`` + ``add_shape``
+file wrapper) にも展開した。本モジュールは以下を検証する:
+
+- theme token (e.g. ``"primary"``) + theme name (e.g. ``"ir"``) が theme
+  registry の hex に解決される。
+- raw hex (``"#FF0000"`` / ``"FF0000"``) は passthrough する (``#`` 剥離のみ)。
+- ``theme=None`` なら v0.5.1 挙動が byte-for-byte 保たれる (resolver の
+  passthrough no-op)。
+- MCP tool ``pptx_add_auto_fit_textbox`` / ``pptx_add_shape`` が ``theme``
+  kwarg を surface する。
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.util import Inches
+
+from pptx_mcp_server.engine.pptx_io import open_pptx, save_pptx
+from pptx_mcp_server.engine.shapes import (
+    _add_shape,
+    add_auto_fit_textbox,
+)
+from pptx_mcp_server.server import (
+    pptx_add_auto_fit_textbox,
+    pptx_add_shape,
+)
+from pptx_mcp_server.theme import IR
+
+
+# ---------------------------------------------------------------------------
+# add_auto_fit_textbox — theme kwarg
+# ---------------------------------------------------------------------------
+
+
+class TestAddAutoFitTextboxTheme:
+    """``add_auto_fit_textbox(color_hex=..., theme=...)`` が color を
+    ``resolve_theme_color`` 経由で解決することを確認する (#131)."""
+
+    def test_theme_token_resolves_to_ir_primary_hex(self, slide):
+        """``color_hex="primary", theme="ir"`` → IR primary (#0A2540)."""
+        shape, _ = add_auto_fit_textbox(
+            slide,
+            "text",
+            left=1.0, top=1.0, width=3.0, height=0.5,
+            color_hex="primary",
+            theme="ir",
+        )
+        run = shape.text_frame.paragraphs[0].runs[0]
+        expected = IR.colors["primary"].lstrip("#")
+        assert run.font.color.rgb == RGBColor.from_string(expected)
+
+    def test_raw_hash_hex_passes_through_with_theme(self, slide):
+        """``color_hex="#FF0000", theme="ir"`` → raw hex 経路 (``#`` 剥離)."""
+        shape, _ = add_auto_fit_textbox(
+            slide,
+            "text",
+            left=1.0, top=1.0, width=3.0, height=0.5,
+            color_hex="#FF0000",
+            theme="ir",
+        )
+        run = shape.text_frame.paragraphs[0].runs[0]
+        assert run.font.color.rgb == RGBColor(0xFF, 0x00, 0x00)
+
+    def test_theme_none_preserves_v0_5_1_behavior(self, slide):
+        """``theme=None`` なら resolver は passthrough (raw hex のみ有効)."""
+        shape, _ = add_auto_fit_textbox(
+            slide,
+            "text",
+            left=1.0, top=1.0, width=3.0, height=0.5,
+            color_hex="333333",
+            # theme 省略 (None default)
+        )
+        run = shape.text_frame.paragraphs[0].runs[0]
+        assert run.font.color.rgb == RGBColor(0x33, 0x33, 0x33)
+
+    def test_unknown_token_without_theme_passes_as_noop(self, slide):
+        """``theme=None`` + 未登録 token は raw string として下流に流れ、
+        ``_parse_color`` 側で ``INVALID_PARAMETER`` が発生する (defensive
+        挙動ではなく既存の失敗経路を踏襲する)."""
+        from pptx_mcp_server.engine.pptx_io import EngineError
+        with pytest.raises(EngineError):
+            add_auto_fit_textbox(
+                slide,
+                "text",
+                left=1.0, top=1.0, width=3.0, height=0.5,
+                color_hex="primary",
+                # theme=None → "primary" は hex として扱われ _parse_color で失敗
+            )
+
+
+# ---------------------------------------------------------------------------
+# _add_shape — theme kwarg (fill_color)
+# ---------------------------------------------------------------------------
+
+
+class TestAddShapeTheme:
+    """``_add_shape(fill_color=..., theme=...)`` が色を
+    ``resolve_theme_color`` 経由で解決することを確認する (#131)."""
+
+    def test_theme_token_resolves_fill_color(self, slide):
+        """``fill_color="primary", theme="ir"`` → IR primary hex."""
+        idx = _add_shape(
+            slide, "rectangle",
+            left=1.0, top=1.0, width=2.0, height=1.0,
+            fill_color="primary",
+            theme="ir",
+        )
+        shape = list(slide.shapes)[idx]
+        expected = IR.colors["primary"].lstrip("#")
+        assert shape.fill.fore_color.rgb == RGBColor.from_string(expected)
+
+    def test_raw_hex_passes_through_with_theme(self, slide):
+        """``fill_color="#FF0000", theme="ir"`` → raw hex 経路."""
+        idx = _add_shape(
+            slide, "rectangle",
+            left=1.0, top=1.0, width=2.0, height=1.0,
+            fill_color="#FF0000",
+            theme="ir",
+        )
+        shape = list(slide.shapes)[idx]
+        assert shape.fill.fore_color.rgb == RGBColor(0xFF, 0x00, 0x00)
+
+    def test_theme_none_preserves_v0_5_1_behavior(self, slide):
+        """``theme=None`` なら raw hex はそのまま、token は失敗する (既存動作)."""
+        idx = _add_shape(
+            slide, "rectangle",
+            left=1.0, top=1.0, width=2.0, height=1.0,
+            fill_color="2251FF",
+            # theme=None
+        )
+        shape = list(slide.shapes)[idx]
+        assert shape.fill.fore_color.rgb == RGBColor(0x22, 0x51, 0xFF)
+
+    def test_theme_resolves_line_color(self, slide):
+        """``line_color`` も同様に resolve される."""
+        idx = _add_shape(
+            slide, "rectangle",
+            left=1.0, top=1.0, width=2.0, height=1.0,
+            fill_color="#FFFFFF",
+            line_color="accent",
+            line_width=1.0,
+            theme="ir",
+        )
+        shape = list(slide.shapes)[idx]
+        expected = IR.colors["accent"].lstrip("#")
+        assert shape.line.color.rgb == RGBColor.from_string(expected)
+
+
+# ---------------------------------------------------------------------------
+# MCP tool surface — pptx_add_auto_fit_textbox / pptx_add_shape expose theme
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def blank_pptx(tmp_path):
+    """16:9 blank deck を 1 slide で作成して path を返す."""
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    layout = prs.slide_layouts[6]
+    prs.slides.add_slide(layout)
+    path = str(tmp_path / "deck.pptx")
+    save_pptx(prs, path)
+    return path
+
+
+class TestMcpToolThemeSurface:
+    """MCP tool wrappers が ``theme`` kwarg を surface し、engine 側に
+    透過することを確認する (#131)."""
+
+    def test_pptx_add_auto_fit_textbox_exposes_theme_kwarg(self, blank_pptx):
+        """``pptx_add_auto_fit_textbox(theme="ir", color_hex="primary")`` が
+        保存後に IR primary 色を反映する."""
+        resp = pptx_add_auto_fit_textbox(
+            blank_pptx, 0, "title",
+            left=1.0, top=1.0, width=3.0, height=0.5,
+            color_hex="primary",
+            theme="ir",
+        )
+        payload = json.loads(resp)
+        assert payload["ok"] is True, payload
+
+        prs = open_pptx(blank_pptx)
+        slide = prs.slides[0]
+        shape = list(slide.shapes)[payload["result"]["shape_index"]]
+        run = shape.text_frame.paragraphs[0].runs[0]
+        expected = IR.colors["primary"].lstrip("#")
+        assert run.font.color.rgb == RGBColor.from_string(expected)
+
+    def test_pptx_add_shape_exposes_theme_kwarg(self, blank_pptx):
+        """``pptx_add_shape(theme="ir", fill_color="accent")`` が保存後に
+        IR accent 色を反映する."""
+        resp = pptx_add_shape(
+            blank_pptx, 0, "rectangle",
+            1.0, 1.0, 2.0, 1.0,
+            fill_color="accent",
+            theme="ir",
+        )
+        payload = json.loads(resp)
+        assert payload["ok"] is True, payload
+
+        prs = open_pptx(blank_pptx)
+        slide = prs.slides[0]
+        # 直近追加 shape は末尾にある
+        shape = list(slide.shapes)[-1]
+        expected = IR.colors["accent"].lstrip("#")
+        assert shape.fill.fore_color.rgb == RGBColor.from_string(expected)

--- a/tests/test_tool_tiering.py
+++ b/tests/test_tool_tiering.py
@@ -1,0 +1,253 @@
+"""MCP tool tiering (v0.6.0, issue #137).
+
+The ``_tool_registry.mcp_tool`` decorator hides advanced-tier tools from
+FastMCP's registry unless ``PPTX_MCP_INCLUDE_ADVANCED`` is set at import
+time. These tests verify:
+
+1. Default surface excludes advanced tools.
+2. Opting in via env var registers all tools.
+3. Advanced tool functions remain importable from the server module so
+   library-mode callers and existing tests keep working untouched.
+4. The default tier has the expected count (regression guard).
+5. Classification is exhaustive — every ``@mcp_tool(...)``-decorated
+   tool in ``server.py`` is assigned to exactly one tier.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+from pptx_mcp_server import _tool_registry, server
+
+
+# Snapshot of the expected default tier at v0.6.0. Update this set when
+# a new default-tier tool is added; advanced additions should NOT touch
+# this fixture (keep the regression guard meaningful).
+EXPECTED_DEFAULT_TIER = frozenset({
+    # Setup / inspection
+    "pptx_create", "pptx_get_info", "pptx_read_slide", "pptx_add_slide",
+    # Block components (v0.6.0)
+    "pptx_add_section_header", "pptx_add_metric_card_row",
+    "pptx_add_kpi_row", "pptx_add_numbered_list",
+    "pptx_add_page_marker", "pptx_add_slide_footer",
+    # v0.5.0 high-level primitives
+    "pptx_add_data_table", "pptx_add_responsive_card_row",
+    "pptx_add_milestone_timeline", "pptx_add_flex_container",
+    "pptx_add_chart", "pptx_add_image",
+    # Batch build
+    "pptx_build_slide", "pptx_build_deck",
+    # Validation / rendering
+    "pptx_check_layout", "pptx_render_slide",
+})
+
+EXPECTED_ADVANCED_TIER = frozenset({
+    # Shape primitives
+    "pptx_add_textbox", "pptx_add_shape", "pptx_add_auto_fit_textbox",
+    # Edit ops
+    "pptx_edit_text", "pptx_add_paragraph", "pptx_delete_shape",
+    "pptx_list_shapes", "pptx_format_shape",
+    # Connectors / callouts / icons
+    "pptx_add_connector", "pptx_add_callout",
+    "pptx_add_icon", "pptx_list_icons",
+    # Slide-level editing
+    "pptx_set_dimensions", "pptx_set_slide_background",
+    "pptx_move_slide", "pptx_delete_slide", "pptx_duplicate_slide",
+    # Table editing
+    "pptx_add_table", "pptx_edit_table_cell",
+    "pptx_edit_table_cells", "pptx_format_table",
+    # Composite helpers
+    "pptx_add_section_divider", "pptx_add_content_slide",
+    "pptx_add_bullet_block",
+    # Legacy (deprecated in v0.7.0)
+    "pptx_add_kpi_row_legacy",
+})
+
+
+def _registered_tool_names() -> set[str]:
+    """Live FastMCP registry of the currently-imported server module."""
+    return set(server.mcp._tool_manager._tools.keys())
+
+
+def _reload_with_env(monkeypatch: pytest.MonkeyPatch, value: str | None):
+    """Reload ``_tool_registry`` + ``server`` under a specific env state.
+
+    The env var is read once at module import, so flipping the gate
+    mid-test requires re-importing both modules. Returns the reloaded
+    ``server`` module so callers can introspect it.
+    """
+    if value is None:
+        monkeypatch.delenv("PPTX_MCP_INCLUDE_ADVANCED", raising=False)
+    else:
+        monkeypatch.setenv("PPTX_MCP_INCLUDE_ADVANCED", value)
+    # Drop cached modules so reload re-runs module-body code fresh.
+    sys.modules.pop("pptx_mcp_server.server", None)
+    sys.modules.pop("pptx_mcp_server._tool_registry", None)
+    import pptx_mcp_server._tool_registry as reg  # noqa: F401
+    import pptx_mcp_server.server as srv
+    return srv
+
+
+# ---------------------------------------------------------------------------
+# Regression fixture — reset modules after each test so the live imports at
+# top of this file see the "unset env" state for other tests / collections.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _restore_default_registry():
+    yield
+    # After any test that mutated env + reloaded, restore the import with
+    # no env var so the rest of the suite sees the default tier.
+    sys.modules.pop("pptx_mcp_server.server", None)
+    sys.modules.pop("pptx_mcp_server._tool_registry", None)
+    # Re-import so ``server`` / ``_tool_registry`` at module-scope of
+    # OTHER test files remain consistent.
+    import pptx_mcp_server._tool_registry  # noqa: F401
+    import pptx_mcp_server.server  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_default_surface_excludes_advanced_tools(monkeypatch):
+    """Without the env var, no advanced tool appears in the registry."""
+    srv = _reload_with_env(monkeypatch, None)
+    registered = set(srv.mcp._tool_manager._tools.keys())
+    leaked = registered & EXPECTED_ADVANCED_TIER
+    assert not leaked, f"Advanced tools leaked into default surface: {sorted(leaked)}"
+    # And every default tool is there.
+    missing = EXPECTED_DEFAULT_TIER - registered
+    assert not missing, f"Default tools missing: {sorted(missing)}"
+
+
+def test_include_advanced_env_registers_all(monkeypatch):
+    """With PPTX_MCP_INCLUDE_ADVANCED=1, all 45 tools register."""
+    srv = _reload_with_env(monkeypatch, "1")
+    registered = set(srv.mcp._tool_manager._tools.keys())
+    expected = EXPECTED_DEFAULT_TIER | EXPECTED_ADVANCED_TIER
+    missing = expected - registered
+    assert not missing, f"Tools missing after opt-in: {sorted(missing)}"
+    assert len(registered) == len(expected), (
+        f"Expected {len(expected)} tools with advanced on, "
+        f"got {len(registered)}: unexpected extras "
+        f"{sorted(registered - expected)}"
+    )
+
+
+@pytest.mark.parametrize("truthy", ["1", "true", "yes", "TRUE", "Yes"])
+def test_env_var_truthy_values(monkeypatch, truthy):
+    """The env var accepts case-insensitive ``1``/``true``/``yes``."""
+    srv = _reload_with_env(monkeypatch, truthy)
+    registered = set(srv.mcp._tool_manager._tools.keys())
+    assert EXPECTED_ADVANCED_TIER <= registered, (
+        f"Advanced tier should register when env={truthy!r}"
+    )
+
+
+def test_advanced_functions_still_importable(monkeypatch):
+    """Advanced tool *functions* remain importable even when gated off.
+
+    This is critical: existing tests (test_server.py, etc.) call tool
+    functions directly as library functions. Gating only removes the
+    FastMCP registration, not the Python symbol.
+    """
+    srv = _reload_with_env(monkeypatch, None)
+    # Sample advanced functions from different sub-categories.
+    assert callable(srv.pptx_add_textbox)
+    assert callable(srv.pptx_add_shape)
+    assert callable(srv.pptx_edit_text)
+    assert callable(srv.pptx_list_shapes)
+    assert callable(srv.pptx_add_kpi_row_legacy)
+    assert callable(srv.pptx_format_table)
+    # And none of these are in the default tier registry.
+    registered = set(srv.mcp._tool_manager._tools.keys())
+    for name in (
+        "pptx_add_textbox", "pptx_add_shape", "pptx_edit_text",
+        "pptx_list_shapes", "pptx_add_kpi_row_legacy", "pptx_format_table",
+    ):
+        assert name not in registered, (
+            f"{name} should be hidden from the default MCP registry"
+        )
+
+
+def test_default_tier_count_matches_expectation():
+    """Freeze the default-tier count as a regression guard.
+
+    Update ``EXPECTED_DEFAULT_TIER`` and this count together when
+    promoting a new tool into the default surface.
+    """
+    registered = _registered_tool_names()
+    # Sanity: the top-of-file live import sees the default surface.
+    default_count = len(EXPECTED_DEFAULT_TIER)
+    assert default_count == 20, (
+        f"Default tier expected size 20, got {default_count}. "
+        "Update the test + EXPECTED_DEFAULT_TIER together."
+    )
+    assert len(registered) == default_count, (
+        f"Registered {len(registered)} tools, expected "
+        f"{default_count} in default tier."
+    )
+
+
+def test_classification_is_exhaustive():
+    """Every ``@mcp_tool(...)``-decorated tool in server.py is classified.
+
+    Parses the server source to find every decorator + function pair,
+    then asserts the name is either in the default or advanced tier. If
+    this fails, a new tool was added without a tier decision.
+    """
+    src = Path(server.__file__).read_text()
+    # Match "@mcp_tool(mcp...)\n[async ]def pptx_x(":
+    # capture the tier flag and the function name separately.
+    pattern = re.compile(
+        r"^@mcp_tool\(mcp(?P<args>[^)]*)\)\n"
+        r"(?:async\s+)?def\s+(?P<name>pptx_[A-Za-z0-9_]+)\(",
+        re.MULTILINE,
+    )
+    found = {m.group("name"): ("advanced=True" in m.group("args"))
+             for m in pattern.finditer(src)}
+    assert found, "No decorated tools found — regex broken?"
+    assert len(found) == 45, (
+        f"Expected 45 decorated tools in server.py, found {len(found)}. "
+        "Did the regex miss a new decorator form?"
+    )
+    classified = EXPECTED_DEFAULT_TIER | EXPECTED_ADVANCED_TIER
+    unclassified = set(found) - classified
+    assert not unclassified, (
+        f"Tools in server.py not in either tier fixture: {sorted(unclassified)}. "
+        "Add them to EXPECTED_DEFAULT_TIER or EXPECTED_ADVANCED_TIER."
+    )
+    # And the decorator flag matches the fixture.
+    for name, is_advanced in found.items():
+        if is_advanced:
+            assert name in EXPECTED_ADVANCED_TIER, (
+                f"{name} decorated advanced=True but not in advanced fixture"
+            )
+        else:
+            assert name in EXPECTED_DEFAULT_TIER, (
+                f"{name} decorated without advanced=True but in advanced fixture"
+            )
+
+
+def test_advanced_tool_names_helper_matches_fixture(monkeypatch):
+    """The ``advanced_tool_names()`` introspection helper agrees with the
+    decorator calls found in server.py."""
+    srv = _reload_with_env(monkeypatch, None)
+    tracked = set(srv.advanced_tool_names())
+    assert tracked == EXPECTED_ADVANCED_TIER, (
+        f"advanced_tool_names() mismatch.\n"
+        f"  extra={sorted(tracked - EXPECTED_ADVANCED_TIER)}\n"
+        f"  missing={sorted(EXPECTED_ADVANCED_TIER - tracked)}"
+    )
+
+
+def test_is_advanced_enabled_reflects_env(monkeypatch):
+    srv_off = _reload_with_env(monkeypatch, None)
+    assert srv_off.is_advanced_enabled() is False
+    srv_on = _reload_with_env(monkeypatch, "1")
+    assert srv_on.is_advanced_enabled() is True

--- a/tests/test_tool_tiering.py
+++ b/tests/test_tool_tiering.py
@@ -175,14 +175,19 @@ def test_advanced_functions_still_importable(monkeypatch):
         )
 
 
-def test_default_tier_count_matches_expectation():
+def test_default_tier_count_matches_expectation(monkeypatch):
     """Freeze the default-tier count as a regression guard.
 
     Update ``EXPECTED_DEFAULT_TIER`` and this count together when
     promoting a new tool into the default surface.
+
+    Uses ``_reload_with_env(None)`` so the assertion is independent of
+    the ambient ``PPTX_MCP_INCLUDE_ADVANCED`` env state — without this,
+    running under ``PPTX_MCP_INCLUDE_ADVANCED=1`` would surface 45 tools
+    in the live registry and fail the count.
     """
-    registered = _registered_tool_names()
-    # Sanity: the top-of-file live import sees the default surface.
+    srv = _reload_with_env(monkeypatch, None)
+    registered = set(srv.mcp._tool_manager._tools.keys())
     default_count = len(EXPECTED_DEFAULT_TIER)
     assert default_count == 20, (
         f"Default tier expected size 20, got {default_count}. "


### PR DESCRIPTION
## Summary

Closes the v0.6.0 milestone (tracker #129). Transforms pptx-mcp-server from "library of primitives that compose via caller coordinates" into a **3-layer component library (shadcn-for-PPTX style)**: atomic primitives → block components → (future) slide templates.

**Foundation:** `Container` primitive + `check_containment` validator (catches slide-2-class overflow at validate-time).

**Block components (5):** MetricCard · KPIRow · NumberedList · PageMarker+SlideFooter · SectionHeader — each is bounded, theme-aware, containment-validated.

**Infra:** MCP tool tiering (`PPTX_MCP_INCLUDE_ADVANCED=1` opt-in) — default surface is now 20 tools (block components + batch + validator); 25 raw-shape primitives moved behind the gate.

## Issues closed

- `closes #130` — Container primitive + `check_containment` validator (foundation)
- `closes #131` — theme-aware atomic primitives (`add_auto_fit_textbox`, `_add_shape`)
- `closes #132` — MetricCard block component (`pptx_add_metric_card_row`)
- `closes #133` — KPIRow block component (`pptx_add_kpi_row`) + legacy tool rename
- `closes #134` — NumberedList block component (`pptx_add_numbered_list`)
- `closes #135` — PageMarker + SlideFooter block components
- `closes #136` — SectionHeader block component (`pptx_add_section_header`)
- `closes #137` — MCP tool tiering (`advanced=False` decorator flag)

Tracker `#129` will be closed after this PR merges.

## Changes

### New / expanded surface
- `src/pptx_mcp_server/engine/components/` package: `container.py`, `metric_card.py`, `kpi_row.py`, `numbered_list.py`, `markers.py`, `section_header.py`, `_util.py`
- 6 new MCP tools (block components), 1 renamed (legacy `pptx_add_kpi_row` → `pptx_add_kpi_row_legacy`)
- `check_containment(prs, *, tolerance=0.01)` validator integrated into `check_deck_extended`
- `theme: str | None = None` kwarg threaded through atomic shape-creating primitives (non-breaking; `None` preserves v0.5.1 behavior byte-for-byte)
- `src/pptx_mcp_server/_tool_registry.py`: `mcp_tool(mcp, advanced=...)` decorator + env-var gate

### Cleanup / harden
- 5× `_resolve_color` copies consolidated to `engine/components/_util.py:resolve_component_color` (−117 LOC, closes behavior-drift window)
- `pptx_add_section_header` now sets envelope `message` key (#120 contract)
- `clear_container_registry` autouse fixture centralized in `tests/conftest.py` (removed 4 duplicates)
- CHANGELOG / README / INSTRUCTIONS updated with all 7 issue entries + block-component documentation + tool-tier guide

### Breaking changes
- **MCP tool rename:** `pptx_add_kpi_row` (legacy 4-arg signature) → `pptx_add_kpi_row_legacy`. The canonical name now points to the new block-component variant (7-arg). Migration snippet in `pptx_add_kpi_row_legacy` docstring + CHANGELOG.
- **Default MCP tool surface reduced** 45 → 20. Agents using raw-shape primitives (`pptx_add_textbox`, `pptx_add_shape`, etc.) must set `PPTX_MCP_INCLUDE_ADVANCED=1`.

## Test plan

- [x] Full test suite green: 652 baseline → **743 passing** (+91 new including integration tests)
- [x] Default mode (`PPTX_MCP_INCLUDE_ADVANCED` unset): 743/743 pass
- [x] Advanced mode (`PPTX_MCP_INCLUDE_ADVANCED=1`): 743/743 pass (tool-tiering tests env-independent)
- [x] 3 consecutive runs produced identical counts (no flaky tests)
- [x] Integration test: 5-component IR-style slide composition passes `check_containment` clean
- [x] Shuffled-order test run confirms fixture isolation
- [x] No new dependencies; no new outbound I/O; `pyproject.toml` deps unchanged
- [ ] CI (ubuntu-latest × python 3.11 / 3.12 / 3.13) — to be observed after push

## Review process (internal, per-wave)

Each of the 8 work issues went through a 3-stage review in isolated worktrees:
1. **Spec compliance review** — verified every acceptance-criteria bullet against actual code
2. **Code quality review** — superpowers:code-reviewer; all fixes applied before merge
3. **Security review** — claude-opus-4-7; threat model: local + semi-trusted LLM kwargs

A post-hardening round re-audited: consolidation correctness (Task D), release-readiness (docs/envelope), security + stability (3× suite runs). All LGTM.

## Non-goals (explicit, per tracker #129)

- Slide templates (v0.7.0)
- Breaking changes to atomic primitives beyond the MCP-tier gate
- Deletion of any existing MCP tools (tiering hides them, doesn't remove)
- `engine/primitives/` rename (v0.7.0 after templates land)

## Deferred to v0.6.1+

Minor refinements surfaced by integration review (not blockers):
- Unified `theme="unknown_name"` contract (currently silent passthrough)
- Standardize `begin_container(name=...)` indexing across all row-variant components
- `engine/components/__init__.py` eager re-export → switch to per-module imports (would eliminate the deferred-import workaround in block modules)
- Tighten `>= 15` default-tool count bound in `test_no_hardcoded_25_tools_assertion` to `>= 20`

## Follow-up after merge

- Close tracker `#129` with completion summary
- Bump `pyproject.toml` version `0.5.1` → `0.6.0`
- Tag `v0.6.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)